### PR TITLE
chore: disable OTEL exporters by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
 ENV AIDIAL_SETTINGS=/app/config/aidial.settings.json
 ENV JAVA_OPTS="-Dgflog.config=/app/config/gflog.xml"
+ENV OTEL_TRACES_EXPORTER="none"
+ENV OTEL_METRICS_EXPORTER="none"
+ENV OTEL_LOGS_EXPORTER="none"
+
 WORKDIR /app
 
 RUN adduser -u 1001 --disabled-password --gecos "" appuser


### PR DESCRIPTION
Disable OTEL exporters for logs, metrics, and traces by default.

Thus, avoid errors in logs:
```log
Jan 25, 2024 2:44:39 PM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
SEVERE: Failed to export metrics. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
```

https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/

To enable it, pass (examples, to be adjusted before usage):
- `OTEL_TRACES_EXPORTER="otlp"` + `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/traces"` to enable traces
- `OTEL_METRICS_EXPORTER="otlp"` + `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://localhost:4318/v1/metrics"` to enable metrics
- `OTEL_LOGS_EXPORTER="otlp"` + `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://localhost:4318/v1/logs"` to enable logs