### PR TITLE
feat: Add server-specific files to the request for application with schema while proxying the completion request

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -269,6 +269,7 @@ public class DeploymentPostController {
             if (ProxyUtil.processChain(tree, enhancementFunctions)) {
                 context.setRequestBody(Buffer.buffer(ProxyUtil.MAPPER.writeValueAsBytes(tree)));
             }
+            proxy.getApiKeyStore().assignPerRequestApiKey(context.getProxyApiKeyData());
         } catch (Throwable e) {
             if (e instanceof HttpException httpException) {
                 respond(httpException.getStatus(), httpException.getMessage());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -12,6 +12,7 @@ import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.data.ErrorData;
 import com.epam.aidial.core.server.function.BaseRequestFunction;
+import com.epam.aidial.core.server.function.CollectRequestApplicationFilesFn;
 import com.epam.aidial.core.server.function.CollectRequestAttachmentsFn;
 import com.epam.aidial.core.server.function.CollectRequestDataFn;
 import com.epam.aidial.core.server.function.CollectResponseAttachmentsFn;
@@ -73,7 +74,8 @@ public class DeploymentPostController {
                 new ApplyDefaultDeploymentSettingsFn(proxy, context),
                 new EnhanceAssistantRequestFn(proxy, context),
                 new EnhanceModelRequestFn(proxy, context),
-                new AppendApplicationPropertiesFn(proxy, context));
+                new AppendApplicationPropertiesFn(proxy, context),
+                new CollectRequestApplicationFilesFn(proxy, context));
     }
 
     public Future<?> handle(String deploymentId, String deploymentApi) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
@@ -17,6 +17,7 @@ import com.epam.aidial.core.server.util.ApplicationTypeSchemaProcessingException
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
+import com.epam.aidial.core.server.validation.ApplicationTypeResourceException;
 import com.epam.aidial.core.server.validation.ApplicationTypeSchemaValidationException;
 import com.epam.aidial.core.storage.data.MetadataBase;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
@@ -37,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.epam.aidial.core.storage.http.HttpStatus.BAD_REQUEST;
+import static com.epam.aidial.core.storage.http.HttpStatus.FORBIDDEN;
 import static com.epam.aidial.core.storage.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
@@ -178,6 +180,8 @@ public class ResourceController extends AccessControlBaseController {
                     });
         } catch (ValidationException | IllegalArgumentException | ApplicationTypeSchemaValidationException e) {
             throw new HttpException(BAD_REQUEST, " Custom application validation failed", e);
+        } catch (ApplicationTypeResourceException e) {
+            throw new HttpException(FORBIDDEN, "Failed to access application resource " + e.getResourceUri(), e);
         } catch (ApplicationTypeSchemaProcessingException e) {
             throw new HttpException(INTERNAL_SERVER_ERROR, "Custom application processing exception", e);
         }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
@@ -12,7 +12,6 @@ import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.ApplicationService;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
 import com.epam.aidial.core.server.service.ResourceNotFoundException;
-import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaProcessingException;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
@@ -132,11 +131,9 @@ public class ResourceController extends AccessControlBaseController {
         Future<Pair<ResourceItemMetadata, String>> responseFuture = (descriptor.getType() == ResourceTypes.APPLICATION)
                 ? getApplicationData(descriptor, hasWriteAccess, etagHeader) : getResourceData(descriptor, etagHeader);
 
-        responseFuture.onSuccess(pair -> {
-                    context.putHeader(HttpHeaders.ETAG, pair.getKey().getEtag())
-                            .exposeHeaders()
-                            .respond(HttpStatus.OK, pair.getValue());
-                })
+        responseFuture.onSuccess(pair -> context.putHeader(HttpHeaders.ETAG, pair.getKey().getEtag())
+                .exposeHeaders()
+                .respond(HttpStatus.OK, pair.getValue()))
                 .onFailure(error -> handleError(descriptor, error));
 
         return Future.succeededFuture();
@@ -179,7 +176,7 @@ public class ResourceController extends AccessControlBaseController {
                         throw new HttpException(BAD_REQUEST, "No read access to file: " + file.getUrl());
                     });
         } catch (ValidationException | IllegalArgumentException | ApplicationTypeSchemaValidationException e) {
-            throw new HttpException(BAD_REQUEST, " Custom application validation failed", e);
+            throw new HttpException(BAD_REQUEST, "Custom application validation failed", e);
         } catch (ApplicationTypeResourceException e) {
             throw new HttpException(FORBIDDEN, "Failed to access application resource " + e.getResourceUri(), e);
         } catch (ApplicationTypeSchemaProcessingException e) {
@@ -236,11 +233,9 @@ public class ResourceController extends AccessControlBaseController {
             });
         }
 
-        responseFuture.onSuccess((metadata) -> {
-                    context.putHeader(HttpHeaders.ETAG, metadata.getEtag())
-                            .exposeHeaders()
-                            .respond(HttpStatus.OK, metadata);
-                })
+        responseFuture.onSuccess((metadata) -> context.putHeader(HttpHeaders.ETAG, metadata.getEtag())
+                .exposeHeaders()
+                .respond(HttpStatus.OK, metadata))
                 .onFailure(error -> handleError(descriptor, error));
 
         return Future.succeededFuture();

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
@@ -1,0 +1,62 @@
+package com.epam.aidial.core.server.function;
+
+import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.data.AutoSharedData;
+import com.epam.aidial.core.server.security.AccessService;
+import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.storage.data.ResourceAccessType;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+
+@Slf4j
+public class CollectRequestApplicationFilesFn extends BaseRequestFunction<ObjectNode> {
+    public CollectRequestApplicationFilesFn(Proxy proxy, ProxyContext context) {
+        super(proxy, context);
+    }
+
+    @Override
+    public Boolean apply(ObjectNode tree) {
+        Deployment deployment = context.getDeployment();
+        if (!(deployment instanceof Application application && application.getApplicationTypeSchemaId() != null)) {
+            return false;
+        }
+        List<ResourceDescriptor> resources = ApplicationTypeSchemaUtils.getServerFiles(context.getConfig(), application, proxy.getEncryptionService(),
+                proxy.getResourceService());
+        ApiKeyData keyData = context.getProxyApiKeyData();
+        appendFilesToProxyApiKeyData(keyData, resources);
+        String perRequestKey = context.getProxyApiKeyData().getPerRequestKey();
+        if (perRequestKey == null) { //This class may be not the one who modifies the perRequestKey
+            proxy.getApiKeyStore().assignPerRequestApiKey(keyData);
+        } else {
+            proxy.getApiKeyStore().updatePerRequestApiKey(perRequestKey, json -> ProxyUtil.convertToString(keyData));
+        }
+        return false;
+    }
+
+    private void appendFilesToProxyApiKeyData(ApiKeyData apiKeyData, List<ResourceDescriptor> resources) {
+        for (ResourceDescriptor resource : resources) {
+            String resourceUrl = resource.getUrl();
+            AccessService accessService = proxy.getAccessService();
+            if (accessService.hasReadAccess(resource, context)) {
+                if (resource.isFolder()) {
+                    apiKeyData.getAttachedFolders().put(resourceUrl, new AutoSharedData(ResourceAccessType.READ_ONLY));
+                } else {
+                    apiKeyData.getAttachedFiles().put(resourceUrl, new AutoSharedData(ResourceAccessType.READ_ONLY));
+                }
+            } else {
+                throw new HttpException(HttpStatus.FORBIDDEN, "Access denied to the file %s".formatted(resourceUrl));
+            }
+        }
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
@@ -33,6 +33,9 @@ public class CollectRequestApplicationFilesFn extends BaseRequestFunction<Object
             if (!(deployment instanceof Application application && application.getApplicationTypeSchemaId() != null)) {
                 return false;
             }
+            if (application.getApplicationProperties() == null) {
+                throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR, "Typed application's properties not set");
+            }
             List<ResourceDescriptor> resources = ApplicationTypeSchemaUtils.getServerFiles(context.getConfig(), application, proxy.getEncryptionService(),
                     proxy.getResourceService());
             ApiKeyData keyData = context.getProxyApiKeyData();

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
@@ -8,7 +8,6 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.data.AutoSharedData;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
-import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.validation.ApplicationTypeResourceException;
 import com.epam.aidial.core.storage.data.ResourceAccessType;
 import com.epam.aidial.core.storage.http.HttpException;
@@ -38,14 +37,7 @@ public class CollectRequestApplicationFilesFn extends BaseRequestFunction<Object
             }
             List<ResourceDescriptor> resources = ApplicationTypeSchemaUtils.getServerFiles(context.getConfig(), application, proxy.getEncryptionService(),
                     proxy.getResourceService());
-            ApiKeyData keyData = context.getProxyApiKeyData();
-            appendFilesToProxyApiKeyData(keyData, resources);
-            String perRequestKey = keyData.getPerRequestKey();
-            if (perRequestKey == null) { //This class may be not the one who modifies the perRequestKey
-                proxy.getApiKeyStore().assignPerRequestApiKey(keyData);
-            } else {
-                proxy.getApiKeyStore().updatePerRequestApiKey(perRequestKey, json -> ProxyUtil.convertToString(keyData));
-            }
+            appendFilesToProxyApiKeyData(resources);
             return false;
         } catch (HttpException ex) {
             throw ex;
@@ -56,7 +48,8 @@ public class CollectRequestApplicationFilesFn extends BaseRequestFunction<Object
         }
     }
 
-    private void appendFilesToProxyApiKeyData(ApiKeyData apiKeyData, List<ResourceDescriptor> resources) {
+    private void appendFilesToProxyApiKeyData(List<ResourceDescriptor> resources) {
+        ApiKeyData apiKeyData = context.getProxyApiKeyData();
         for (ResourceDescriptor resource : resources) {
             String resourceUrl = resource.getUrl();
             AccessService accessService = proxy.getAccessService();

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestAttachmentsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestAttachmentsFn.java
@@ -28,9 +28,6 @@ public class CollectRequestAttachmentsFn extends BaseRequestFunction<ObjectNode>
     @Override
     public Boolean apply(ObjectNode tree) {
         ProxyUtil.collectAttachedFilesFromRequest(tree, this::processAttachedFile);
-        // assign api key data after processing attachments
-        ApiKeyData destApiKeyData = context.getProxyApiKeyData();
-        proxy.getApiKeyStore().assignPerRequestApiKey(destApiKeyData);
         return false;
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
@@ -173,9 +173,6 @@ public class ApplicationTypeSchemaUtils {
             if (customApplicationSchema == null) {
                 return Collections.emptyList();
             }
-            if (application.getApplicationProperties() == null) {
-                throw new ApplicationTypeSchemaValidationException("Typed application's properties not set");
-            }
             JsonSchema appSchema = SCHEMA_FACTORY.getSchema(customApplicationSchema);
             CollectorContext collectorContext = new CollectorContext();
             String customPropsJson = ProxyUtil.MAPPER.writeValueAsString(application.getApplicationProperties());

--- a/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtils.java
@@ -154,8 +154,19 @@ public class ApplicationTypeSchemaUtils {
         application.setApplicationProperties(customPropertiesMap);
     }
 
+    public static List<ResourceDescriptor> getServerFiles(Config config, Application application, EncryptionService encryptionService,
+                                                          ResourceService resourceService) {
+        return getFiles(config, application, encryptionService, resourceService, ListCollector.FileCollectorType.ONLY_SERVER_FILES);
+    }
+
+    public static List<ResourceDescriptor> getFiles(Config config, Application application, EncryptionService encryptionService,
+                                                    ResourceService resourceService) {
+        return getFiles(config, application, encryptionService, resourceService, ListCollector.FileCollectorType.ALL_FILES);
+    }
+
     @SuppressWarnings("unchecked")
-    public static List<ResourceDescriptor> getFiles(Config config, Application application, EncryptionService encryptionService, ResourceService resourceService) {
+    private static List<ResourceDescriptor> getFiles(Config config, Application application, EncryptionService encryptionService,
+                                                    ResourceService resourceService, ListCollector.FileCollectorType collectorName) {
         try {
             String customApplicationSchema = getCustomApplicationSchemaOrThrow(config, application);
             if (customApplicationSchema == null) {
@@ -169,7 +180,7 @@ public class ApplicationTypeSchemaUtils {
             if (!validationResult.isEmpty()) {
                 throw new ApplicationTypeSchemaValidationException("Failed to validate custom app against the schema", validationResult);
             }
-            ListCollector<String> propsCollector = (ListCollector<String>) collectorContext.getCollectorMap().get("file");
+            ListCollector<String> propsCollector = (ListCollector<String>) collectorContext.getCollectorMap().get(collectorName.getValue());
             if (propsCollector == null) {
                 return Collections.emptyList();
             }

--- a/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeResourceException.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeResourceException.java
@@ -1,0 +1,20 @@
+package com.epam.aidial.core.server.validation;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationTypeResourceException extends RuntimeException {
+
+    private final String resourceUri;
+
+    public ApplicationTypeResourceException(String message, String resourceUri, Throwable cause) {
+        super(message, cause);
+        this.resourceUri = resourceUri;
+    }
+
+    public ApplicationTypeResourceException(String message, String resourceUri) {
+        super(message);
+        this.resourceUri = resourceUri;
+    }
+
+}

--- a/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeResourceException.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeResourceException.java
@@ -2,6 +2,12 @@ package com.epam.aidial.core.server.validation;
 
 import lombok.Getter;
 
+
+/**
+ * Exception thrown when there is an issue with a resource associated with an application type.
+ * This exception is typically used when a resource listed as dependent to the application
+ * is not found, inaccessible, or there is a failure in obtaining the resource descriptor.
+ */
 @Getter
 public class ApplicationTypeResourceException extends RuntimeException {
 

--- a/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeSchemaValidationException.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeSchemaValidationException.java
@@ -14,10 +14,6 @@ public class ApplicationTypeSchemaValidationException extends RuntimeException {
         this.validationMessages = validationMessages;
     }
 
-    public ApplicationTypeSchemaValidationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public ApplicationTypeSchemaValidationException(String message) {
         super(message);
     }

--- a/server/src/main/java/com/epam/aidial/core/server/validation/ListCollector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/ListCollector.java
@@ -1,11 +1,25 @@
 package com.epam.aidial.core.server.validation;
 
 import com.networknt.schema.Collector;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ListCollector<T> implements Collector<List<T>> {
+
+    @Getter
+    public enum FileCollectorType {
+        ALL_FILES("file"),
+        ONLY_SERVER_FILES("server_file");
+
+        private final String value;
+
+        FileCollectorType(String value) {
+            this.value = value;
+        }
+    }
+
     private final List<T> references = new ArrayList<>();
 
     @Override

--- a/server/src/test/java/com/epam/aidial/core/server/ResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ResourceApiTest.java
@@ -403,7 +403,7 @@ class ResourceApiTest extends ResourceBaseTest {
                        "description": "My application description"
                   }
                 """);
-        Assertions.assertEquals(400, response.status());
+        Assertions.assertEquals(403, response.status());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
@@ -7,12 +7,10 @@ import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.security.AccessService;
-import com.epam.aidial.core.server.security.ApiKeyStore;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,10 +51,6 @@ public class CollectRequestApplicationFilesFnTest {
     @Mock
     private ResourceService resourceService;
 
-    private ApiKeyStore apiKeyStore;
-
-    @Mock
-    private Vertx vertx;
 
     @InjectMocks
     private CollectRequestApplicationFilesFn fn;
@@ -100,7 +94,6 @@ public class CollectRequestApplicationFilesFnTest {
     void setUp() {
         application = new Application();
         tree = JsonNodeFactory.instance.objectNode();
-        apiKeyStore = new ApiKeyStore(resourceService, vertx);
     }
 
     @Test
@@ -127,7 +120,6 @@ public class CollectRequestApplicationFilesFnTest {
     void apply_appendsFilesToApiKeyData_whenApplicationHasCustomSchemaId() {
         when(proxy.getAccessService()).thenReturn(accessService);
         when(proxy.getResourceService()).thenReturn(resourceService);
-        when(proxy.getApiKeyStore()).thenReturn(apiKeyStore);
         when(context.getProxyApiKeyData()).thenReturn(new ApiKeyData());
         when(context.getConfig()).thenReturn(config);
         String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
@@ -147,7 +139,6 @@ public class CollectRequestApplicationFilesFnTest {
 
         assertFalse(result);
         assertNotNull(apiKeyData.getAttachedFiles().get(serverFile));
-        assertNotNull(apiKeyData.getPerRequestKey());
         assertEquals(1, apiKeyData.getAttachedFiles().size());
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
@@ -1,18 +1,25 @@
-package com.epam.aidial.core.server.function.enhancement;
+package com.epam.aidial.core.server.function;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
-import com.epam.aidial.core.server.util.ProxyUtil;
-import com.epam.aidial.core.server.validation.ApplicationTypeSchemaValidationException;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.security.AccessService;
+import com.epam.aidial.core.server.security.ApiKeyStore;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.service.ResourceService;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -21,14 +28,15 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AppendCustomApplicationPropertiesFnTest {
+@ExtendWith(MockitoExtension.class)
+public class CollectRequestApplicationFilesFnTest {
 
     @Mock
     private Proxy proxy;
@@ -39,9 +47,22 @@ public class AppendCustomApplicationPropertiesFnTest {
     @Mock
     private Config config;
 
-    private Application application;
+    @Mock
+    private AccessService accessService;
 
-    private AppendApplicationPropertiesFn function;
+    @Mock
+    private ResourceService resourceService;
+
+    private ApiKeyStore apiKeyStore;
+
+    @Mock
+    private Vertx vertx;
+
+    @InjectMocks
+    private CollectRequestApplicationFilesFn fn;
+
+    private Application application;
+    private ObjectNode tree;
 
     private final String schema = """
             {
@@ -77,80 +98,38 @@ public class AppendCustomApplicationPropertiesFnTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-        function = new AppendApplicationPropertiesFn(proxy, context);
         application = new Application();
-        when(context.getConfig()).thenReturn(config);
+        tree = JsonNodeFactory.instance.objectNode();
+        apiKeyStore = new ApiKeyStore(resourceService, vertx);
     }
 
     @Test
-    void apply_throws_whenApplicationHasCustomSchemaIdAndNoCustomFieldsPassedAndApplicationPropertiesIsNull() {
-        when(context.getDeployment()).thenReturn(application);
-        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
-        when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
-        ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
-        assertThrows(ApplicationTypeSchemaValidationException.class, () -> function.apply(tree));
-    }
-
-    @Test
-    void apply_appendsCustomProperties_whenApplicationHasCustomSchemaIdAndNoCustomFieldsPassed() {
-        String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
-        when(context.getDeployment()).thenReturn(application);
-        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
-        Map<String, Object> customProps = new HashMap<>();
-        customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
-        customProps.put("serverFile", serverFile);
-        application.setApplicationProperties(customProps);
-        when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
-        ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
-        boolean result = function.apply(tree);
-        assertTrue(result);
-        assertNotNull(tree.get("custom_fields"));
-        assertEquals(serverFile,
-                tree.get("custom_fields").get("application_properties").get("serverFile").asText());
-        assertFalse(tree.get("custom_fields").get("application_properties").has("clientFile"));
-    }
-
-    @Test
-    void apply_returnsFalse_whenDeploymentIsNotApplication() {
+    void apply_doesNotAppendsFilesToApiKeyData_whenDeploymentIsNotApplication() {
         Deployment deployment = mock(Deployment.class);
         when(context.getDeployment()).thenReturn(deployment);
 
-        ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
-        boolean result = function.apply(tree);
-
-        assertFalse(result);
-        assertNull(tree.get("custom_fields"));
+        assertFalse(fn.apply(tree));
+        verify(proxy, never()).getApiKeyStore();
+        verify(context, never()).getProxyApiKeyData();
     }
 
     @Test
-    void apply_returnsFalse_whenApplicationHasNoCustomSchemaId() {
+    void apply_doesNotAppendsFilesToApiKeyData_whenApplicationHasNoCustomSchemaId() {
         when(context.getDeployment()).thenReturn(application);
         application.setApplicationTypeSchemaId(null);
 
-        ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
-        boolean result = function.apply(tree);
-
-        assertFalse(result);
-        assertNull(tree.get("custom_fields"));
+        assertFalse(fn.apply(tree));
+        verify(proxy, never()).getApiKeyStore();
+        verify(context, never()).getProxyApiKeyData();
     }
 
     @Test
-    void apply_returnsTrue_whenCustomPropertiesAreEmptyAndApplicationHasCustomSchemaId() {
-        when(context.getDeployment()).thenReturn(application);
-        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
-        Map<String, Object> customProps = new HashMap<>();
-        customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
-        application.setApplicationProperties(customProps);
-        when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
-        ObjectNode tree = ProxyUtil.MAPPER.createObjectNode();
-        boolean result = function.apply(tree);
-        assertTrue(result);
-        assertNotNull(tree.get("custom_fields"));
-    }
-
-    @Test
-    void apply_appendsCustomProperties_whenApplicationHasCustomSchemaIdAndCustomFieldsPassed() throws JsonProcessingException {
+    void apply_appendsFilesToApiKeyData_whenApplicationHasCustomSchemaId() {
+        when(proxy.getAccessService()).thenReturn(accessService);
+        when(proxy.getResourceService()).thenReturn(resourceService);
+        when(proxy.getApiKeyStore()).thenReturn(apiKeyStore);
+        when(context.getProxyApiKeyData()).thenReturn(new ApiKeyData());
+        when(context.getConfig()).thenReturn(config);
         String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
         when(context.getDeployment()).thenReturn(application);
         application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
@@ -159,22 +138,55 @@ public class AppendCustomApplicationPropertiesFnTest {
         customProps.put("serverFile", serverFile);
         application.setApplicationProperties(customProps);
         when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
-        ObjectNode tree = (ObjectNode) ProxyUtil.MAPPER.readTree("""
-                {
-                    "custom_fields": {
-                        "foo": "bar"
-                    }
-                }
-                """);
-        boolean result = function.apply(tree);
-        assertTrue(result);
-        assertNotNull(tree.get("custom_fields"));
-        assertEquals(serverFile,
-                tree.get("custom_fields").get("application_properties").get("serverFile").asText());
-        assertFalse(tree.get("custom_fields").get("application_properties").has("clientFile"));
-        assertTrue(tree.get("custom_fields").has("foo"));
-        assertEquals("bar",
-                tree.get("custom_fields").get("foo").asText());
+        when(accessService.hasReadAccess(any(), any())).thenReturn(true);
+        when(resourceService.hasResource(any())).thenReturn(true);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
 
+        boolean result = fn.apply(tree);
+
+        assertFalse(result);
+        assertNotNull(apiKeyData.getAttachedFiles().get(serverFile));
+        assertNotNull(apiKeyData.getPerRequestKey());
+        assertEquals(1, apiKeyData.getAttachedFiles().size());
+    }
+
+    @Test
+    void apply_throws_whenResourceServiceHasNoResource() {
+        when(proxy.getResourceService()).thenReturn(resourceService);
+        when(context.getConfig()).thenReturn(config);
+        String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        Map<String, Object> customProps = new HashMap<>();
+        customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
+        customProps.put("serverFile", serverFile);
+        application.setApplicationProperties(customProps);
+        when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
+        when(resourceService.hasResource(any())).thenReturn(false); //Has No Resource
+
+        Assertions.assertThrows(HttpException.class, () -> fn.apply(tree));
+    }
+
+    @Test
+    void apply_throws_whenAccessServiceHasNoReadAccess() {
+        when(proxy.getAccessService()).thenReturn(accessService);
+        when(proxy.getResourceService()).thenReturn(resourceService);
+        when(context.getProxyApiKeyData()).thenReturn(new ApiKeyData());
+        when(context.getConfig()).thenReturn(config);
+        String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        Map<String, Object> customProps = new HashMap<>();
+        customProps.put("clientFile", "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
+        customProps.put("serverFile", serverFile);
+        application.setApplicationProperties(customProps);
+        when(config.getCustomApplicationSchema(eq(URI.create("customSchemaId")))).thenReturn(schema);
+        when(accessService.hasReadAccess(any(), any())).thenReturn(false); //Has no Read Access
+        when(resourceService.hasResource(any())).thenReturn(true);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+
+        Assertions.assertThrows(HttpException.class, () -> fn.apply(tree));
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
@@ -360,4 +360,48 @@ public class ApplicationTypeSchemaUtilsTest {
         Assertions.assertThrows(ApplicationTypeSchemaValidationException.class, () ->
                 ApplicationTypeSchemaUtils.getFiles(config, application, encryptionService, resourceService));
     }
+
+    @Test
+    public void getServerFiles_returnsListOfServerFiles_whenSchemaExists() {
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        ResourceService resourceService = mock(ResourceService.class);
+
+        when(resourceService.hasResource(any())).thenReturn(true);
+
+        List<ResourceDescriptor> result = ApplicationTypeSchemaUtils.getServerFiles(config, application, encryptionService, resourceService);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(result.get(0).getUrl(), serverProperties.get("serverFile"));
+    }
+
+    @Test
+    public void getServerFiles_returnsEmptyList_whenSchemaIsNull() {
+        application.setApplicationTypeSchemaId(null);
+
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        ResourceService resourceService = mock(ResourceService.class);
+
+        List<ResourceDescriptor> result = ApplicationTypeSchemaUtils.getServerFiles(config, application, encryptionService, resourceService);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getServerFiles_throwsException_whenResourceNotFound() {
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        ResourceService resourceService = mock(ResourceService.class);
+
+        when(resourceService.hasResource(any())).thenReturn(false);
+
+        Assertions.assertThrows(ApplicationTypeSchemaValidationException.class, () ->
+                ApplicationTypeSchemaUtils.getServerFiles(config, application, encryptionService, resourceService));
+    }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
@@ -230,21 +230,22 @@ public class ApplicationTypeSchemaUtilsTest {
 
     @Test
     public void modifyEndpointForCustomApplication_throws_whenEndpointNotFound() {
-        String schemaWithoutEndpoint = "{"
-                                       + "\"$schema\": \"https://dial.epam.com/application_type_schemas/schema#\","
-                                       + "\"$id\": \"https://mydial.epam.com/custom_application_schemas/specific_application_type\","
-                                       + "\"properties\": {"
-                                       + "  \"clientFile\": {"
-                                       + "    \"type\": \"string\","
-                                       + "    \"format\": \"dial-file-encoded\","
-                                       + "    \"dial:meta\": {"
-                                       + "      \"dial:propertyKind\": \"client\","
-                                       + "      \"dial:propertyOrder\": 1"
-                                       + "    }"
-                                       + "  }"
-                                       + "},"
-                                       + "\"required\": [\"clientFile\"]"
-                                       + "}";
+        String schemaWithoutEndpoint = """
+                {
+                "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",
+                "properties": {
+                  "clientFile": {
+                    "type": "string",
+                    "format": "dial-file-encoded",
+                    "dial:meta": {
+                      "dial:propertyKind": "client",
+                      "dial:propertyOrder": 1
+                    }
+                  }
+                },
+                "required": ["clientFile"]
+                }""";
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(config.getCustomApplicationSchema(any())).thenReturn(schemaWithoutEndpoint);
 

--- a/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.validation.ApplicationTypeResourceException;
 import com.epam.aidial.core.server.validation.ApplicationTypeSchemaValidationException;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.service.ResourceService;
@@ -32,34 +33,35 @@ public class ApplicationTypeSchemaUtilsTest {
     private ResourceDescriptor resource;
     private AccessService accessService;
 
-    private final String schema = "{"
-            + "\"$schema\": \"https://dial.epam.com/application_type_schemas/schema#\","
-            + "\"$id\": \"https://mydial.epam.com/custom_application_schemas/specific_application_type\","
-            + "\"dial:applicationTypeEditorUrl\": \"https://mydial.epam.com/specific_application_type_editor\","
-            + "\"dial:applicationTypeDisplayName\": \"Specific Application Type\","
-            + "\"dial:applicationTypeCompletionEndpoint\": \"http://specific_application_service/opeani/v1/completion\","
-            + "\"properties\": {"
-            + "  \"clientFile\": {"
-            + "    \"type\": \"string\","
-            + "    \"format\": \"dial-file-encoded\","
-            + "    \"dial:meta\": {"
-            + "      \"dial:propertyKind\": \"client\","
-            + "      \"dial:propertyOrder\": 1"
-            + "    },"
-            + "    \"dial:file\" : true"
-            + "  },"
-            + "  \"serverFile\": {"
-            + "    \"type\": \"string\","
-            + "    \"format\": \"dial-file-encoded\","
-            + "    \"dial:meta\": {"
-            + "      \"dial:propertyKind\": \"server\","
-            + "      \"dial:propertyOrder\": 2"
-            + "    },"
-            + "    \"dial:file\" : true"
-            + "  }"
-            + "},"
-            + "\"required\": [\"clientFile\",\"serverFile\"]"
-            + "}";
+    private final String schema = """
+            {
+              "$schema" : "https://dial.epam.com/application_type_schemas/schema#",
+              "$id" : "https://mydial.epam.com/custom_application_schemas/specific_application_type",
+              "dial:applicationTypeEditorUrl" : "https://mydial.epam.com/specific_application_type_editor",
+              "dial:applicationTypeDisplayName" : "Specific Application Type",
+              "dial:applicationTypeCompletionEndpoint" : "http://specific_application_service/opeani/v1/completion",
+              "properties" : {
+                "clientFile" : {
+                  "type" : "string",
+                  "format" : "dial-file-encoded",
+                  "dial:meta" : {
+                    "dial:propertyKind" : "client",
+                    "dial:propertyOrder" : 1
+                  },
+                  "dial:file" : true
+                },
+                "serverFile" : {
+                  "type" : "string",
+                  "format" : "dial-file-encoded",
+                  "dial:meta" : {
+                    "dial:propertyKind" : "server",
+                    "dial:propertyOrder" : 2
+                  },
+                  "dial:file" : true
+                }
+              },
+              "required" : [ "clientFile", "serverFile" ]
+            }""";
 
     private final Map<String, Object> clientProperties = Map.of("clientFile",
             "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext");
@@ -229,20 +231,20 @@ public class ApplicationTypeSchemaUtilsTest {
     @Test
     public void modifyEndpointForCustomApplication_throws_whenEndpointNotFound() {
         String schemaWithoutEndpoint = "{"
-                + "\"$schema\": \"https://dial.epam.com/application_type_schemas/schema#\","
-                + "\"$id\": \"https://mydial.epam.com/custom_application_schemas/specific_application_type\","
-                + "\"properties\": {"
-                + "  \"clientFile\": {"
-                + "    \"type\": \"string\","
-                + "    \"format\": \"dial-file-encoded\","
-                + "    \"dial:meta\": {"
-                + "      \"dial:propertyKind\": \"client\","
-                + "      \"dial:propertyOrder\": 1"
-                + "    }"
-                + "  }"
-                + "},"
-                + "\"required\": [\"clientFile\"]"
-                + "}";
+                                       + "\"$schema\": \"https://dial.epam.com/application_type_schemas/schema#\","
+                                       + "\"$id\": \"https://mydial.epam.com/custom_application_schemas/specific_application_type\","
+                                       + "\"properties\": {"
+                                       + "  \"clientFile\": {"
+                                       + "    \"type\": \"string\","
+                                       + "    \"format\": \"dial-file-encoded\","
+                                       + "    \"dial:meta\": {"
+                                       + "      \"dial:propertyKind\": \"client\","
+                                       + "      \"dial:propertyOrder\": 1"
+                                       + "    }"
+                                       + "  }"
+                                       + "},"
+                                       + "\"required\": [\"clientFile\"]"
+                                       + "}";
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(config.getCustomApplicationSchema(any())).thenReturn(schemaWithoutEndpoint);
 
@@ -357,7 +359,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
         when(resourceService.hasResource(any())).thenReturn(false);
 
-        Assertions.assertThrows(ApplicationTypeSchemaValidationException.class, () ->
+        Assertions.assertThrows(ApplicationTypeResourceException.class, () ->
                 ApplicationTypeSchemaUtils.getFiles(config, application, encryptionService, resourceService));
     }
 
@@ -401,7 +403,7 @@ public class ApplicationTypeSchemaUtilsTest {
 
         when(resourceService.hasResource(any())).thenReturn(false);
 
-        Assertions.assertThrows(ApplicationTypeSchemaValidationException.class, () ->
+        Assertions.assertThrows(ApplicationTypeResourceException.class, () ->
                 ApplicationTypeSchemaUtils.getServerFiles(config, application, encryptionService, resourceService));
     }
 }


### PR DESCRIPTION
* CollectRequestApplicationFilesFn adds files from server application properties as auto-shared to the request key
* if application properties are null, then throw an internal server error
* if some of the files from properties are not accessible, then throw a forbidden error
* forbidden error on inaccessible or non-existing files added to all the handlers of custom applications (via validation modification)