### PR TITLE
chore: dial file format with additional brackets supported

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/metaschemas/DialFileFormat.java
+++ b/config/src/main/java/com/epam/aidial/core/metaschemas/DialFileFormat.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 public class DialFileFormat implements Format {
 
-    private static final Pattern PATTERN = Pattern.compile("^files/([a-zA-Z0-9]+)/((?:(?:[a-zA-Z0-9_\\-.~]|%[a-zA-Z0-9]{2})+/?)+)$");
+    private static final Pattern PATTERN = Pattern.compile("^files/([a-zA-Z0-9]+)/((?:(?:[a-zA-Z0-9()_\\-.~]|%[a-zA-Z0-9]{2})+/?)+)$");
 
     @Override
     public boolean matches(ExecutionContext executionContext, ValidationContext validationContext, JsonNode value) {

--- a/config/src/test/java/com/epam/aidial/core/metaschemas/DialFileFormatTest.java
+++ b/config/src/test/java/com/epam/aidial/core/metaschemas/DialFileFormatTest.java
@@ -61,6 +61,17 @@ public class DialFileFormatTest {
     }
 
     @Test
+    void sampleApplicationWithRealFilenameWithBraces_validatesAgainstSchema_ok() throws Exception {
+        JsonNode customSchemaNode = MAPPER.readTree(customSchemaStr);
+        JsonSchema customSchema = schemaFactory.getSchema(customSchemaNode);
+        String sampleObjectStr = "{ \"file\": \"files/2pSUd9nfm2gTvgY9ZXj1Z5cSprWyXp8YpDR2EF1pzUxDxNDmKxBx4dK9BRT8xiHgXp/(TechDoc)%20WalletManager%20Overview.svg\" }";
+        JsonNode sampleObjectNode = MAPPER.readTree(sampleObjectStr);
+        Set<ValidationMessage> customSchemaValidationMessages = customSchema.validate(sampleObjectNode);
+        assertTrue(customSchemaValidationMessages.isEmpty(), "Sample app should be valid against custom schema");
+    }
+
+
+    @Test
     void sampleApplication_validatesAgainstSchema_failed_wrongBucket() throws Exception {
         JsonNode customSchemaNode = MAPPER.readTree(customSchemaStr);
         JsonSchema customSchema = schemaFactory.getSchema(customSchemaNode);


### PR DESCRIPTION
Added support for file URLs like the following: files/2pSUd9nfm2gTvgY9ZXj1Z5cSprWyXp8YpDR2EF1pzUxDxNDmKxBx4dK9BRT8xiHgXp/(TechDoc)%20WalletManager%20Overview.svg 

It is not 100% valid percent-encoding, but it must be so because dial-chat doesn't replace brackets.
