### PR TITLE
feat: added pricing params to the listing

### DIFF
--- a/src/main/java/com/epam/aidial/core/config/Model.java
+++ b/src/main/java/com/epam/aidial/core/config/Model.java
@@ -12,5 +12,6 @@ import java.util.List;
 public class Model extends Deployment {
     private ModelType type;
     private TokenLimits limits;
+    private Pricing pricing;
     private List<Upstream> upstreams = List.of();
 }

--- a/src/main/java/com/epam/aidial/core/config/Pricing.java
+++ b/src/main/java/com/epam/aidial/core/config/Pricing.java
@@ -1,0 +1,10 @@
+package com.epam.aidial.core.config;
+
+import lombok.Data;
+
+@Data
+public class Pricing {
+    private String unit;
+    private Double prompt;
+    private Double completion;
+}

--- a/src/main/java/com/epam/aidial/core/controller/ModelController.java
+++ b/src/main/java/com/epam/aidial/core/controller/ModelController.java
@@ -4,9 +4,11 @@ import com.epam.aidial.core.ProxyContext;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
+import com.epam.aidial.core.config.Pricing;
 import com.epam.aidial.core.config.TokenLimits;
 import com.epam.aidial.core.data.ListData;
 import com.epam.aidial.core.data.ModelData;
+import com.epam.aidial.core.data.PricingData;
 import com.epam.aidial.core.data.TokenLimitsData;
 import com.epam.aidial.core.util.HttpStatus;
 import io.vertx.core.Future;
@@ -70,16 +72,29 @@ public class ModelController {
         }
 
         data.setLimits(createLimits(model.getLimits()));
+        data.setPricing(createPricing(model.getPricing()));
         return data;
     }
 
     private static TokenLimitsData createLimits(TokenLimits limits) {
-        TokenLimitsData data = new TokenLimitsData();
-        if (limits != null) {
-            data.setMaxPromptTokens(limits.getMaxPromptTokens());
-            data.setMaxCompletionTokens(limits.getMaxCompletionTokens());
-            data.setMaxTotalTokens(limits.getMaxTotalTokens());
+        if (limits == null) {
+            return null;
         }
+        TokenLimitsData data = new TokenLimitsData();
+        data.setMaxPromptTokens(limits.getMaxPromptTokens());
+        data.setMaxCompletionTokens(limits.getMaxCompletionTokens());
+        data.setMaxTotalTokens(limits.getMaxTotalTokens());
+        return data;
+    }
+
+    private static PricingData createPricing(Pricing pricing) {
+        if (pricing == null) {
+            return null;
+        }
+        PricingData data = new PricingData();
+        data.setUnit(pricing.getUnit());
+        data.setPrompt(pricing.getPrompt());
+        data.setCompletion(pricing.getCompletion());
         return data;
     }
 }

--- a/src/main/java/com/epam/aidial/core/data/ModelData.java
+++ b/src/main/java/com/epam/aidial/core/data/ModelData.java
@@ -14,7 +14,8 @@ public class ModelData extends DeploymentData {
 
     private String lifecycleStatus = "generally-available";
     private CapabilitiesData capabilities = new CapabilitiesData();
-    private TokenLimitsData limits = new TokenLimitsData();
+    private TokenLimitsData limits;
+    private PricingData pricing;
 
     {
         setObject("model");

--- a/src/main/java/com/epam/aidial/core/data/PricingData.java
+++ b/src/main/java/com/epam/aidial/core/data/PricingData.java
@@ -1,0 +1,15 @@
+package com.epam.aidial.core.data;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PricingData {
+    private String unit;
+    private Double prompt;
+    private Double completion;
+}

--- a/src/main/resources/aidial.config.json
+++ b/src/main/resources/aidial.config.json
@@ -52,6 +52,11 @@
       ],
       "limits": {
         "maxTotalTokens": 4096
+      },
+      "pricing": {
+        "unit": "token",
+        "prompt": 0.00005,
+        "completion": 0.0001
       }
     },
     "embedding-ada": {
@@ -62,6 +67,10 @@
       ],
       "limits": {
         "maxTotalTokens": 8192
+      },
+      "pricing": {
+        "unit": "token",
+        "prompt": 0.00005
       }
     },
     "exotic-model": {

--- a/src/main/resources/aidial.config.json
+++ b/src/main/resources/aidial.config.json
@@ -75,7 +75,12 @@
     },
     "exotic-model": {
       "type": "chat",
-      "endpoint" : "http://localhost:7001/openai/deployments/exotic-model/chat/completions"
+      "endpoint" : "http://localhost:7001/openai/deployments/exotic-model/chat/completions",
+      "pricing": {
+        "unit": "char_without_whitespace",
+        "prompt": 0.00005,
+        "completion": 0.0001
+      }
     }
   },
   "keys": {


### PR DESCRIPTION
Added pricing parameter to the listing as part of #34 
* `pricing.prompt` - prompt price per unit
* `pricing.completion` - completion price per unit
* `pricing.unit` - the prices are specified per this unit (e.g. `token` for the [majority](https://openai.com/pricing) of [models](https://www-files.anthropic.com/production/images/model_pricing_july2023.pdf), `char_without_whitespace` for [PaLM](https://cloud.google.com/vertex-ai/pricing))

The currency is USD by default.