### PR TITLE
feat: Add customViewState field to conversation api

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/Conversation.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/Conversation.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Data
@@ -32,6 +33,7 @@ public class Conversation {
     ModelId model;
     Set<String> selectedAddons;
     List<Message> messages;
+    Map<String, Object> customViewState;
 
     @JsonCreator
     public Conversation(@JsonProperty(value = "id", required = true) String id,
@@ -42,7 +44,8 @@ public class Conversation {
                         @JsonProperty(value = "lastActivityDate", required = true) long lastActivityDate,
                         @JsonProperty(value = "model", required = true) ModelId model,
                         @JsonProperty(value = "selectedAddons", required = true) Set<String> selectedAddons,
-                        @JsonProperty(value = "messages", required = true) List<Message> messages) {
+                        @JsonProperty(value = "messages", required = true) List<Message> messages,
+                        @JsonProperty(value = "customViewState") Map<String, Object> customViewState) {
         this.id = id;
         this.folderId = folderId;
         this.name = name;
@@ -52,6 +55,7 @@ public class Conversation {
         this.model = model;
         this.selectedAddons = selectedAddons;
         this.messages = messages;
+        this.customViewState = customViewState;
     }
 
     @Data

--- a/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
@@ -462,7 +462,7 @@ public class ProxyUtilTest {
     }
 
     @Test
-    public void customViewStateValidation() {
+    public void testCustomViewStateValidation() {
         String validConversationJson = """
             {
             "id": "conversation_id",

--- a/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
@@ -464,46 +464,46 @@ public class ProxyUtilTest {
     @Test
     public void testCustomViewStateValidation() {
         String validConversationJson = """
-            {
-            "id": "conversation_id",
-            "name": "display_name",
-            "model": {
-              "id": "model_id"
-              },
-            "prompt": "system prompt",
-            "temperature": 1,
-            "folderId": "folder1",
-            "messages": [
-              {
-              "role": "user",
-              "content": "content",
-              "custom_content": {"attachment_url": "some_url"},
-              "model": {"id": "model_id"},
-              "settings":
                 {
-                "prompt": "sysPrompt",
-                "temperature": 5,
-                "selectedAddons": ["A", "B", "C"],
-                "assistantModelId": "assistantId"
+                "id": "conversation_id",
+                "name": "display_name",
+                "model": {
+                  "id": "model_id"
+                  },
+                "prompt": "system prompt",
+                "temperature": 1,
+                "folderId": "folder1",
+                "messages": [
+                  {
+                  "role": "user",
+                  "content": "content",
+                  "custom_content": {"attachment_url": "some_url"},
+                  "model": {"id": "model_id"},
+                  "settings":
+                    {
+                    "prompt": "sysPrompt",
+                    "temperature": 5,
+                    "selectedAddons": ["A", "B", "C"],
+                    "assistantModelId": "assistantId"
+                    }
+                  }
+                ],
+                "replay": {
+                  "isReplay": true,
+                  "replayUserMessagesStack": [],
+                  "activeReplayIndex": 0
+                  },
+                "selectedAddons": ["R", "T", "G"],
+                "assistantModelId": "assistantId",
+                "lastActivityDate": 4848683153,
+                "customViewState": {
+                    "a": ["A"],
+                    "b": {
+                        "c": ["C"],
+                        "d": 5.12
+                    }
                 }
-              }
-            ],
-            "replay": {
-              "isReplay": true,
-              "replayUserMessagesStack": [],
-              "activeReplayIndex": 0
-              },
-            "selectedAddons": ["R", "T", "G"],
-            "assistantModelId": "assistantId",
-            "lastActivityDate": 4848683153,
-            "customViewState": {
-                "a": ["A"],
-                "b": {
-                    "c": ["C"],
-                    "d": 5.12
                 }
-            }
-            }
             """;
 
         assertDoesNotThrow(() -> ProxyUtil.convertToObject(validConversationJson, Conversation.class));

--- a/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
@@ -504,7 +504,7 @@ public class ProxyUtilTest {
                     }
                 }
                 }
-            """;
+                """;
 
         assertDoesNotThrow(() -> ProxyUtil.convertToObject(validConversationJson, Conversation.class));
     }

--- a/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ProxyUtilTest.java
@@ -461,4 +461,51 @@ public class ProxyUtilTest {
 
     }
 
+    @Test
+    public void customViewStateValidation() {
+        String validConversationJson = """
+            {
+            "id": "conversation_id",
+            "name": "display_name",
+            "model": {
+              "id": "model_id"
+              },
+            "prompt": "system prompt",
+            "temperature": 1,
+            "folderId": "folder1",
+            "messages": [
+              {
+              "role": "user",
+              "content": "content",
+              "custom_content": {"attachment_url": "some_url"},
+              "model": {"id": "model_id"},
+              "settings":
+                {
+                "prompt": "sysPrompt",
+                "temperature": 5,
+                "selectedAddons": ["A", "B", "C"],
+                "assistantModelId": "assistantId"
+                }
+              }
+            ],
+            "replay": {
+              "isReplay": true,
+              "replayUserMessagesStack": [],
+              "activeReplayIndex": 0
+              },
+            "selectedAddons": ["R", "T", "G"],
+            "assistantModelId": "assistantId",
+            "lastActivityDate": 4848683153,
+            "customViewState": {
+                "a": ["A"],
+                "b": {
+                    "c": ["C"],
+                    "d": 5.12
+                }
+            }
+            }
+            """;
+
+        assertDoesNotThrow(() -> ProxyUtil.convertToObject(validConversationJson, Conversation.class));
+    }
 }


### PR DESCRIPTION
We need a field with an arbitrary structure to save state of the custom conversation views.