### PR TITLE
fix: ORT fails with 'No locally installed toolchains match and toolchain download repositories have not been configured.'

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
+apply plugin: 'org.gradle.toolchains.foojay-resolver-convention'
+
 rootProject.name = "aidial-core"
 include 'config'
 include 'server'


### PR DESCRIPTION
See the failed ORT [scan](https://github.com/epam/ai-dial-core/actions/runs/12050930503/job/33600846981?pr=592#step:3:1224)