### PR TITLE
fix: Core accumulates a huge number of http server metrics #308

### DIFF
--- a/src/main/resources/aidial.settings.json
+++ b/src/main/resources/aidial.settings.json
@@ -3,6 +3,7 @@
     "workerPoolSize": 32,
     "metricsOptions": {
       "enabled": true,
+      "disabledMetricsCategories": ["http.server"],
       "jvmMetricsEnabled": true,
       "labels": [
         "HTTP_METHOD",


### PR DESCRIPTION
Disable http server metrics since they don't have any practical use for issue investigation and monitoring.
At the same time they are accumulated and never be released by micrometer library.