### PR TITLE
fix: route Files API by encoded path, url parameter in metadata response is URL encoded

### DIFF
--- a/src/main/java/com/epam/aidial/core/controller/AccessControlBaseController.java
+++ b/src/main/java/com/epam/aidial/core/controller/AccessControlBaseController.java
@@ -9,16 +9,26 @@ import com.epam.aidial.core.util.HttpStatus;
 import io.vertx.core.Future;
 import lombok.AllArgsConstructor;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 @AllArgsConstructor
 public abstract class AccessControlBaseController {
+
+    private static final String DEFAULT_RESOURCE_ERROR_MESSAGE = "Invalid file url provided %s";
 
     final Proxy proxy;
     final ProxyContext context;
 
 
+    /**
+     * @param bucket url encoded bucket name
+     * @param filePath url encoded file path
+     */
     public Future<?> handle(String bucket, String filePath) {
+        String urlDecodedBucket = URLDecoder.decode(bucket, StandardCharsets.UTF_8);
         String expectedUserBucket = BlobStorageUtil.buildUserBucket(context);
-        String decryptedBucket = proxy.getEncryptionService().decrypt(bucket);
+        String decryptedBucket = proxy.getEncryptionService().decrypt(urlDecodedBucket);
 
         if (!expectedUserBucket.equals(decryptedBucket)) {
             return context.respond(HttpStatus.FORBIDDEN, "You don't have an access to the bucket " + bucket);
@@ -26,9 +36,10 @@ public abstract class AccessControlBaseController {
 
         ResourceDescription resource;
         try {
-            resource = ResourceDescription.from(ResourceType.FILE, bucket, decryptedBucket, filePath);
+            resource = ResourceDescription.from(ResourceType.FILE, urlDecodedBucket, decryptedBucket, filePath);
         } catch (Exception ex) {
-            return context.respond(HttpStatus.BAD_REQUEST, "Invalid file url provided");
+            String errorMessage = ex.getMessage() != null ? ex.getMessage() : DEFAULT_RESOURCE_ERROR_MESSAGE.formatted(filePath);
+            return context.respond(HttpStatus.BAD_REQUEST, errorMessage);
         }
 
         return handle(resource);

--- a/src/main/java/com/epam/aidial/core/controller/AccessControlBaseController.java
+++ b/src/main/java/com/epam/aidial/core/controller/AccessControlBaseController.java
@@ -6,11 +6,9 @@ import com.epam.aidial.core.storage.BlobStorageUtil;
 import com.epam.aidial.core.storage.ResourceDescription;
 import com.epam.aidial.core.storage.ResourceType;
 import com.epam.aidial.core.util.HttpStatus;
+import com.epam.aidial.core.util.UrlUtil;
 import io.vertx.core.Future;
 import lombok.AllArgsConstructor;
-
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 @AllArgsConstructor
 public abstract class AccessControlBaseController {
@@ -26,7 +24,7 @@ public abstract class AccessControlBaseController {
      * @param filePath url encoded file path
      */
     public Future<?> handle(String bucket, String filePath) {
-        String urlDecodedBucket = URLDecoder.decode(bucket, StandardCharsets.UTF_8);
+        String urlDecodedBucket = UrlUtil.decodePath(bucket);
         String expectedUserBucket = BlobStorageUtil.buildUserBucket(context);
         String decryptedBucket = proxy.getEncryptionService().decrypt(urlDecodedBucket);
 

--- a/src/main/java/com/epam/aidial/core/controller/AccessControlBaseController.java
+++ b/src/main/java/com/epam/aidial/core/controller/AccessControlBaseController.java
@@ -36,7 +36,7 @@ public abstract class AccessControlBaseController {
 
         ResourceDescription resource;
         try {
-            resource = ResourceDescription.from(ResourceType.FILE, urlDecodedBucket, decryptedBucket, filePath);
+            resource = ResourceDescription.fromEncoded(ResourceType.FILE, urlDecodedBucket, decryptedBucket, filePath);
         } catch (Exception ex) {
             String errorMessage = ex.getMessage() != null ? ex.getMessage() : DEFAULT_RESOURCE_ERROR_MESSAGE.formatted(filePath);
             return context.respond(HttpStatus.BAD_REQUEST, errorMessage);

--- a/src/main/java/com/epam/aidial/core/controller/ControllerSelector.java
+++ b/src/main/java/com/epam/aidial/core/controller/ControllerSelector.java
@@ -44,14 +44,15 @@ public class ControllerSelector {
     private static final Pattern PATTERN_TRUNCATE_PROMPT = Pattern.compile("/+v1/deployments/([-.@a-zA-Z0-9]+)/truncate_prompt");
 
     public Controller select(Proxy proxy, ProxyContext context) {
-        String path = URLDecoder.decode(context.getRequest().path(), StandardCharsets.UTF_8);
+        String path = context.getRequest().path();
+        String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
         HttpMethod method = context.getRequest().method();
         Controller controller = null;
 
         if (method == HttpMethod.GET) {
-            controller = selectGet(proxy, context, path);
+            controller = selectGet(proxy, context, path, decodedPath);
         } else if (method == HttpMethod.POST) {
-            controller = selectPost(proxy, context, path);
+            controller = selectPost(proxy, context, decodedPath);
         } else if (method == HttpMethod.DELETE) {
             controller = selectDelete(proxy, context, path);
         } else if (method == HttpMethod.PUT) {
@@ -61,69 +62,69 @@ public class ControllerSelector {
         return (controller == null) ? new RouteController(proxy, context) : controller;
     }
 
-    private static Controller selectGet(Proxy proxy, ProxyContext context, String path) {
+    private static Controller selectGet(Proxy proxy, ProxyContext context, String path, String decodedPath) {
         Matcher match;
 
-        match = match(PATTERN_DEPLOYMENT, path);
+        match = match(PATTERN_DEPLOYMENT, decodedPath);
         if (match != null) {
             DeploymentController controller = new DeploymentController(context);
             String deploymentId = match.group(1);
             return () -> controller.getDeployment(deploymentId);
         }
 
-        match = match(PATTERN_DEPLOYMENTS, path);
+        match = match(PATTERN_DEPLOYMENTS, decodedPath);
         if (match != null) {
             DeploymentController controller = new DeploymentController(context);
             return controller::getDeployments;
         }
 
-        match = match(PATTERN_MODEL, path);
+        match = match(PATTERN_MODEL, decodedPath);
         if (match != null) {
             ModelController controller = new ModelController(context);
             String modelId = match.group(1);
             return () -> controller.getModel(modelId);
         }
 
-        match = match(PATTERN_MODELS, path);
+        match = match(PATTERN_MODELS, decodedPath);
         if (match != null) {
             ModelController controller = new ModelController(context);
             return controller::getModels;
         }
 
-        match = match(PATTERN_ADDON, path);
+        match = match(PATTERN_ADDON, decodedPath);
         if (match != null) {
             AddonController controller = new AddonController(context);
             String addonId = match.group(1);
             return () -> controller.getAddon(addonId);
         }
 
-        match = match(PATTERN_ADDONS, path);
+        match = match(PATTERN_ADDONS, decodedPath);
         if (match != null) {
             AddonController controller = new AddonController(context);
             return controller::getAddons;
         }
 
-        match = match(PATTERN_ASSISTANT, path);
+        match = match(PATTERN_ASSISTANT, decodedPath);
         if (match != null) {
             AssistantController controller = new AssistantController(context);
             String assistantId = match.group(1);
             return () -> controller.getAssistant(assistantId);
         }
 
-        match = match(PATTERN_ASSISTANTS, path);
+        match = match(PATTERN_ASSISTANTS, decodedPath);
         if (match != null) {
             AssistantController controller = new AssistantController(context);
             return controller::getAssistants;
         }
 
-        match = match(PATTERN_APPLICATION, path);
+        match = match(PATTERN_APPLICATION, decodedPath);
         if (match != null) {
             ApplicationController controller = new ApplicationController(context);
             String application = match.group(1);
             return () -> controller.getApplication(application);
         }
 
-        match = match(PATTERN_APPLICATIONS, path);
+        match = match(PATTERN_APPLICATIONS, decodedPath);
         if (match != null) {
             ApplicationController controller = new ApplicationController(context);
             return controller::getApplications;
@@ -145,7 +146,7 @@ public class ControllerSelector {
             return () -> controller.handle(bucket, filePath);
         }
 
-        match = match(PATTERN_BUCKET, path);
+        match = match(PATTERN_BUCKET, decodedPath);
         if (match != null) {
             BucketController controller = new BucketController(proxy, context);
             return controller::getBucket;

--- a/src/main/java/com/epam/aidial/core/controller/DeleteFileController.java
+++ b/src/main/java/com/epam/aidial/core/controller/DeleteFileController.java
@@ -29,7 +29,7 @@ public class DeleteFileController extends AccessControlBaseController {
                 storage.delete(absoluteFilePath);
                 return null;
             } catch (Exception ex) {
-                log.error("Failed to delete file " + absoluteFilePath, ex);
+                log.error("Failed to delete file  %s/%s".formatted(resource.getBucketName(), resource.getOriginalPath()), ex);
                 throw new RuntimeException(ex);
             }
         });

--- a/src/main/java/com/epam/aidial/core/controller/DownloadFileController.java
+++ b/src/main/java/com/epam/aidial/core/controller/DownloadFileController.java
@@ -61,7 +61,7 @@ public class DownloadFileController extends AccessControlBaseController {
                 result.fail(e);
             }
         }).onFailure(error -> context.respond(HttpStatus.INTERNAL_SERVER_ERROR,
-                "Failed to fetch file with path %s/%s".formatted(resource.getBucketName(), resource.getRelativePath())));
+                "Failed to fetch file with path %s/%s".formatted(resource.getBucketName(), resource.getOriginalPath())));
 
         return result.future();
     }

--- a/src/main/java/com/epam/aidial/core/controller/FileMetadataController.java
+++ b/src/main/java/com/epam/aidial/core/controller/FileMetadataController.java
@@ -30,7 +30,7 @@ public class FileMetadataController extends AccessControlBaseController {
             } catch (Exception ex) {
                 log.error("Failed to list files", ex);
                 context.respond(HttpStatus.INTERNAL_SERVER_ERROR,
-                        "Failed to list files by path %s/%s".formatted(resource.getBucketName(), resource.getRelativePath()));
+                        "Failed to list files by path %s/%s".formatted(resource.getBucketName(), resource.getOriginalPath()));
             }
 
             return null;

--- a/src/main/java/com/epam/aidial/core/controller/UploadFileController.java
+++ b/src/main/java/com/epam/aidial/core/controller/UploadFileController.java
@@ -43,7 +43,7 @@ public class UploadFileController extends AccessControlBaseController {
                             .onFailure(error -> {
                                 writeStream.abortUpload(error);
                                 context.respond(HttpStatus.INTERNAL_SERVER_ERROR,
-                                        "Failed to upload file by path %s/%s".formatted(resource.getBucketName(), resource.getRelativePath()));
+                                        "Failed to upload file by path %s/%s".formatted(resource.getBucketName(), resource.getOriginalPath()));
                             });
                 });
 

--- a/src/main/java/com/epam/aidial/core/storage/BlobStorage.java
+++ b/src/main/java/com/epam/aidial/core/storage/BlobStorage.java
@@ -180,7 +180,7 @@ public class BlobStorage implements Closeable {
 
     private static ResourceDescription getResourceDescription(ResourceType resourceType, String bucketName, String bucketLocation, String absoluteFilePath) {
         String relativeFilePath = absoluteFilePath.substring(bucketLocation.length() + resourceType.getFolder().length() + 1);
-        return ResourceDescription.from(resourceType, bucketName, bucketLocation, relativeFilePath);
+        return ResourceDescription.fromDecoded(resourceType, bucketName, bucketLocation, relativeFilePath);
     }
 
     private static BlobMetadata buildBlobMetadata(String absoluteFilePath, String contentType, String bucketName) {

--- a/src/main/java/com/epam/aidial/core/storage/BlobStorageUtil.java
+++ b/src/main/java/com/epam/aidial/core/storage/BlobStorageUtil.java
@@ -33,10 +33,6 @@ public class BlobStorageUtil {
         throw new IllegalArgumentException("Can't find user bucket. Either user sub or api-key project must be provided");
     }
 
-    public String buildAbsoluteFilePath(ResourceType resource, String bucket, String path) {
-        return bucket + resource.getFolder() + PATH_SEPARATOR + path;
-    }
-
     public boolean isFolder(String path) {
         return path.endsWith(PATH_SEPARATOR);
     }

--- a/src/main/java/com/epam/aidial/core/storage/ResourceDescription.java
+++ b/src/main/java/com/epam/aidial/core/storage/ResourceDescription.java
@@ -5,9 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,21 +18,24 @@ public class ResourceDescription {
     ResourceType type;
     String name;
     List<String> parentFolders;
-    String relativePath;
+    String originalPath;
     String bucketName;
     String bucketLocation;
     boolean isFolder;
 
     public String getUrl() {
         StringBuilder builder = new StringBuilder();
-        builder.append(bucketName)
+        builder.append(urlEncode(bucketName))
                 .append(BlobStorageUtil.PATH_SEPARATOR);
         if (parentFolders != null) {
-            builder.append(String.join(BlobStorageUtil.PATH_SEPARATOR, parentFolders))
+            String parentPath = parentFolders.stream()
+                    .map(ResourceDescription::urlEncode)
+                    .collect(Collectors.joining(BlobStorageUtil.PATH_SEPARATOR));
+            builder.append(parentPath)
                     .append(BlobStorageUtil.PATH_SEPARATOR);
         }
         if (name != null && !isHomeFolder(name)) {
-            builder.append(name);
+            builder.append(urlEncode(name));
 
             if (isFolder) {
                 builder.append(BlobStorageUtil.PATH_SEPARATOR);
@@ -60,29 +66,54 @@ public class ResourceDescription {
         return parentFolders == null ? null : String.join(BlobStorageUtil.PATH_SEPARATOR, parentFolders);
     }
 
-    public static ResourceDescription from(ResourceType type, String bucketName, String bucketLocation, String relativeFilePath) {
+    /**
+     * Creates resource for the given parameters
+     *
+     * @param type           resource type
+     * @param bucketName     bucket name (encrypted)
+     * @param bucketLocation bucket location on blob storage; bucket location must end with /
+     * @param path           url encoded relative path; url path is null or empty we treat it as user home
+     */
+    public static ResourceDescription from(ResourceType type, String bucketName, String bucketLocation, String path) {
         // in case empty path - treat it as a home folder
-        relativeFilePath = StringUtils.isBlank(relativeFilePath) ? BlobStorageUtil.PATH_SEPARATOR : relativeFilePath;
+        String urlEncodedRelativePath = StringUtils.isBlank(path) ? BlobStorageUtil.PATH_SEPARATOR : path;
         verify(bucketLocation.endsWith(BlobStorageUtil.PATH_SEPARATOR), "Bucket location must end with /");
 
-        String[] elements = relativeFilePath.split(BlobStorageUtil.PATH_SEPARATOR);
+        String[] encodedElements = urlEncodedRelativePath.split(BlobStorageUtil.PATH_SEPARATOR);
+        List<String> elements = Arrays.stream(encodedElements).map(ResourceDescription::urlDecode).toList();
+        elements.forEach(element ->
+                verify(isValidFilename(element), "Invalid path provided " + urlEncodedRelativePath)
+        );
         List<String> parentFolders = null;
         String name = "/";
-        if (elements.length > 0) {
-            name = elements[elements.length - 1];
+        if (!elements.isEmpty()) {
+            name = elements.get(elements.size() - 1);
         }
-        if (elements.length > 1) {
-            String parentPath = relativeFilePath.substring(0, relativeFilePath.length() - name.length() - 1);
+        if (elements.size() > 1) {
+            String parentPath = urlEncodedRelativePath.substring(0, urlEncodedRelativePath.length() - name.length() - 1);
             if (!parentPath.isEmpty() && !parentPath.equals(BlobStorageUtil.PATH_SEPARATOR)) {
                 parentFolders = List.of(parentPath.split(BlobStorageUtil.PATH_SEPARATOR));
             }
         }
 
-        return new ResourceDescription(type, name, parentFolders, relativeFilePath, bucketName, bucketLocation, BlobStorageUtil.isFolder(relativeFilePath));
+        return new ResourceDescription(type, name, parentFolders, urlEncodedRelativePath, bucketName, bucketLocation,
+                BlobStorageUtil.isFolder(urlEncodedRelativePath));
     }
 
     private static boolean isHomeFolder(String path) {
         return path.equals(BlobStorageUtil.PATH_SEPARATOR);
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String urlDecode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+
+    private static boolean isValidFilename(String value) {
+        return !value.contains(BlobStorageUtil.PATH_SEPARATOR);
     }
 
     private static void verify(boolean condition, String message) {

--- a/src/main/java/com/epam/aidial/core/storage/ResourceDescription.java
+++ b/src/main/java/com/epam/aidial/core/storage/ResourceDescription.java
@@ -36,7 +36,7 @@ public class ResourceDescription {
             }
         }
 
-        return URLEncoder.encode(builder.toString(), StandardCharsets.UTF_8);
+        return builder.toString();
     }
 
     public String getAbsoluteFilePath() {

--- a/src/main/java/com/epam/aidial/core/util/UrlUtil.java
+++ b/src/main/java/com/epam/aidial/core/util/UrlUtil.java
@@ -1,0 +1,28 @@
+package com.epam.aidial.core.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@UtilityClass
+public class UrlUtil {
+
+    public String encodePath(String path) {
+        try {
+            URI uri = new URI(null, null, path, null);
+            return uri.toASCIIString();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String decodePath(String path) {
+        try {
+            URI uri = new URI(path);
+            return uri.getPath();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/core/util/UrlUtil.java
+++ b/src/main/java/com/epam/aidial/core/util/UrlUtil.java
@@ -20,6 +20,9 @@ public class UrlUtil {
     public String decodePath(String path) {
         try {
             URI uri = new URI(path);
+            if (uri.getRawFragment() != null || uri.getRawQuery() != null) {
+                throw new IllegalArgumentException("Wrong path provided " + path);
+            }
             return uri.getPath();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);

--- a/src/test/java/com/epam/aidial/core/FileApiTest.java
+++ b/src/test/java/com/epam/aidial/core/FileApiTest.java
@@ -88,7 +88,7 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FolderMetadata emptyBucketResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2F", List.of());
+                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
         client.get(serverPort, "localhost", "/v1/files/metadata/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/")
                 .putHeader("Api-key", "proxyKey2")
                 .as(BodyCodec.json(FolderMetadata.class))
@@ -156,11 +156,11 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FileMetadata expectedFileMetadata = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffile.txt", 17, "text/custom");
+                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt", 17, "text/custom");
 
         Future.succeededFuture().compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
-            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffile.txt")
+            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt")
                     .putHeader("Api-key", "proxyKey2")
                     .as(BodyCodec.json(FileMetadata.class))
                     .sendMultipartForm(generateMultipartForm("file.txt", TEST_FILE_CONTENT, "text/custom"),
@@ -209,11 +209,11 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FolderMetadata emptyFolderResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2F", List.of());
+                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
         FileMetadata expectedFileMetadata = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffile.txt", 17, "text/custom");
+                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt", 17, "text/custom");
         FolderMetadata expectedFolderMetadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2F", List.of(expectedFileMetadata));
+                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of(expectedFileMetadata));
 
         Future.succeededFuture().compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
@@ -234,7 +234,7 @@ public class FileApiTest {
         }).compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
             // upload test file
-            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffile.txt")
+            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt")
                     .putHeader("Api-key", "proxyKey2")
                     .as(BodyCodec.json(FileMetadata.class))
                     .sendMultipartForm(generateMultipartForm("file.txt", TEST_FILE_CONTENT, "text/custom"),
@@ -270,12 +270,12 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FileMetadata expectedFileMetadata = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "file.txt", "folder1", "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffolder1%2Ffile.txt", 17, "text/plain");
+                "file.txt", "folder1", "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/folder1/file.txt", 17, "text/plain");
 
         Future.succeededFuture().compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
             // upload test file
-            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffolder1%2Ffile.txt")
+            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/folder1/file.txt")
                     .putHeader("Api-key", "proxyKey2")
                     .as(BodyCodec.json(FileMetadata.class))
                     .sendMultipartForm(generateMultipartForm("file.txt", TEST_FILE_CONTENT),
@@ -310,16 +310,16 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FolderMetadata emptyFolderResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2F", List.of());
+                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
 
         FileMetadata expectedFileMetadata1 = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffile.txt", 17, "text/custom");
+                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt", 17, "text/custom");
         FileMetadata expectedFileMetadata2 = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "file.txt", "folder1", "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffolder1%2Ffile.txt", 17, "text/custom");
+                "file.txt", "folder1", "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/folder1/file.txt", 17, "text/custom");
         FolderMetadata expectedFolder1Metadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "folder1", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ffolder1%2F");
+                "folder1", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/folder1/");
         FolderMetadata expectedRootFolderMetadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2F",
+                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/",
                 List.of(expectedFileMetadata1, expectedFolder1Metadata));
 
         Future.succeededFuture().compose((mapper) -> {
@@ -395,7 +395,7 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FileMetadata expectedFileMetadata = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "test_file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt%2Ftest_file.txt", 17, "text/plain");
+                "test_file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/test_file.txt", 17, "text/plain");
 
         Future.succeededFuture().compose((mapper) -> {
             Promise<Void> promise = Promise.promise();

--- a/src/test/java/com/epam/aidial/core/FileApiTest.java
+++ b/src/test/java/com/epam/aidial/core/FileApiTest.java
@@ -88,7 +88,7 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FolderMetadata emptyBucketResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
+                null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
         client.get(serverPort, "localhost", "/v1/files/metadata/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/")
                 .putHeader("Api-key", "proxyKey2")
                 .as(BodyCodec.json(FolderMetadata.class))
@@ -209,11 +209,11 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FolderMetadata emptyFolderResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
+                null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
         FileMetadata expectedFileMetadata = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
                 "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt", 17, "text/custom");
         FolderMetadata expectedFolderMetadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of(expectedFileMetadata));
+                null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of(expectedFileMetadata));
 
         Future.succeededFuture().compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
@@ -310,7 +310,7 @@ public class FileApiTest {
         WebClient client = WebClient.create(vertx);
 
         FolderMetadata emptyFolderResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
+                null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
 
         FileMetadata expectedFileMetadata1 = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
                 "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt", 17, "text/custom");
@@ -319,7 +319,7 @@ public class FileApiTest {
         FolderMetadata expectedFolder1Metadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
                 "folder1", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/folder1/");
         FolderMetadata expectedRootFolderMetadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "/", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/",
+                null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/",
                 List.of(expectedFileMetadata1, expectedFolder1Metadata));
 
         Future.succeededFuture().compose((mapper) -> {

--- a/src/test/java/com/epam/aidial/core/FileApiTest.java
+++ b/src/test/java/com/epam/aidial/core/FileApiTest.java
@@ -211,7 +211,7 @@ public class FileApiTest {
         FolderMetadata emptyFolderResponse = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
                 null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of());
         FileMetadata expectedFileMetadata = new FileMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
-                "file.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt", 17, "text/custom");
+                "файл.txt", null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/%D1%84%D0%B0%D0%B9%D0%BB.txt", 17, "text/custom");
         FolderMetadata expectedFolderMetadata = new FolderMetadata("7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt",
                 null, null, "7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/", List.of(expectedFileMetadata));
 
@@ -234,10 +234,10 @@ public class FileApiTest {
         }).compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
             // upload test file
-            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.txt")
+            client.put(serverPort, "localhost", "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/%D1%84%D0%B0%D0%B9%D0%BB.txt")
                     .putHeader("Api-key", "proxyKey2")
                     .as(BodyCodec.json(FileMetadata.class))
-                    .sendMultipartForm(generateMultipartForm("file.txt", TEST_FILE_CONTENT, "text/custom"),
+                    .sendMultipartForm(generateMultipartForm("файл.txt", TEST_FILE_CONTENT, "text/custom"),
                             context.succeeding(response -> {
                                 context.verify(() -> {
                                     assertEquals(200, response.statusCode());

--- a/src/test/java/com/epam/aidial/core/controller/ControllerSelectorTest.java
+++ b/src/test/java/com/epam/aidial/core/controller/ControllerSelectorTest.java
@@ -195,6 +195,23 @@ public class ControllerSelectorTest {
     }
 
     @Test
+    public void testSelectListMetadataFileController2() {
+        when(request.path()).thenReturn("/v1/files/metadata/bucket/fol%2Fder%201/");
+        when(request.method()).thenReturn(HttpMethod.GET);
+        Controller controller = ControllerSelector.select(proxy, context);
+        assertNotNull(controller);
+        SerializedLambda lambda = getSerializedLambda(controller);
+        assertNotNull(lambda);
+        assertEquals(3, lambda.getCapturedArgCount());
+        Object arg1 = lambda.getCapturedArg(0);
+        Object arg2 = lambda.getCapturedArg(1);
+        Object arg3 = lambda.getCapturedArg(2);
+        assertInstanceOf(FileMetadataController.class, arg1);
+        assertEquals("bucket", arg2);
+        assertEquals("fol%2Fder%201/", arg3);
+    }
+
+    @Test
     public void testSelectDownloadFileController() {
         when(request.path()).thenReturn("/v1/files/bucket/folder1/file1.txt");
         when(request.method()).thenReturn(HttpMethod.GET);
@@ -209,6 +226,23 @@ public class ControllerSelectorTest {
         assertInstanceOf(DownloadFileController.class, arg1);
         assertEquals("bucket", arg2);
         assertEquals("folder1/file1.txt", arg3);
+    }
+
+    @Test
+    public void testSelectDownloadFileController2() {
+        when(request.path()).thenReturn("/v1/files/bucket/fol%2Fder%201/file1%23.txt");
+        when(request.method()).thenReturn(HttpMethod.GET);
+        Controller controller = ControllerSelector.select(proxy, context);
+        assertNotNull(controller);
+        SerializedLambda lambda = getSerializedLambda(controller);
+        assertNotNull(lambda);
+        assertEquals(3, lambda.getCapturedArgCount());
+        Object arg1 = lambda.getCapturedArg(0);
+        Object arg2 = lambda.getCapturedArg(1);
+        Object arg3 = lambda.getCapturedArg(2);
+        assertInstanceOf(DownloadFileController.class, arg1);
+        assertEquals("bucket", arg2);
+        assertEquals("fol%2Fder%201/file1%23.txt", arg3);
     }
 
     @Test
@@ -246,6 +280,23 @@ public class ControllerSelectorTest {
     }
 
     @Test
+    public void testSelectUploadFileController2() {
+        when(request.path()).thenReturn("/v1/files/bucket/fol%2Fder%201/file1%23.txt");
+        when(request.method()).thenReturn(HttpMethod.PUT);
+        Controller controller = ControllerSelector.select(proxy, context);
+        assertNotNull(controller);
+        SerializedLambda lambda = getSerializedLambda(controller);
+        assertNotNull(lambda);
+        assertEquals(3, lambda.getCapturedArgCount());
+        Object arg1 = lambda.getCapturedArg(0);
+        Object arg2 = lambda.getCapturedArg(1);
+        Object arg3 = lambda.getCapturedArg(2);
+        assertInstanceOf(UploadFileController.class, arg1);
+        assertEquals("bucket", arg2);
+        assertEquals("fol%2Fder%201/file1%23.txt", arg3);
+    }
+
+    @Test
     public void testSelectDeleteFileController() {
         when(request.path()).thenReturn("/v1/files/bucket/folder1/file1.txt");
         when(request.method()).thenReturn(HttpMethod.DELETE);
@@ -260,6 +311,23 @@ public class ControllerSelectorTest {
         assertInstanceOf(DeleteFileController.class, arg1);
         assertEquals("bucket", arg2);
         assertEquals("folder1/file1.txt", arg3);
+    }
+
+    @Test
+    public void testSelectDeleteFileController2() {
+        when(request.path()).thenReturn("/v1/files/bucket/fol%2Fder%201/file1%23.txt");
+        when(request.method()).thenReturn(HttpMethod.DELETE);
+        Controller controller = ControllerSelector.select(proxy, context);
+        assertNotNull(controller);
+        SerializedLambda lambda = getSerializedLambda(controller);
+        assertNotNull(lambda);
+        assertEquals(3, lambda.getCapturedArgCount());
+        Object arg1 = lambda.getCapturedArg(0);
+        Object arg2 = lambda.getCapturedArg(1);
+        Object arg3 = lambda.getCapturedArg(2);
+        assertInstanceOf(DeleteFileController.class, arg1);
+        assertEquals("bucket", arg2);
+        assertEquals("fol%2Fder%201/file1%23.txt", arg3);
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/core/storage/ResourceDescriptionTest.java
+++ b/src/test/java/com/epam/aidial/core/storage/ResourceDescriptionTest.java
@@ -15,8 +15,8 @@ public class ResourceDescriptionTest {
 
     @Test
     public void testHomeFolderDescription() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "aes-bucket-name", "buckets/location/", "/");
-        assertEquals("/", resource.getName());
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "aes-bucket-name", "buckets/location/", "/");
+        assertNull(resource.getName());
         assertEquals("aes-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
@@ -25,27 +25,27 @@ public class ResourceDescriptionTest {
         assertEquals("/", resource.getOriginalPath());
         assertTrue(resource.isFolder());
         assertNull(resource.getParentPath());
-        assertNull(resource.getParentFolders());
+        assertTrue(resource.getParentFolders().isEmpty());
     }
 
     @Test
     public void testUserFolderDescription() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/");
-        assertEquals("folder1", resource.getName());
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder%201/");
+        assertEquals("folder 1", resource.getName());
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name/folder1/", resource.getUrl());
-        assertEquals("buckets/location/files/folder1/", resource.getAbsoluteFilePath());
-        assertEquals("folder1/", resource.getOriginalPath());
+        assertEquals("test-bucket-name/folder%201/", resource.getUrl());
+        assertEquals("buckets/location/files/folder 1/", resource.getAbsoluteFilePath());
+        assertEquals("folder%201/", resource.getOriginalPath());
         assertTrue(resource.isFolder());
         assertNull(resource.getParentPath());
-        assertNull(resource.getParentFolders());
+        assertTrue(resource.getParentFolders().isEmpty());
     }
 
     @Test
     public void testUserFolderDescription2() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/folder2/");
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/folder2/");
         assertEquals("folder2", resource.getName());
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
@@ -60,7 +60,7 @@ public class ResourceDescriptionTest {
 
     @Test
     public void testUserFolderDescription3() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/folder2/folder3/");
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/folder2/folder3/");
         assertEquals("folder3", resource.getName());
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
@@ -75,7 +75,7 @@ public class ResourceDescriptionTest {
 
     @Test
     public void testFileDescription1() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "test-bucket-name", "buckets/location/", "file.txt");
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "test-bucket-name", "buckets/location/", "file.txt");
         assertEquals("file.txt", resource.getName());
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
@@ -85,12 +85,12 @@ public class ResourceDescriptionTest {
         assertEquals("file.txt", resource.getOriginalPath());
         assertFalse(resource.isFolder());
         assertNull(resource.getParentPath());
-        assertNull(resource.getParentFolders());
+        assertTrue(resource.getParentFolders().isEmpty());
     }
 
     @Test
     public void testFileDescription2() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/file.txt");
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/file.txt");
         assertEquals("file.txt", resource.getName());
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
@@ -105,7 +105,7 @@ public class ResourceDescriptionTest {
 
     @Test
     public void testFileDescription3() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/folder2/file.txt");
+        ResourceDescription resource = ResourceDescription.fromEncoded(ResourceType.FILE, "test-bucket-name", "buckets/location/", "folder1/folder2/file.txt");
         assertEquals("file.txt", resource.getName());
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
@@ -121,30 +121,30 @@ public class ResourceDescriptionTest {
     @Test
     public void testInvalidBucketLocation() {
         assertThrows(IllegalArgumentException.class,
-                () -> ResourceDescription.from(ResourceType.FILE, "bucket-name", "buckets/location", "file.txt"));
+                () -> ResourceDescription.fromEncoded(ResourceType.FILE, "bucket-name", "buckets/location", "file.txt"));
     }
 
     @Test
     public void testEmptyRelativePath() {
         assertEquals(
-                ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "/"),
-                ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "")
+                ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "/"),
+                ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "")
         );
         assertEquals(
-                ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "/"),
-                ResourceDescription.from(ResourceType.FILE, "bucket", "location/", null)
+                ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "/"),
+                ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", null)
         );
         assertEquals(
-                ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "/"),
-                ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "   ")
+                ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "/"),
+                ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "   ")
         );
     }
 
     @Test
     public void testResourceWithInvalidFilename() {
         assertThrows(IllegalArgumentException.class,
-                () -> ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "folde%2F/"));
+                () -> ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "folde%2F/"));
         assertThrows(IllegalArgumentException.class,
-                () -> ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "folder1/file%2F.txt"));
+                () -> ResourceDescription.fromEncoded(ResourceType.FILE, "bucket", "location/", "folder1/file%2F.txt"));
     }
 }

--- a/src/test/java/com/epam/aidial/core/storage/ResourceDescriptionTest.java
+++ b/src/test/java/com/epam/aidial/core/storage/ResourceDescriptionTest.java
@@ -20,7 +20,7 @@ public class ResourceDescriptionTest {
         assertEquals("aes/bucket/name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("aes%2Fbucket%2Fname%2F", resource.getUrl());
+        assertEquals("aes/bucket/name/", resource.getUrl());
         assertEquals("buckets/location/files/", resource.getAbsoluteFilePath());
         assertEquals("/", resource.getRelativePath());
         assertTrue(resource.isFolder());
@@ -35,7 +35,7 @@ public class ResourceDescriptionTest {
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name%2Ffolder1%2F", resource.getUrl());
+        assertEquals("test-bucket-name/folder1/", resource.getUrl());
         assertEquals("buckets/location/files/folder1/", resource.getAbsoluteFilePath());
         assertEquals("folder1/", resource.getRelativePath());
         assertTrue(resource.isFolder());
@@ -50,7 +50,7 @@ public class ResourceDescriptionTest {
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name%2Ffolder1%2Ffolder2%2F", resource.getUrl());
+        assertEquals("test-bucket-name/folder1/folder2/", resource.getUrl());
         assertEquals("buckets/location/files/folder1/folder2/", resource.getAbsoluteFilePath());
         assertEquals("folder1/folder2/", resource.getRelativePath());
         assertTrue(resource.isFolder());
@@ -65,7 +65,7 @@ public class ResourceDescriptionTest {
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name%2Ffolder1%2Ffolder2%2Ffolder3%2F", resource.getUrl());
+        assertEquals("test-bucket-name/folder1/folder2/folder3/", resource.getUrl());
         assertEquals("buckets/location/files/folder1/folder2/folder3/", resource.getAbsoluteFilePath());
         assertEquals("folder1/folder2/folder3/", resource.getRelativePath());
         assertTrue(resource.isFolder());
@@ -80,7 +80,7 @@ public class ResourceDescriptionTest {
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name%2Ffile.txt", resource.getUrl());
+        assertEquals("test-bucket-name/file.txt", resource.getUrl());
         assertEquals("buckets/location/files/file.txt", resource.getAbsoluteFilePath());
         assertEquals("file.txt", resource.getRelativePath());
         assertFalse(resource.isFolder());
@@ -95,7 +95,7 @@ public class ResourceDescriptionTest {
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name%2Ffolder1%2Ffile.txt", resource.getUrl());
+        assertEquals("test-bucket-name/folder1/file.txt", resource.getUrl());
         assertEquals("buckets/location/files/folder1/file.txt", resource.getAbsoluteFilePath());
         assertEquals("folder1/file.txt", resource.getRelativePath());
         assertFalse(resource.isFolder());
@@ -110,7 +110,7 @@ public class ResourceDescriptionTest {
         assertEquals("test-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("test-bucket-name%2Ffolder1%2Ffolder2%2Ffile.txt", resource.getUrl());
+        assertEquals("test-bucket-name/folder1/folder2/file.txt", resource.getUrl());
         assertEquals("buckets/location/files/folder1/folder2/file.txt", resource.getAbsoluteFilePath());
         assertEquals("folder1/folder2/file.txt", resource.getRelativePath());
         assertFalse(resource.isFolder());

--- a/src/test/java/com/epam/aidial/core/storage/ResourceDescriptionTest.java
+++ b/src/test/java/com/epam/aidial/core/storage/ResourceDescriptionTest.java
@@ -15,14 +15,14 @@ public class ResourceDescriptionTest {
 
     @Test
     public void testHomeFolderDescription() {
-        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "aes/bucket/name", "buckets/location/", "/");
+        ResourceDescription resource = ResourceDescription.from(ResourceType.FILE, "aes-bucket-name", "buckets/location/", "/");
         assertEquals("/", resource.getName());
-        assertEquals("aes/bucket/name", resource.getBucketName());
+        assertEquals("aes-bucket-name", resource.getBucketName());
         assertEquals("buckets/location/", resource.getBucketLocation());
         assertEquals(ResourceType.FILE, resource.getType());
-        assertEquals("aes/bucket/name/", resource.getUrl());
+        assertEquals("aes-bucket-name/", resource.getUrl());
         assertEquals("buckets/location/files/", resource.getAbsoluteFilePath());
-        assertEquals("/", resource.getRelativePath());
+        assertEquals("/", resource.getOriginalPath());
         assertTrue(resource.isFolder());
         assertNull(resource.getParentPath());
         assertNull(resource.getParentFolders());
@@ -37,7 +37,7 @@ public class ResourceDescriptionTest {
         assertEquals(ResourceType.FILE, resource.getType());
         assertEquals("test-bucket-name/folder1/", resource.getUrl());
         assertEquals("buckets/location/files/folder1/", resource.getAbsoluteFilePath());
-        assertEquals("folder1/", resource.getRelativePath());
+        assertEquals("folder1/", resource.getOriginalPath());
         assertTrue(resource.isFolder());
         assertNull(resource.getParentPath());
         assertNull(resource.getParentFolders());
@@ -52,7 +52,7 @@ public class ResourceDescriptionTest {
         assertEquals(ResourceType.FILE, resource.getType());
         assertEquals("test-bucket-name/folder1/folder2/", resource.getUrl());
         assertEquals("buckets/location/files/folder1/folder2/", resource.getAbsoluteFilePath());
-        assertEquals("folder1/folder2/", resource.getRelativePath());
+        assertEquals("folder1/folder2/", resource.getOriginalPath());
         assertTrue(resource.isFolder());
         assertEquals("folder1", resource.getParentPath());
         assertIterableEquals(List.of("folder1"), resource.getParentFolders());
@@ -67,7 +67,7 @@ public class ResourceDescriptionTest {
         assertEquals(ResourceType.FILE, resource.getType());
         assertEquals("test-bucket-name/folder1/folder2/folder3/", resource.getUrl());
         assertEquals("buckets/location/files/folder1/folder2/folder3/", resource.getAbsoluteFilePath());
-        assertEquals("folder1/folder2/folder3/", resource.getRelativePath());
+        assertEquals("folder1/folder2/folder3/", resource.getOriginalPath());
         assertTrue(resource.isFolder());
         assertEquals("folder1/folder2", resource.getParentPath());
         assertIterableEquals(List.of("folder1", "folder2"), resource.getParentFolders());
@@ -82,7 +82,7 @@ public class ResourceDescriptionTest {
         assertEquals(ResourceType.FILE, resource.getType());
         assertEquals("test-bucket-name/file.txt", resource.getUrl());
         assertEquals("buckets/location/files/file.txt", resource.getAbsoluteFilePath());
-        assertEquals("file.txt", resource.getRelativePath());
+        assertEquals("file.txt", resource.getOriginalPath());
         assertFalse(resource.isFolder());
         assertNull(resource.getParentPath());
         assertNull(resource.getParentFolders());
@@ -97,7 +97,7 @@ public class ResourceDescriptionTest {
         assertEquals(ResourceType.FILE, resource.getType());
         assertEquals("test-bucket-name/folder1/file.txt", resource.getUrl());
         assertEquals("buckets/location/files/folder1/file.txt", resource.getAbsoluteFilePath());
-        assertEquals("folder1/file.txt", resource.getRelativePath());
+        assertEquals("folder1/file.txt", resource.getOriginalPath());
         assertFalse(resource.isFolder());
         assertEquals("folder1", resource.getParentPath());
         assertIterableEquals(List.of("folder1"), resource.getParentFolders());
@@ -112,7 +112,7 @@ public class ResourceDescriptionTest {
         assertEquals(ResourceType.FILE, resource.getType());
         assertEquals("test-bucket-name/folder1/folder2/file.txt", resource.getUrl());
         assertEquals("buckets/location/files/folder1/folder2/file.txt", resource.getAbsoluteFilePath());
-        assertEquals("folder1/folder2/file.txt", resource.getRelativePath());
+        assertEquals("folder1/folder2/file.txt", resource.getOriginalPath());
         assertFalse(resource.isFolder());
         assertEquals("folder1/folder2", resource.getParentPath());
         assertIterableEquals(List.of("folder1", "folder2"), resource.getParentFolders());
@@ -138,5 +138,13 @@ public class ResourceDescriptionTest {
                 ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "/"),
                 ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "   ")
         );
+    }
+
+    @Test
+    public void testResourceWithInvalidFilename() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "folde%2F/"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ResourceDescription.from(ResourceType.FILE, "bucket", "location/", "folder1/file%2F.txt"));
     }
 }

--- a/src/test/java/com/epam/aidial/core/util/UrlUtilTest.java
+++ b/src/test/java/com/epam/aidial/core/util/UrlUtilTest.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.util;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UrlUtilTest {
 
@@ -10,6 +11,7 @@ public class UrlUtilTest {
     public void testPathEncoding() {
         assertEquals("folder%201", UrlUtil.encodePath("folder 1"));
         assertEquals("folder%20%23", UrlUtil.encodePath("folder #"));
+        assertEquals("%D1%84%D0%B0%D0%B9%D0%BB.txt", UrlUtil.encodePath("файл.txt"));
         assertEquals("fo$l+=d,e%23r%201", UrlUtil.encodePath("fo$l+=d,e#r 1"));
     }
 
@@ -19,5 +21,8 @@ public class UrlUtilTest {
         assertEquals("folder #", UrlUtil.decodePath("folder%20%23"));
         assertEquals("fo$l+=d,e#r 1", UrlUtil.decodePath("fo$l+=d,e%23r%201"));
         assertEquals("fo$l+=d,e#r 1", UrlUtil.decodePath("fo%24l%2B%3Dd%2Ce%23r%201"));
+        assertEquals("файл.txt", UrlUtil.decodePath("%D1%84%D0%B0%D0%B9%D0%BB.txt"));
+        assertThrows(IllegalArgumentException.class, () -> UrlUtil.decodePath("/folder1/file#5.txt"));
+        assertThrows(IllegalArgumentException.class, () -> UrlUtil.decodePath("/folder1/q?file=5.txt"));
     }
 }

--- a/src/test/java/com/epam/aidial/core/util/UrlUtilTest.java
+++ b/src/test/java/com/epam/aidial/core/util/UrlUtilTest.java
@@ -1,0 +1,23 @@
+package com.epam.aidial.core.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UrlUtilTest {
+
+    @Test
+    public void testPathEncoding() {
+        assertEquals("folder%201", UrlUtil.encodePath("folder 1"));
+        assertEquals("folder%20%23", UrlUtil.encodePath("folder #"));
+        assertEquals("fo$l+=d,e%23r%201", UrlUtil.encodePath("fo$l+=d,e#r 1"));
+    }
+
+    @Test
+    public void testPathDecoding() {
+        assertEquals("folder 1", UrlUtil.decodePath("folder%201"));
+        assertEquals("folder #", UrlUtil.decodePath("folder%20%23"));
+        assertEquals("fo$l+=d,e#r 1", UrlUtil.decodePath("fo$l+=d,e%23r%201"));
+        assertEquals("fo$l+=d,e#r 1", UrlUtil.decodePath("fo%24l%2B%3Dd%2Ce%23r%201"));
+    }
+}


### PR DESCRIPTION
1. Core should urldecode path segments, not the full path (as https://github.com/epam/ai-dial-core/blob/development/src/main/java/com/epam/aidial/core/controller/ControllerSelector.java#L47C1-L47C1)
2. url in the metadata should be correct url. No extra encoding or decoding is required to access it.
3. name and parentPath in metadata a NOT parts on the url. They should be encoded when building url (as per URL RFC).
4. Symbol / is reserved as a path segments separator and not allowed in file names and directory names. Requests with / in a file name or directory name will be 400 Bad request. Following requests will end up with 400:
PUT v1/files/a/b/c%2Fd
GET v1/files/a/b/c%2Fd
GET v1/files/metadata/a/b/c%2Fd