### PR TITLE
feat: added listing params for attachment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 build/
 bin/
+*.log

--- a/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.config;
 
 import lombok.Data;
 
+import java.util.List;
 import java.util.Set;
 
 @Data
@@ -23,4 +24,6 @@ public abstract class Deployment {
      */
     private boolean forwardApiKey = true;
     private String rateEndpoint;
+    private List<String> inputAttachmentTypes;
+    private Integer maxInputAttachments;
 }

--- a/src/main/java/com/epam/aidial/core/controller/ApplicationController.java
+++ b/src/main/java/com/epam/aidial/core/controller/ApplicationController.java
@@ -57,6 +57,8 @@ public class ApplicationController {
         data.setDisplayName(application.getDisplayName());
         data.setIconUrl(application.getIconUrl());
         data.setDescription(application.getDescription());
+        data.setInputAttachmentTypes(application.getInputAttachmentTypes());
+        data.setMaxInputAttachments(application.getMaxInputAttachments());
         return data;
     }
 }

--- a/src/main/java/com/epam/aidial/core/controller/AssistantController.java
+++ b/src/main/java/com/epam/aidial/core/controller/AssistantController.java
@@ -58,6 +58,8 @@ public class AssistantController {
         data.setIconUrl(assistant.getIconUrl());
         data.setDescription(assistant.getDescription());
         data.setAddons(assistant.getAddons());
+        data.setInputAttachmentTypes(assistant.getInputAttachmentTypes());
+        data.setMaxInputAttachments(assistant.getMaxInputAttachments());
         return data;
     }
 }

--- a/src/main/java/com/epam/aidial/core/controller/ModelController.java
+++ b/src/main/java/com/epam/aidial/core/controller/ModelController.java
@@ -69,7 +69,6 @@ public class ModelController {
 
         data.setInputAttachmentTypes(model.getInputAttachmentTypes());
         data.setMaxInputAttachments(model.getMaxInputAttachments());
-
         return data;
     }
 }

--- a/src/main/java/com/epam/aidial/core/controller/ModelController.java
+++ b/src/main/java/com/epam/aidial/core/controller/ModelController.java
@@ -67,6 +67,9 @@ public class ModelController {
             data.getCapabilities().setChatCompletion(true);
         }
 
+        data.setInputAttachmentTypes(model.getInputAttachmentTypes());
+        data.setMaxInputAttachments(model.getMaxInputAttachments());
+
         return data;
     }
 }

--- a/src/main/java/com/epam/aidial/core/data/DeploymentData.java
+++ b/src/main/java/com/epam/aidial/core/data/DeploymentData.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -23,4 +25,6 @@ public class DeploymentData {
     private long createdAt = 1672534800;
     private long updatedAt = 1672534800;
     private ScaleSettingsData scaleSettings = new ScaleSettingsData();
+    private List<String> inputAttachmentTypes;
+    private Integer maxInputAttachments;
 }

--- a/src/main/resources/aidial.config.json
+++ b/src/main/resources/aidial.config.json
@@ -36,7 +36,9 @@
       "endpoint": "http://localhost:7001/openai/deployments/10k/chat/completions",
       "displayName": "10k",
       "iconUrl": "http://localhost:7001/logo10k.png",
-      "description": "Some description of the application for testing"
+      "description": "Some description of the application for testing",
+      "inputAttachmentTypes": ["*/*"],
+      "maxInputAttachments": 1
     }
   },
   "models": {


### PR DESCRIPTION
Added listing parameter for support of input attachments as part of #34 
* `input_attachment_types` (optional List[String]) - list of supported attachment types as MIME types. `*/*` means any file type is supported.
* `max_input_attachments` (optional int) - max number of attachments per user message. When omitted and `input_attachment_types` is not empty, then default is Infinity. When omitted and `input_attachment_types` is empty, then default is 0.