### PR TITLE
chore: properties grouped to container field for applications with type schema

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Application.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Application.java
@@ -1,9 +1,6 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -25,21 +22,11 @@ public class Application extends Deployment {
 
     private Function function;
 
-    @JsonIgnore
-    private Map<String, Object> customProperties = new HashMap<>(); //all custom application properties will land there
+    @JsonAlias({"applicationProperties", "application_properties"})
+    private Map<String, Object> applicationProperties; //all custom application properties will land there
 
-    @JsonAnySetter
-    public void setCustomProperty(String key, Object value) { //all custom application properties will land there
-        customProperties.put(key, value);
-    }
-
-    @JsonAnyGetter
-    public  Map<String, Object> getCustomProperties() {
-        return customProperties;
-    }
-
-    @JsonAlias({"customAppSchemaId", "custom_app_schema_id"})
-    private URI customAppSchemaId;
+    @JsonAlias({"applicationTypeSchemaId", "application_type_schema_id"})
+    private URI applicationTypeSchemaId;
 
     @Data
     @Accessors(chain = true)
@@ -135,7 +122,7 @@ public class Application extends Deployment {
         this.setInterceptors(source.getInterceptors());
         this.setDescriptionKeywords(source.getDescriptionKeywords());
         this.setFunction(source.getFunction());
-        this.setCustomProperties(source.getCustomProperties());
-        this.setCustomAppSchemaId(source.getCustomAppSchemaId());
+        this.setApplicationProperties(source.getApplicationProperties());
+        this.setApplicationTypeSchemaId(source.getApplicationTypeSchemaId());
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidator.java
+++ b/config/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidator.java
@@ -42,13 +42,16 @@ public class CustomApplicationsConformToTypeSchemasValidator implements Constrai
         ObjectMapper mapper = new ObjectMapper();
         for (Map.Entry<String, Application> entry : value.getApplications().entrySet()) {
             Application application = entry.getValue();
-            URI schemaId = application.getCustomAppSchemaId();
+            URI schemaId = application.getApplicationTypeSchemaId();
             if (schemaId == null) {
                 continue;
             }
 
             JsonSchema schema = schemaFactory.getSchema(schemaId);
-            JsonNode applicationNode = mapper.valueToTree(application);
+            if (application.getApplicationProperties() == null) {
+                continue;
+            }
+            JsonNode applicationNode = mapper.valueToTree(application.getApplicationProperties());
             Set<ValidationMessage> validationResults = schema.validate(applicationNode);
             if (!validationResults.isEmpty()) {
                 String logMessage = validationResults.stream()

--- a/config/src/test/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidatorTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidatorTest.java
@@ -58,10 +58,43 @@ class CustomApplicationsConformToTypeSchemasValidatorTest {
     }
 
     @Test
+    void isValidReturnsTrueWhenApplicationHasNullProps() {
+        Map<String, Application> applications = new HashMap<>();
+        Application application = new Application();
+        application.setApplicationTypeSchemaId(URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type"));
+        applications.put("app1", application);
+        config.setApplications(applications);
+        Map<String, String> schemas = new HashMap<>();
+        String customSchemaStr = "{"
+                                 + "\"$schema\": \"https://dial.epam.com/application_type_schemas/schema#\","
+                                 + "\"$id\": \"https://mydial.epam.com/custom_application_schemas/specific_application_type\","
+                                 + "\"dial:applicationTypeEditorUrl\": \"https://mydial.epam.com/specific_application_type_editor\","
+                                 + "\"dial:applicationTypeDisplayName\": \"Specific Application Type\","
+                                 + "\"dial:applicationTypeCompletionEndpoint\": \"http://specific_application_service/opeani/v1/completion\","
+                                 + "\"properties\": {"
+                                 + "  \"file\": {"
+                                 + "    \"type\": \"string\","
+                                 + "    \"format\": \"dial-file-encoded\","
+                                 + "    \"dial:meta\": {"
+                                 + "      \"dial:propertyKind\": \"client\","
+                                 + "      \"dial:propertyOrder\": 1"
+                                 + "    }"
+                                 + "  }"
+                                 + "},"
+                                 + "\"required\": [\"file\"]"
+                                 + "}";
+        schemas.put("https://mydial.epam.com/custom_application_schemas/specific_application_type", customSchemaStr);
+        config.setApplicationTypeSchemas(schemas);
+
+        assertTrue(validator.isValid(config, context));
+    }
+
+    @Test
     void isValidReturnsFalseWhenSchemaValidationFails() {
         Map<String, Application> applications = new HashMap<>();
         Application application = new Application();
         application.setApplicationTypeSchemaId(URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type"));
+        application.setApplicationProperties(Map.of());
         applications.put("app1", application);
         config.setApplications(applications);
         Map<String, String> schemas = new HashMap<>();

--- a/config/src/test/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidatorTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidatorTest.java
@@ -61,7 +61,7 @@ class CustomApplicationsConformToTypeSchemasValidatorTest {
     void isValidReturnsFalseWhenSchemaValidationFails() {
         Map<String, Application> applications = new HashMap<>();
         Application application = new Application();
-        application.setCustomAppSchemaId(URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type"));
+        application.setApplicationTypeSchemaId(URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type"));
         applications.put("app1", application);
         config.setApplications(applications);
         Map<String, String> schemas = new HashMap<>();
@@ -93,10 +93,10 @@ class CustomApplicationsConformToTypeSchemasValidatorTest {
     void isValidReturnsTrueWhenSchemaValidationPasses() {
         Map<String, Application> applications = new HashMap<>();
         Application application = new Application();
-        application.setCustomAppSchemaId(URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type"));
+        application.setApplicationTypeSchemaId(URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type"));
         Map<String, Object> props = new HashMap<>();
         props.put("file", "files/bucket/path/name.ext");
-        application.setCustomProperties(props);
+        application.setApplicationProperties(props);
         applications.put("app1", application);
         config.setApplications(applications);
         Map<String, String> schemas = new HashMap<>();

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationUtil.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationUtil.java
@@ -25,8 +25,8 @@ public class ApplicationUtil {
         data.setDefaults(application.getDefaults());
         data.setDescriptionKeywords(application.getDescriptionKeywords());
 
-        data.setCustomAppSchemaId(application.getCustomAppSchemaId());
-        data.setCustomProperties(application.getCustomProperties());
+        data.setApplicationTypeSchemaId(application.getApplicationTypeSchemaId());
+        data.setApplicationProperties(application.getApplicationProperties());
         String reference = application.getReference();
         data.setReference(reference == null ? application.getName() : reference);
         data.setFunction(application.getFunction());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -77,7 +77,7 @@ public class DeploymentController {
                             return Future.succeededFuture(deployment);
                         }
                         return proxy.getVertx().executeBlocking(() -> {
-                            if (application.getCustomAppSchemaId() == null) {
+                            if (application.getApplicationTypeSchemaId() == null) {
                                 return application;
                             }
                             Application modifiedApp = application;
@@ -118,7 +118,7 @@ public class DeploymentController {
 
             Application app = proxy.getApplicationService().getApplication(resource).getValue();
 
-            if (app.getCustomAppSchemaId() != null) {
+            if (app.getApplicationTypeSchemaId() != null) {
                 if (filterCustomProperties) {
                     app = ApplicationTypeSchemaUtils.filterCustomClientPropertiesWhenNoWriteAccess(context, resource, app);
                 }

--- a/server/src/main/java/com/epam/aidial/core/server/data/ApplicationData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ApplicationData.java
@@ -2,9 +2,6 @@ package com.epam.aidial.core.server.data;
 
 import com.epam.aidial.core.config.Application;
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -12,7 +9,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -26,22 +22,12 @@ public class ApplicationData extends DeploymentData {
         setScaleSettings(null);
     }
 
-    @JsonIgnore
-    private Map<String, Object> customProperties = new HashMap<>(); //all custom application properties will land there
-
-    @JsonAnySetter
-    public void setCustomProperty(String key, Object value) { //all custom application properties will land there
-        customProperties.put(key, value);
-    }
-
-    @JsonAnyGetter
-    public  Map<String, Object> getCustomProperty() {
-        return customProperties;
-    }
+    @Nullable
+    private Map<String, Object> applicationProperties; //all custom application properties will land there
 
     @Nullable
-    @JsonAlias({"customAppSchemaId", "custom_app_schema_id"})
-    private URI customAppSchemaId;
+    @JsonAlias({"applicationTypeSchemaId", "application_type_schema_id"})
+    private URI applicationTypeSchemaId;
 
     private Application.Function function;
 }

--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/AppendApplicationPropertiesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/AppendApplicationPropertiesFn.java
@@ -22,7 +22,7 @@ public class AppendApplicationPropertiesFn extends BaseRequestFunction<ObjectNod
     @Override
     public Boolean apply(ObjectNode tree) {
         Deployment deployment = context.getDeployment();
-        if (!(deployment instanceof Application application && application.getCustomAppSchemaId() != null)) {
+        if (!(deployment instanceof Application application && application.getApplicationTypeSchemaId() != null)) {
             return false;
         }
         Map<String, Object> props = ApplicationTypeSchemaUtils.getCustomServerProperties(context.getConfig(), application);

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
@@ -26,7 +26,6 @@ import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
 import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -220,6 +219,11 @@ public class ApplicationService {
         ResourceItemMetadata meta = resourceService.computeResource(resource, etag, json -> {
             Application existing = ProxyUtil.convertToObject(json, Application.class);
             Application.Function function = application.getFunction();
+
+            if (application.getApplicationTypeSchemaId() != null && existing != null
+                    && existing.getApplicationProperties() != null && application.getApplicationProperties() == null) {
+                throw new HttpException(HttpStatus.BAD_REQUEST, "The application with schema can not be updated to the one without properties");
+            }
 
             if (function != null) {
                 if (existing == null || existing.getFunction() == null) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
@@ -421,7 +421,7 @@ public class ApplicationService {
     private void prepareApplication(ResourceDescriptor resource, Application application) {
         verifyApplication(resource);
 
-        if (application.getCustomAppSchemaId() != null) {
+        if (application.getApplicationTypeSchemaId() != null) {
             if (application.getEndpoint() != null || application.getFunction() != null) {
                 throw new IllegalArgumentException("Endpoint must not be set for custom application");
             }

--- a/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
@@ -413,7 +413,7 @@ public class PublicationService {
                         return Stream.empty();
                     }
                     Application application = applicationService.getApplication(source).getValue();
-                    if (application.getCustomAppSchemaId() == null) {
+                    if (application.getApplicationTypeSchemaId() == null) {
                         return Stream.empty();
                     }
                     String targetFolder = buildTargetFolderForCustomAppFiles(resource);

--- a/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
@@ -126,6 +126,9 @@ public class ApplicationTypeSchemaUtils {
         if (customApplicationSchema == null) {
             return application;
         }
+        if (application.getApplicationProperties() == null) {
+            return application;
+        }
         Application copy = new Application(application);
         Map<String, Object> appWithClientOptionsOnly = filterProperties(application.getApplicationProperties(), customApplicationSchema, "client");
         copy.setApplicationProperties(appWithClientOptionsOnly);

--- a/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
@@ -48,7 +48,7 @@ public class ApplicationTypeSchemaUtils {
             .build();
 
     static String getCustomApplicationSchemaOrThrow(Config config, Application application) {
-        URI schemaId = application.getCustomAppSchemaId();
+        URI schemaId = application.getApplicationTypeSchemaId();
         if (schemaId == null) {
             return null;
         }
@@ -91,7 +91,7 @@ public class ApplicationTypeSchemaUtils {
         if (customApplicationSchema == null) {
             return Collections.emptyMap();
         }
-        return filterProperties(application.getCustomProperties(), customApplicationSchema, "server");
+        return filterProperties(application.getApplicationProperties(), customApplicationSchema, "server");
     }
 
     public static String getCustomApplicationEndpoint(Config config, Application application) {
@@ -124,8 +124,8 @@ public class ApplicationTypeSchemaUtils {
             return application;
         }
         Application copy = new Application(application);
-        Map<String, Object> appWithClientOptionsOnly = filterProperties(application.getCustomProperties(), customApplicationSchema, "client");
-        copy.setCustomProperties(appWithClientOptionsOnly);
+        Map<String, Object> appWithClientOptionsOnly = filterProperties(application.getApplicationProperties(), customApplicationSchema, "client");
+        copy.setApplicationProperties(appWithClientOptionsOnly);
         return copy;
     }
 
@@ -137,15 +137,15 @@ public class ApplicationTypeSchemaUtils {
     }
 
     public static void replaceCustomAppFiles(Application application, Map<String, String> replacementLinks) {
-        if (application.getCustomAppSchemaId() == null) {
+        if (application.getApplicationTypeSchemaId() == null) {
             return;
         }
-        JsonNode customProperties = ProxyUtil.MAPPER.convertValue(application.getCustomProperties(), JsonNode.class);
+        JsonNode customProperties = ProxyUtil.MAPPER.convertValue(application.getApplicationProperties(), JsonNode.class);
         replaceLinksInJsonNode(customProperties, replacementLinks, null, null);
         Map<String, Object> customPropertiesMap = ProxyUtil.MAPPER.convertValue(customProperties, new TypeReference<>() {
         });
 
-        application.setCustomProperties(customPropertiesMap);
+        application.setApplicationProperties(customPropertiesMap);
     }
 
     @SuppressWarnings("unchecked")
@@ -157,7 +157,7 @@ public class ApplicationTypeSchemaUtils {
             }
             JsonSchema appSchema = SCHEMA_FACTORY.getSchema(customApplicationSchema);
             CollectorContext collectorContext = new CollectorContext();
-            String customPropsJson = ProxyUtil.MAPPER.writeValueAsString(application.getCustomProperties());
+            String customPropsJson = ProxyUtil.MAPPER.writeValueAsString(application.getApplicationProperties());
             Set<ValidationMessage> validationResult = appSchema.validate(customPropsJson, InputFormat.JSON,
                     e -> e.setCollectorContext(collectorContext));
             if (!validationResult.isEmpty()) {

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -979,13 +979,15 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
         response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file1.txt",
-                            "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file2.txt"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file1.txt",
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file2.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],
@@ -1009,10 +1011,12 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                   "interceptors" : [ ],
                   "description_keywords" : [ ],
                   "max_retry_attempts" : 1,
-                  "custom_app_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                  "property2" : "test property2",
-                  "property1" : "test property1",
-                  "property3" : [ "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file1.txt", "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file2.txt" ]
+                  "application_properties" : {
+                    "property1" : "test property1",
+                    "property2" : "test property2",
+                    "property3" : [ "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file1.txt", "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file2.txt" ]
+                  },
+                  "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type"
                 }
                 """);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -1020,4 +1020,116 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                 }
                 """);
     }
+
+    @Test
+    void testApplicationWithTypeSchemaCreationAndThenGet_NoApplicationPropertiesGet_WhenNoApplicationPropertiesCreated() {
+
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        response = send(HttpMethod.GET, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, "");
+        verifyJsonNotExact(response, 200, """
+                {
+                  "name" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files",
+                  "display_name" : "test_app",
+                  "icon_url" : "https://mydial.somewhere.com/app-icon.svg",
+                  "description" : "My application description",
+                  "reference": "@ignore",
+                  "forward_auth_token" : false,
+                  "defaults" : { },
+                  "interceptors" : [ ],
+                  "description_keywords" : [ ],
+                  "max_retry_attempts" : 1,
+                  "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type"
+                }
+                """);
+    }
+
+    @Test
+    void testApplicationWithTypeSchemaCreationAndThenUpdate_Fails_WhenApplicationPropertiesCreatedAndThenFreed() {
+
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "application_properties" : {
+                        "property1" : "test property1",
+                        "property2" : "test property2"
+                       },
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(400, response.status());
+    }
+
+    @Test
+    void testApplicationWithTypeSchemaCreationAndThenUpdate_Ok_WhenApplicationPropertiesCreatedAndThenUpdated() {
+
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "application_properties" : {
+                        "property1" : "test property1",
+                        "property2" : "test property2"
+                       },
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "application_properties" : {
+                        "property1" : "test property11",
+                        "property2" : "test property21"
+                       },
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+    }
+
 }

--- a/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
@@ -1541,13 +1541,15 @@ class PublicationApiTest extends ResourceBaseTest {
         response = send(HttpMethod.PUT, "/v1/applications/%s/test_app".formatted(bucket), null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/%s/test_file.txt",
-                            "files/%s/xyz/test_file.txt"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/%s/test_file.txt",
+                                "files/%s/xyz/test_file.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],

--- a/server/src/test/java/com/epam/aidial/core/server/ResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ResourceApiTest.java
@@ -387,12 +387,14 @@ class ResourceApiTest extends ResourceBaseTest {
         Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files_failed", null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/unexisting_folder/unexisting_file.txt"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/unexisting_folder/unexisting_file.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],
@@ -409,7 +411,8 @@ class ResourceApiTest extends ResourceBaseTest {
         Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_props_failed", null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "applicationProperties": {},
                        "userRoles": [
                             "Admin"
                        ],

--- a/server/src/test/java/com/epam/aidial/core/server/ResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ResourceApiTest.java
@@ -338,13 +338,15 @@ class ResourceApiTest extends ResourceBaseTest {
         response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file1.txt",
-                            "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file2.txt"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file1.txt",
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_file2.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],
@@ -361,12 +363,14 @@ class ResourceApiTest extends ResourceBaseTest {
         Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_folder", null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/xyz/"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/xyz/"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],

--- a/server/src/test/java/com/epam/aidial/core/server/ShareApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ShareApiTest.java
@@ -1662,14 +1662,16 @@ public class ShareApiTest extends ResourceBaseTest {
 
         response = send(HttpMethod.PUT, "/v1/applications/%s/test_app".formatted(bucket), null, """
                   {
-                      "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/%s/test_file1.txt",
-                            "files/%s/test_file2.txt"
-                       ],
+                       "displayName": "test_app",
+                       "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/%s/test_file1.txt",
+                                "files/%s/test_file2.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],
@@ -1773,12 +1775,14 @@ public class ShareApiTest extends ResourceBaseTest {
         response = send(HttpMethod.PUT, "/v1/applications/%s/test_app".formatted(bucket), null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/public/folder/test_file.txt"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/public/folder/test_file.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],
@@ -1838,12 +1842,14 @@ public class ShareApiTest extends ResourceBaseTest {
         response = send(HttpMethod.PUT, "/v1/applications/%s/test_app".formatted(bucket), null, """
                   {
                       "displayName": "test_app",
-                      "customAppSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                       "property1": "test property1",
-                       "property2": "test property2",
-                       "property3": [
-                            "files/%s/test_file.txt"
-                       ],
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/%s/test_file.txt"
+                        ]
+                       },
                        "userRoles": [
                             "Admin"
                        ],

--- a/server/src/test/java/com/epam/aidial/core/server/function/enhancement/AppendCustomApplicationPropertiesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/enhancement/AppendCustomApplicationPropertiesFnTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.server.validation.ApplicationTypeSchemaValidationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -76,6 +78,15 @@ public class AppendCustomApplicationPropertiesFnTest {
         function = new AppendApplicationPropertiesFn(proxy, context);
         application = new Application();
         when(context.getConfig()).thenReturn(config);
+    }
+
+    @Test
+    void apply_throws_whenApplicationHasCustomSchemaIdAndNoCustomFieldsPassedAndApplicationPropertiesIsNull() {
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
+        ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
+        assertThrows(ApplicationTypeSchemaValidationException.class, () -> function.apply(tree));
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/function/enhancement/AppendCustomApplicationPropertiesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/enhancement/AppendCustomApplicationPropertiesFnTest.java
@@ -82,11 +82,11 @@ public class AppendCustomApplicationPropertiesFnTest {
     void apply_appendsCustomProperties_whenApplicationHasCustomSchemaIdAndNoCustomFieldsPassed() {
         String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
         when(context.getDeployment()).thenReturn(application);
-        application.setCustomAppSchemaId(URI.create("customSchemaId"));
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
         Map<String, Object> customProps = new HashMap<>();
         customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
         customProps.put("serverFile", serverFile);
-        application.setCustomProperties(customProps);
+        application.setApplicationProperties(customProps);
         when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
         ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
         boolean result = function.apply(tree);
@@ -112,7 +112,7 @@ public class AppendCustomApplicationPropertiesFnTest {
     @Test
     void apply_returnsFalse_whenApplicationHasNoCustomSchemaId() {
         when(context.getDeployment()).thenReturn(application);
-        application.setCustomAppSchemaId(null);
+        application.setApplicationTypeSchemaId(null);
 
         ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
         boolean result = function.apply(tree);
@@ -124,10 +124,10 @@ public class AppendCustomApplicationPropertiesFnTest {
     @Test
     void apply_returnsTrue_whenCustomPropertiesAreEmptyAndApplicationHasCustomSchemaId() {
         when(context.getDeployment()).thenReturn(application);
-        application.setCustomAppSchemaId(URI.create("customSchemaId"));
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
         Map<String, Object> customProps = new HashMap<>();
         customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
-        application.setCustomProperties(customProps);
+        application.setApplicationProperties(customProps);
         when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
         ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
         boolean result = function.apply(tree);
@@ -139,11 +139,11 @@ public class AppendCustomApplicationPropertiesFnTest {
     void apply_appendsCustomProperties_whenApplicationHasCustomSchemaIdAndCustomFieldsPassed() throws JsonProcessingException {
         String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
         when(context.getDeployment()).thenReturn(application);
-        application.setCustomAppSchemaId(URI.create("customSchemaId"));
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
         Map<String, Object> customProps = new HashMap<>();
         customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
         customProps.put("serverFile", serverFile);
-        application.setCustomProperties(customProps);
+        application.setApplicationProperties(customProps);
         when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
         ObjectNode tree = (ObjectNode) ProxyUtil.MAPPER.readTree("""
                 {

--- a/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
@@ -89,7 +89,7 @@ public class ApplicationTypeSchemaUtilsTest {
     @Test
     public void getCustomApplicationSchemaOrThrow_returnsSchema_whenSchemaIdExists() {
         URI schemaId = URI.create("schemaId");
-        application.setCustomAppSchemaId(schemaId);
+        application.setApplicationTypeSchemaId(schemaId);
         when(config.getCustomApplicationSchema(schemaId)).thenReturn("schema");
 
         String result = ApplicationTypeSchemaUtils.getCustomApplicationSchemaOrThrow(config, application);
@@ -100,7 +100,7 @@ public class ApplicationTypeSchemaUtilsTest {
     @Test
     public void getCustomApplicationSchemaOrThrow_throws_whenSchemaNotFound() {
         URI schemaId = URI.create("schemaId");
-        application.setCustomAppSchemaId(schemaId);
+        application.setApplicationTypeSchemaId(schemaId);
         when(config.getCustomApplicationSchema(schemaId)).thenReturn(null);
 
         assertThrows(ApplicationTypeSchemaValidationException.class, () ->
@@ -109,7 +109,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void getCustomApplicationSchemaOrThrow_returnsNull_whenSchemaIdIsNull() {
-        application.setCustomAppSchemaId(null);
+        application.setApplicationTypeSchemaId(null);
 
         String result = ApplicationTypeSchemaUtils.getCustomApplicationSchemaOrThrow(config, application);
 
@@ -119,8 +119,8 @@ public class ApplicationTypeSchemaUtilsTest {
     @Test
     public void getCustomServerProperties_returnsProperties_whenSchemaExists() {
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
-        application.setCustomProperties(customProperties);
-        application.setCustomAppSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
 
         Map<String, Object> result = ApplicationTypeSchemaUtils.getCustomServerProperties(config, application);
 
@@ -129,7 +129,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void getCustomServerProperties_returnsEmptyMap_whenSchemaIsNull() {
-        application.setCustomAppSchemaId(null);
+        application.setApplicationTypeSchemaId(null);
 
         Map<String, Object> result = ApplicationTypeSchemaUtils.getCustomServerProperties(config, application);
 
@@ -138,7 +138,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void getCustomServerProperties_throws_whenSchemaNotFound() {
-        application.setCustomAppSchemaId(URI.create("schemaId"));
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(config.getCustomApplicationSchema(any())).thenReturn(null);
 
         Assertions.assertThrows(ApplicationTypeSchemaValidationException.class, () ->
@@ -149,18 +149,18 @@ public class ApplicationTypeSchemaUtilsTest {
     @Test
     public void filterCustomClientProperties_returnsFilteredProperties_whenSchemaExists() {
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
-        application.setCustomAppSchemaId(URI.create("schemaId"));
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
 
         Application result = ApplicationTypeSchemaUtils.filterCustomClientProperties(config, application);
 
         Assertions.assertNotSame(application, result);
-        Assertions.assertEquals(clientProperties, result.getCustomProperties());
+        Assertions.assertEquals(clientProperties, result.getApplicationProperties());
     }
 
     @Test
     public void filterCustomClientProperties_returnsOriginalApplication_whenSchemaIsNull() {
-        application.setCustomAppSchemaId(null);
+        application.setApplicationTypeSchemaId(null);
 
         Application result = ApplicationTypeSchemaUtils.filterCustomClientProperties(config, application);
 
@@ -171,34 +171,34 @@ public class ApplicationTypeSchemaUtilsTest {
     @Test
     public void filterCustomClientPropertiesWhenNoWriteAccess_returnsFilteredProperties_whenNoWriteAccess() {
         URI schemUri = URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type");
-        application.setCustomAppSchemaId(schemUri);
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(schemUri);
+        application.setApplicationProperties(customProperties);
         when(config.getCustomApplicationSchema(eq(schemUri))).thenReturn(schema);
         when(accessService.hasWriteAccess(resource, ctx)).thenReturn(false);
 
         Application result = ApplicationTypeSchemaUtils.filterCustomClientPropertiesWhenNoWriteAccess(ctx, resource, application);
 
         Assertions.assertNotSame(application, result);
-        Assertions.assertEquals(clientProperties, result.getCustomProperties());
+        Assertions.assertEquals(clientProperties, result.getApplicationProperties());
     }
 
     @Test
     public void filterCustomClientPropertiesWhenNoWriteAccess_returnsOriginalApplication_whenHasWriteAccess() {
         URI schemUri = URI.create("https://mydial.epam.com/custom_application_schemas/specific_application_type");
         when(accessService.hasWriteAccess(resource, ctx)).thenReturn(true);
-        application.setCustomAppSchemaId(schemUri);
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(schemUri);
+        application.setApplicationProperties(customProperties);
         when(config.getCustomApplicationSchema(eq(schemUri))).thenReturn(schema);
 
         Application result = ApplicationTypeSchemaUtils.filterCustomClientPropertiesWhenNoWriteAccess(ctx, resource, application);
 
         Assertions.assertSame(application, result);
-        Assertions.assertEquals(customProperties, result.getCustomProperties());
+        Assertions.assertEquals(customProperties, result.getApplicationProperties());
     }
 
     @Test
     public void modifyEndpointForCustomApplication_setsCustomEndpoint_whenSchemaExists() {
-        application.setCustomAppSchemaId(URI.create("schemaId"));
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
 
         Application result = ApplicationTypeSchemaUtils.modifyEndpointForCustomApplication(config, application);
@@ -209,7 +209,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void modifyEndpointForCustomApplication_throws_whenSchemaIsNull() {
-        application.setCustomAppSchemaId(null);
+        application.setApplicationTypeSchemaId(null);
 
         Assertions.assertThrows(ApplicationTypeSchemaProcessingException.class,
                 () -> ApplicationTypeSchemaUtils.modifyEndpointForCustomApplication(config, application));
@@ -232,7 +232,7 @@ public class ApplicationTypeSchemaUtilsTest {
                 + "},"
                 + "\"required\": [\"clientFile\"]"
                 + "}";
-        application.setCustomAppSchemaId(URI.create("schemaId"));
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(config.getCustomApplicationSchema(any())).thenReturn(schemaWithoutEndpoint);
 
         Assertions.assertThrows(ApplicationTypeSchemaProcessingException.class, () ->
@@ -245,8 +245,8 @@ public class ApplicationTypeSchemaUtilsTest {
         customProperties.put("clientFile", "oldLink1");
         customProperties.put("serverFile", "oldLink2");
 
-        application.setCustomAppSchemaId(URI.create("schemaId"));
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
 
 
         Map<String, String> replacementLinks = new HashMap<>();
@@ -259,7 +259,7 @@ public class ApplicationTypeSchemaUtilsTest {
         expectedProperties.put("clientFile", "newLink1");
         expectedProperties.put("serverFile", "newLink2");
 
-        Assertions.assertEquals(expectedProperties, application.getCustomProperties());
+        Assertions.assertEquals(expectedProperties, application.getApplicationProperties());
     }
 
     @Test
@@ -268,8 +268,8 @@ public class ApplicationTypeSchemaUtilsTest {
         customProperties.put("clientFile", "oldLink1");
         customProperties.put("serverFile", "oldLink2");
 
-        application.setCustomAppSchemaId(null);
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(null);
+        application.setApplicationProperties(customProperties);
 
         Map<String, String> replacementLinks = new HashMap<>();
         replacementLinks.put("oldLink1", "newLink1");
@@ -277,7 +277,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
         ApplicationTypeSchemaUtils.replaceCustomAppFiles(application, replacementLinks);
 
-        Assertions.assertEquals(customProperties, application.getCustomProperties());
+        Assertions.assertEquals(customProperties, application.getApplicationProperties());
     }
 
     @Test
@@ -288,8 +288,8 @@ public class ApplicationTypeSchemaUtilsTest {
         customProperties.put("clientFile", "oldLink1");
         customProperties.put("serverProps", serverProps);
 
-        application.setCustomAppSchemaId(URI.create("schemaId"));
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
 
         Map<String, String> replacementLinks = new HashMap<>();
         replacementLinks.put("oldLink1", "newLink1");
@@ -303,14 +303,14 @@ public class ApplicationTypeSchemaUtilsTest {
         expectedProperties.put("clientFile", "newLink1");
         expectedProperties.put("serverProps", expectedServerProps);
 
-        Assertions.assertEquals(expectedProperties, application.getCustomProperties());
+        Assertions.assertEquals(expectedProperties, application.getApplicationProperties());
     }
 
 
     @Test
     public void getFiles_returnsListOfFiles_whenSchemaExists() {
-        application.setCustomAppSchemaId(URI.create("schemaId"));
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
 
         EncryptionService encryptionService = mock(EncryptionService.class);
@@ -325,7 +325,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void getFiles_returnsEmptyList_whenSchemaIsNull() {
-        application.setCustomAppSchemaId(null);
+        application.setApplicationTypeSchemaId(null);
 
         EncryptionService encryptionService = mock(EncryptionService.class);
         ResourceService resourceService = mock(ResourceService.class);
@@ -337,8 +337,8 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void getFiles_throwsException_whenResourceNotFound() {
-        application.setCustomAppSchemaId(URI.create("schemaId"));
-        application.setCustomProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
 
         EncryptionService encryptionService = mock(EncryptionService.class);

--- a/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
@@ -159,6 +159,17 @@ public class ApplicationTypeSchemaUtilsTest {
     }
 
     @Test
+    public void filterCustomClientProperties_returnsOriginalApplication_whenApplicationPropertiesIsNull() {
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(null);
+
+        Application result = ApplicationTypeSchemaUtils.filterCustomClientProperties(config, application);
+
+        Assertions.assertSame(application, result);
+    }
+
+    @Test
     public void filterCustomClientProperties_returnsOriginalApplication_whenSchemaIsNull() {
         application.setApplicationTypeSchemaId(null);
 


### PR DESCRIPTION
* All custom properties from application type schema are now stored in applicationProeprties field of the application
* The user can create an application with schema, but without applicationProeprties, no validation will be performed
* The user can update applicationProeprties from null to some value but not vice versa
* If applicationProeprties is null, the completion request will fail
* CustomApplicationSchemaId became applicationTypeSchemaId