### PR TITLE
fix: execution path must contain deployment's name only

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/ApiKeyData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ApiKeyData.java
@@ -72,7 +72,6 @@ public class ApiKeyData {
             proxyApiKeyData.setExtractedClaims(context.getExtractedClaims());
             proxyApiKeyData.setTraceId(context.getTraceId());
             currentPath = new ArrayList<>();
-            currentPath.add(context.getProject() == null ? context.getUserHash() : context.getProject());
         } else {
             proxyApiKeyData.setOriginalKey(apiKeyData.getOriginalKey());
             proxyApiKeyData.setExtractedClaims(apiKeyData.getExtractedClaims());


### PR DESCRIPTION
At the moment the first element of execution path is always either user hash or project name.

Execution path must contain deployment's names only.