### PR TITLE
chore: Fix naming of a field to transfer server-side application properties

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -15,7 +15,7 @@ import com.epam.aidial.core.server.function.BaseRequestFunction;
 import com.epam.aidial.core.server.function.CollectRequestAttachmentsFn;
 import com.epam.aidial.core.server.function.CollectRequestDataFn;
 import com.epam.aidial.core.server.function.CollectResponseAttachmentsFn;
-import com.epam.aidial.core.server.function.enhancement.AppendCustomApplicationPropertiesFn;
+import com.epam.aidial.core.server.function.enhancement.AppendApplicationPropertiesFn;
 import com.epam.aidial.core.server.function.enhancement.ApplyDefaultDeploymentSettingsFn;
 import com.epam.aidial.core.server.function.enhancement.EnhanceAssistantRequestFn;
 import com.epam.aidial.core.server.function.enhancement.EnhanceModelRequestFn;
@@ -73,7 +73,7 @@ public class DeploymentPostController {
                 new ApplyDefaultDeploymentSettingsFn(proxy, context),
                 new EnhanceAssistantRequestFn(proxy, context),
                 new EnhanceModelRequestFn(proxy, context),
-                new AppendCustomApplicationPropertiesFn(proxy, context));
+                new AppendApplicationPropertiesFn(proxy, context));
     }
 
     public Future<?> handle(String deploymentId, String deploymentApi) {

--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/AppendApplicationPropertiesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/AppendApplicationPropertiesFn.java
@@ -7,14 +7,15 @@ import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.function.BaseRequestFunction;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 
 @Slf4j
-public class AppendCustomApplicationPropertiesFn extends BaseRequestFunction<ObjectNode> {
-    public AppendCustomApplicationPropertiesFn(Proxy proxy, ProxyContext context) {
+public class AppendApplicationPropertiesFn extends BaseRequestFunction<ObjectNode> {
+    public AppendApplicationPropertiesFn(Proxy proxy, ProxyContext context) {
         super(proxy, context);
     }
 
@@ -25,11 +26,14 @@ public class AppendCustomApplicationPropertiesFn extends BaseRequestFunction<Obj
             return false;
         }
         Map<String, Object> props = ApplicationTypeSchemaUtils.getCustomServerProperties(context.getConfig(), application);
-        ObjectNode customAppPropertiesNode = ProxyUtil.MAPPER.createObjectNode();
-        for (Map.Entry<String, Object> entry : props.entrySet()) {
-            customAppPropertiesNode.putPOJO(entry.getKey(), entry.getValue());
+        ObjectNode customFieldsNode = ProxyUtil.MAPPER.createObjectNode();
+        customFieldsNode.set("application_properties", ProxyUtil.MAPPER.valueToTree(props));
+        JsonNode currentCustomFields = tree.get("custom_fields");
+        if (currentCustomFields != null) {
+            ((ObjectNode) currentCustomFields).setAll(customFieldsNode);
+        } else {
+            tree.set("custom_fields", customFieldsNode);
         }
-        tree.set("custom_application_properties", customAppPropertiesNode);
         return true;
     }
 }


### PR DESCRIPTION
Changes requested by @adubovik to reflect the unified protocol fashion of transferring data unrelated to openai protocol (our own field).
server-side properties of the applications moved from "custom_application_properties" to "custom_fields"."application_properties"
if any custom_fields arrive, the application_properties field will be appended to it (append while proxying).

https://github.com/epam/ai-dial-sdk/pull/206