### PR TITLE
fix: Allow to attach unescaped links to a chat #481

### DIFF
--- a/src/main/java/com/epam/aidial/core/function/BaseFunction.java
+++ b/src/main/java/com/epam/aidial/core/function/BaseFunction.java
@@ -4,9 +4,9 @@ import com.epam.aidial.core.Proxy;
 import com.epam.aidial.core.ProxyContext;
 import com.epam.aidial.core.security.EncryptionService;
 import com.epam.aidial.core.storage.ResourceDescription;
+import com.epam.aidial.core.util.UrlUtil;
 import lombok.SneakyThrows;
 
-import java.net.URI;
 import java.util.function.Function;
 
 public abstract class BaseFunction<T, R> implements Function<T, R> {
@@ -20,14 +20,11 @@ public abstract class BaseFunction<T, R> implements Function<T, R> {
 
     @SneakyThrows
     public static ResourceDescription fromAnyUrl(String url, EncryptionService encryption) {
-        if (url == null) {
+        if (url == null || UrlUtil.isAbsoluteUrl(url)) {
+            // second check to skip public resource
             return null;
         }
-        URI uri = new URI(url);
-        if (uri.isAbsolute()) {
-            // skip public resource
-            return null;
-        }
+
         return ResourceDescription.fromAnyUrl(url, encryption);
     }
 }

--- a/src/main/java/com/epam/aidial/core/util/UrlUtil.java
+++ b/src/main/java/com/epam/aidial/core/util/UrlUtil.java
@@ -9,12 +9,18 @@ import org.apache.commons.codec.net.PercentCodec;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.regex.Pattern;
 
 @UtilityClass
 public class UrlUtil {
 
     private static final PercentCodec DECODER = new PercentCodec();
     private static final Escaper ENCODER = UrlEscapers.urlPathSegmentEscaper();
+
+    /**
+     * Universal, non case-sensitive, protocol-agnostic URL pattern
+     */
+    private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^(?:[a-z+]+:)?//", Pattern.CASE_INSENSITIVE);
 
     @SneakyThrows
     public String encodePath(String path) {
@@ -38,5 +44,9 @@ public class UrlUtil {
             }
         }
         return new String(DECODER.decode(path.getBytes(Charset.defaultCharset())));
+    }
+
+    public boolean isAbsoluteUrl(String url) {
+        return ABSOLUTE_URL_PATTERN.matcher(url).matches();
     }
 }

--- a/src/main/java/com/epam/aidial/core/util/UrlUtil.java
+++ b/src/main/java/com/epam/aidial/core/util/UrlUtil.java
@@ -20,7 +20,7 @@ public class UrlUtil {
     /**
      * Universal, non case-sensitive, protocol-agnostic URL pattern
      */
-    private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^(?:[a-z][a-z0-9-+.]*:)?//", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^[a-z][a-z0-9-+.]*?://", Pattern.CASE_INSENSITIVE);
 
     @SneakyThrows
     public String encodePath(String path) {

--- a/src/main/java/com/epam/aidial/core/util/UrlUtil.java
+++ b/src/main/java/com/epam/aidial/core/util/UrlUtil.java
@@ -20,7 +20,7 @@ public class UrlUtil {
     /**
      * Universal, non case-sensitive, protocol-agnostic URL pattern
      */
-    private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^(?:[a-z+]+:)?//", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^(?:[a-z][a-z0-9-+.]*:)?//", Pattern.CASE_INSENSITIVE);
 
     @SneakyThrows
     public String encodePath(String path) {
@@ -47,6 +47,6 @@ public class UrlUtil {
     }
 
     public boolean isAbsoluteUrl(String url) {
-        return ABSOLUTE_URL_PATTERN.matcher(url).matches();
+        return ABSOLUTE_URL_PATTERN.matcher(url).find();
     }
 }

--- a/src/test/java/com/epam/aidial/core/util/UrlUtilTest.java
+++ b/src/test/java/com/epam/aidial/core/util/UrlUtilTest.java
@@ -3,7 +3,9 @@ package com.epam.aidial.core.util;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UrlUtilTest {
 
@@ -28,5 +30,17 @@ public class UrlUtilTest {
         assertEquals("echo:1", UrlUtil.decodePath("echo:1"));
         assertThrows(IllegalArgumentException.class, () -> UrlUtil.decodePath("/folder1/file#5.txt"));
         assertThrows(IllegalArgumentException.class, () -> UrlUtil.decodePath("/folder1/q?file=5.txt"));
+    }
+
+    @Test
+    public void testIsAbsoluteUrl() {
+        assertTrue(UrlUtil.isAbsoluteUrl("test://example.com"));
+        assertTrue(UrlUtil.isAbsoluteUrl("TEST://EXAMPLE.COM"));
+        assertTrue(UrlUtil.isAbsoluteUrl("test1+test2://example.com/item"));
+        assertTrue(UrlUtil.isAbsoluteUrl("test1.test2://example.com/item"));
+        assertTrue(UrlUtil.isAbsoluteUrl("test1-test2://example.com/item"));
+        assertFalse(UrlUtil.isAbsoluteUrl("//example.com/item"));
+        assertFalse(UrlUtil.isAbsoluteUrl("/example/file.txt"));
+        assertFalse(UrlUtil.isAbsoluteUrl("file"));
     }
 }


### PR DESCRIPTION
Issue: #481 