### PR TITLE
feat: Allow nested objects inside of usage field

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/token/TokenUsage.java
+++ b/server/src/main/java/com/epam/aidial/core/server/token/TokenUsage.java
@@ -1,13 +1,19 @@
 package com.epam.aidial.core.server.token;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.math.BigDecimal;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TokenUsage {
+    @JsonAlias({"completion_tokens", "completionTokens"})
     private long completionTokens;
+    @JsonAlias({"prompt_tokens", "promptTokens"})
     private long promptTokens;
+    @JsonAlias({"total_tokens", "totalTokens"})
     private long totalTokens;
     private BigDecimal cost;
     private BigDecimal aggCost;

--- a/server/src/main/java/com/epam/aidial/core/server/token/TokenUsageParser.java
+++ b/server/src/main/java/com/epam/aidial/core/server/token/TokenUsageParser.java
@@ -1,16 +1,9 @@
 package com.epam.aidial.core.server.token;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
+import com.epam.aidial.core.server.util.ProxyUtil;
 import io.vertx.core.buffer.Buffer;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-
-import java.io.InputStream;
-import java.util.Arrays;
 
 @Slf4j
 @UtilityClass
@@ -25,61 +18,15 @@ public class TokenUsageParser {
         }
     }
 
-    private TokenUsage parseUsage(Buffer body) throws Exception {
+    private TokenUsage parseUsage(Buffer body) {
         int index = findUsage(body);
         if (index < 0) {
             return null;
         }
 
-        ByteBuf slice = body.slice(index, body.length()).getByteBuf();
-        JsonFactory factory = new JsonFactory();
+        Buffer slice = body.slice(index, body.length());
 
-        try (InputStream stream = new ByteBufInputStream(slice); JsonParser parser = factory.createParser(stream)) {
-            TokenUsage usage = new TokenUsage();
-            verify(parser.nextToken(), JsonToken.START_OBJECT);
-
-            while (true) {
-                JsonToken token = parser.nextToken();
-                if (token == JsonToken.END_OBJECT) {
-                    return usage;
-                }
-
-                verify(token, JsonToken.FIELD_NAME);
-                String name = parser.getCurrentName();
-
-                token = parser.nextValue();
-                verify(token,
-                        JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT,
-                        JsonToken.VALUE_STRING, JsonToken.VALUE_NULL,
-                        JsonToken.VALUE_FALSE, JsonToken.VALUE_TRUE,
-                        JsonToken.START_OBJECT);
-
-                if (token == JsonToken.START_OBJECT) {
-                    // Skip the nested object with token details
-                    int depth = 1;
-                    while (depth > 0) {
-                        JsonToken nextToken = parser.nextToken();
-                        if (nextToken == null) {
-                            throw new IllegalStateException("Usage nested object is malformed");
-                        } else if (nextToken == JsonToken.START_OBJECT) {
-                            depth++;
-                        } else if (nextToken == JsonToken.END_OBJECT) {
-                            depth--;
-                        }
-                    }
-                    continue;
-                }
-
-                switch (name) {
-                    case "completion_tokens" -> usage.setCompletionTokens(parser.getLongValue());
-                    case "prompt_tokens" -> usage.setPromptTokens(parser.getLongValue());
-                    case "total_tokens" -> usage.setTotalTokens(parser.getLongValue());
-                    default -> {
-                        // ignore
-                    }
-                }
-            }
-        }
+        return ProxyUtil.convertToObject(slice, TokenUsage.class);
     }
 
     private int findUsage(Buffer body) {
@@ -128,13 +75,4 @@ public class TokenUsageParser {
         };
     }
 
-    private void verify(JsonToken actual, JsonToken... expected) {
-        for (JsonToken candidate : expected) {
-            if (candidate == actual) {
-                return;
-            }
-        }
-
-        throw new IllegalArgumentException("Actual: " + actual + "Expected: " + Arrays.toString(expected));
-    }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/token/TokenUsageParser.java
+++ b/server/src/main/java/com/epam/aidial/core/server/token/TokenUsageParser.java
@@ -51,7 +51,24 @@ public class TokenUsageParser {
                 verify(token,
                         JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT,
                         JsonToken.VALUE_STRING, JsonToken.VALUE_NULL,
-                        JsonToken.VALUE_FALSE, JsonToken.VALUE_TRUE);
+                        JsonToken.VALUE_FALSE, JsonToken.VALUE_TRUE,
+                        JsonToken.START_OBJECT);
+
+                if (token == JsonToken.START_OBJECT) {
+                    // Skip the nested object with token details
+                    int depth = 1;
+                    while (depth > 0) {
+                        JsonToken nextToken = parser.nextToken();
+                        if (nextToken == null) {
+                            throw new IllegalStateException("Usage nested object is malformed");
+                        } else if (nextToken == JsonToken.START_OBJECT) {
+                            depth++;
+                        } else if (nextToken == JsonToken.END_OBJECT) {
+                            depth--;
+                        }
+                    }
+                    continue;
+                }
 
                 switch (name) {
                     case "completion_tokens" -> usage.setCompletionTokens(parser.getLongValue());

--- a/server/src/test/java/com/epam/aidial/core/server/token/TokenUsageParserTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/token/TokenUsageParserTest.java
@@ -155,6 +155,47 @@ class TokenUsageParserTest {
                 """, 26, 226, 252);
     }
 
+    @Test
+    void testValidResponseWithDetails() {
+        valid("""
+                {
+                  "id": "eb69ae53-055b-4182-af8f-47f5f3ce810c",
+                  "object": "chat.completion",
+                  "created": 1687222196,
+                  "model": "gpt-4o-2024-05-13",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": "some content",
+                        "refusal": null
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 1420,
+                    "completion_tokens": 119,
+                    "total_tokens": 1539,
+                    "prompt_tokens_details": {
+                      "cached_tokens": 0,
+                      "audio_tokens": 0
+                    },
+                    "completion_tokens_details": {
+                      "reasoning_tokens": 0,
+                      "audio_tokens": 0,
+                      "accepted_prediction_tokens": 0,
+                      "rejected_prediction_tokens": 0,
+                      "some_custom_field": {
+                        "some_nested_field": "some_value"
+                      }
+                    }
+                  }
+                }
+                """, 119, 1420, 1539);
+    }
+
     private void valid(String body, long completion, long prompt, long total) {
         TokenUsage usage = TokenUsageParser.parse(Buffer.buffer(body));
         Assertions.assertNotNull(usage);

--- a/server/src/test/java/com/epam/aidial/core/server/token/TokenUsageParserTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/token/TokenUsageParserTest.java
@@ -175,6 +175,7 @@ class TokenUsageParserTest {
                     }
                   ],
                   "usage": {
+                    "foo": [{"a": {}}],
                     "prompt_tokens": 1420,
                     "completion_tokens": 119,
                     "total_tokens": 1539,


### PR DESCRIPTION
With changes in OpenAI API we can have nested field "completion_tokens_details"

```json
"usage": {
               "prompt_tokens": 1234,
               "completion_tokens_details": {
                      "reasoning_tokens": 0,
                      "audio_tokens": 0,
                      "accepted_prediction_tokens": 0,
                      "rejected_prediction_tokens": 0,
                      "some_custom_field": {
                        "some_nested_field": "some_value"
                      }
                    }
}
```

Current logic just returned zero token usage

```json
{
    "apiType": "DialOpenAI",
    "chat": {
        "id": ""
    },
...
    "token_usage": {
        "completion_tokens": 0,
        "prompt_tokens": 0,
        "total_tokens": 0,
        "deployment_price": 0.00000,
        "price": 0.00000
    },
...
}
```


That's due to the fact, that nested objects are not allowed inside of "usage" field, which resulted into exception from

```java
verify(token,
                        JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT,
                        JsonToken.VALUE_STRING, JsonToken.VALUE_NULL,
                        JsonToken.VALUE_FALSE, JsonToken.VALUE_TRUE);
```

but was ignored inside of 
```java
    public TokenUsage parse(Buffer body) {
        try {
            return parseUsage(body);
        } catch (Throwable e) {
            log.warn("Can't parse token usage: {}", e.getMessage());
            return null;
        }
    }
```