### PR TITLE
feat: allowed routes to rewrite path and protect by roles

### DIFF
--- a/src/main/java/com/epam/aidial/core/ProxyContext.java
+++ b/src/main/java/com/epam/aidial/core/ProxyContext.java
@@ -67,6 +67,7 @@ public class ProxyContext {
     private List<String> userRoles;
     private String userHash;
     private TokenUsage tokenUsage;
+    private boolean rewritePath;
     private UpstreamRoute upstreamRoute;
     private HttpClientRequest proxyRequest;
     private Map<String, String> requestHeaders = Map.of();

--- a/src/main/java/com/epam/aidial/core/config/Route.java
+++ b/src/main/java/com/epam/aidial/core/config/Route.java
@@ -13,9 +13,11 @@ public class Route {
 
     private String name;
     private Response response;
+    private boolean rewritePath;
     private List<Pattern> paths = List.of();
     private Set<HttpMethod> methods = Set.of();
     private List<Upstream> upstreams = List.of();
+    private Set<String> userRoles = Set.of();
 
     @Data
     public static class Response {

--- a/src/main/java/com/epam/aidial/core/controller/RouteController.java
+++ b/src/main/java/com/epam/aidial/core/controller/RouteController.java
@@ -23,8 +23,8 @@ import io.vertx.core.http.RequestOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.utils.URIBuilder;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -46,6 +46,12 @@ public class RouteController implements Controller {
             return Future.succeededFuture();
         }
 
+        if (!hasAccess(route)) {
+            log.error("Forbidden route {}. Key: {}. User sub: {}", route.getName(), context.getProject(), context.getUserSub());
+            context.respond(HttpStatus.FORBIDDEN, "Forbidden route");
+            return Future.succeededFuture();
+        }
+
         Route.Response response = route.getResponse();
         if (response == null) {
             UpstreamProvider upstreamProvider = new RouteEndpointProvider(route);
@@ -57,6 +63,7 @@ public class RouteController implements Controller {
                 return Future.succeededFuture();
             }
 
+            context.setRewritePath(route.isRewritePath());
             context.setUpstreamRoute(upstreamRoute);
         } else {
             context.getResponse().setStatusCode(response.getStatus());
@@ -87,7 +94,7 @@ public class RouteController implements Controller {
         Upstream upstream = route.get();
         Objects.requireNonNull(upstream);
         RequestOptions options = new RequestOptions()
-                .setAbsoluteURI(new URL(upstream.getEndpoint()))
+                .setAbsoluteURI(getEndpointUri(upstream))
                 .setMethod(request.method());
 
         return proxy.getClient().request(options)
@@ -240,5 +247,22 @@ public class RouteController implements Controller {
         }
 
         return null;
+    }
+
+    @SneakyThrows
+    private String getEndpointUri(Upstream upstream) {
+        URIBuilder uriBuilder = new URIBuilder(upstream.getEndpoint());
+        if (context.isRewritePath()) {
+            uriBuilder.setPath(context.getRequest().path());
+        }
+        return uriBuilder.toString();
+    }
+
+    private boolean hasAccess(Route route) {
+        Set<String> allowedRoles = route.getUserRoles();
+        List<String> actualRoles = context.getUserRoles();
+
+        return allowedRoles.isEmpty() || actualRoles.stream()
+                .anyMatch(allowedRoles::contains);
     }
 }

--- a/src/main/java/com/epam/aidial/core/controller/RouteController.java
+++ b/src/main/java/com/epam/aidial/core/controller/RouteController.java
@@ -47,7 +47,8 @@ public class RouteController implements Controller {
         }
 
         if (!hasAccess(route)) {
-            log.error("Forbidden route {}. Key: {}. User sub: {}", route.getName(), context.getProject(), context.getUserSub());
+            log.error("Forbidden route {}. Trace: {}. Span: {}. Key: {}. User sub: {}.",
+                    route.getName(), context.getTraceId(), context.getSpanId(), context.getProject(), context.getUserSub());
             context.respond(HttpStatus.FORBIDDEN, "Forbidden route");
             return Future.succeededFuture();
         }

--- a/src/test/java/com/epam/aidial/core/RouteApiTest.java
+++ b/src/test/java/com/epam/aidial/core/RouteApiTest.java
@@ -1,0 +1,47 @@
+package com.epam.aidial.core;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(VertxExtension.class)
+class RouteApiTest extends ResourceBaseTest {
+
+    @ParameterizedTest
+    @MethodSource("datasource")
+    void route(HttpMethod method, String path, String apiKey, int expectedStatus, String expectedResponse,
+               Vertx vertx, VertxTestContext context) {
+
+        var targetServer = vertx.createHttpServer()
+                .requestHandler(req -> req.response().end(req.path()));
+        targetServer.listen(9876)
+                .onComplete(context.succeedingThenComplete());
+
+        var reqBody = method == HttpMethod.POST ? UUID.randomUUID().toString() : null;
+        var resp = send(method, path, null, reqBody, "api-key", apiKey);
+
+        assertEquals(expectedStatus, resp.status());
+        assertEquals(expectedResponse, resp.body());
+    }
+
+    private static List<Arguments> datasource() {
+        return List.of(
+                Arguments.of(HttpMethod.GET, "/v1/plain", "vstore_user_key", 200, "/"),
+                Arguments.of(HttpMethod.GET, "/v1/plain", "vstore_admin_key", 200, "/"),
+                Arguments.of(HttpMethod.GET, "/v1/vector_store/1", "vstore_user_key", 200, "/v1/vector_store/1"),
+                Arguments.of(HttpMethod.GET, "/v1/vector_store/1", "vstore_admin_key", 200, "/v1/vector_store/1"),
+                Arguments.of(HttpMethod.POST, "/v1/vector_store/1", "vstore_user_key", 403, "Forbidden route"),
+                Arguments.of(HttpMethod.POST, "/v1/vector_store/1", "vstore_admin_key", 200, "/v1/vector_store/1")
+        );
+    }
+}

--- a/src/test/resources/aidial.config.json
+++ b/src/test/resources/aidial.config.json
@@ -6,6 +6,25 @@
       "response" : {
         "status": 200
       }
+    },
+    "plain": {
+      "paths": ["/v1/plain"],
+      "methods": ["GET"],
+      "upstreams": [{"endpoint": "http://localhost:9876"}]
+    },
+    "vector_store_query": {
+      "paths": ["/v1/vector_store(/[^/]+)*$"],
+      "rewritePath": true,
+      "methods": ["GET"],
+      "userRoles": ["vstore_user", "vstore_admin"],
+      "upstreams": [{"endpoint": "http://localhost:9876"}]
+    },
+    "vector_store_mutation": {
+      "paths": ["/v1/vector_store(/[^/]+)*$"],
+      "rewritePath": true,
+      "methods": ["POST", "PUT", "DELETE"],
+      "userRoles": ["vstore_admin"],
+      "upstreams": [{"endpoint": "http://localhost:9876"}]
     }
   },
   "addons": {
@@ -101,6 +120,14 @@
     "proxyKey2": {
       "project": "EPM-RTC-RAIL",
       "role": "default"
+    },
+    "vstore_user_key": {
+      "project": "test",
+      "role": "vstore_user"
+    },
+    "vstore_admin_key": {
+      "project": "test",
+      "role": "vstore_admin"
     }
   },
   "roles": {


### PR DESCRIPTION
### Paths rewrite

The idea is to allow routes to rewrite the "initial path", so inside the configuration we would like to introduce a
marker (e.g. new boolean json field `rewritePath`) that specifies whether the "initial path" should be preserved and
used to redirect to the upstream endpoint.

The configuration file might look like

```json
{
  "routes": {
    "vector_store": {
      "paths": ["/v1/vector_stores(/[^/]+)*$"],
      "rewritePath": true,
      "methods": ["POST"],
      "upstream": [
        {
          "endpoint": "https://vstore-addr.domain"
        }
      ]
    }
  }
}
```

and the incoming requests
- `POST https://${DIAL_CORE_ADDR}/v1/vector_stores`
- `POST https://${DIAL_CORE_ADDR}/v1/vector_stores/1`

will be redirected to
- `POST https://vstore-addr.domain/v1/vector_stores`
- `POST https://vstore-addr.domain/v1/vector_stores/1`

accordingly.

### Access Control

To have a more flexible configuration in terms of access control of the routes, it could be useful to have a
list of roles (e.g. `userRoles`) that restricts the access to route, when the identity (either user or api-key) does
not belong to any of the roles listed in `userRoles`.

For example,
```json
{
  "routes": {
    "vector_store_query": {
      "paths": ["/v1/vector_stores(/[^/]+)*$"],
      "methods": ["GET"],
      "rewritePath": true,
      "userRoles": ["vstore_user", "vstore_admin"],
      "upstream": [
        {
          "endpoint": "https://vstore-addr.domain"
        }
      ]
    },
    "vector_store_mutation": {
      "paths": ["/v1/vector_stores(/[^/]+)*$"],
      "methods": ["POST", "PUT", "DELETE"],
      "rewritePath": true,
      "userRoles": ["vstore_admin"],
      "upstream": [
        {
          "endpoint": "https://vstore-addr.domain"
        }
      ]
    }
  }
}
```

So, the identities having `vstore_user` are able only read vector stores, while `vstore_admin` can read and modify
vector store entries.