### PR TITLE
chore: use etag generated by blob storage provider

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -120,7 +120,7 @@ public class AiDial {
             LockService lockService = new LockService(redis, storage.getPrefix());
             TimerService timerService = new VertxTimerService(vertx);
             ResourceService.Settings resourceServiceSettings = Json.decodeValue(settings("resources").toBuffer(), ResourceService.Settings.class);
-            resourceService = new ResourceService(timerService, redis, storage, lockService, generator, resourceServiceSettings, storage.getPrefix());
+            resourceService = new ResourceService(timerService, redis, storage, lockService, resourceServiceSettings, storage.getPrefix());
             InvitationService invitationService = new InvitationService(resourceService, encryptionService, settings("invitations"));
             ApiKeyStore apiKeyStore = new ApiKeyStore(resourceService, vertx);
             ConfigStore configStore = new FileConfigStore(vertx, settings("config"), apiKeyStore);

--- a/server/src/test/java/com/epam/aidial/core/server/FileApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/FileApiTest.java
@@ -18,12 +18,14 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 import java.util.stream.IntStream;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -512,7 +514,6 @@ public class FileApiTest extends ResourceBaseTest {
         WebClient client = WebClient.create(vertx);
 
         byte[] content = new byte[(int) (BlobWriteStream.MIN_PART_SIZE_BYTES * 1.5)];
-        String etag = "0123";
         IntStream.range(0, content.length).forEach(i -> content[i] = (byte) i);
         Future.succeededFuture().compose((mapper) -> {
             Promise<Void> promise = Promise.promise();
@@ -560,12 +561,12 @@ public class FileApiTest extends ResourceBaseTest {
                                                "resourceType" : "FILE",
                                                "createdAt" : "@ignore",
                                                "updatedAt" : "@ignore",
-                                               "etag" : "0123",
+                                               "etag" : "@ignore",
                                                "contentLength" : 7864320,
                                                "contentType" : "application/x-binary"
                                              }
                                             """, response.body());
-                                    assertEquals(etag, response.getHeader(HttpHeaders.ETAG));
+                                    Assertions.assertNotNull(response.getHeader(HttpHeaders.ETAG));
 
                                     checkpoint.flag();
                                     promise.complete();
@@ -583,7 +584,7 @@ public class FileApiTest extends ResourceBaseTest {
                     .send(context.succeeding(response -> context.verify(() -> {
                         assertEquals(200, response.statusCode());
                         assertArrayEquals(content, response.body().getBytes());
-                        assertEquals(etag, response.getHeader(HttpHeaders.ETAG));
+                        Assertions.assertNotNull(response.getHeader(HttpHeaders.ETAG));
                         checkpoint.flag();
                         promise.complete();
                     })));
@@ -607,7 +608,7 @@ public class FileApiTest extends ResourceBaseTest {
                                    "resourceType" : "FILE",
                                    "createdAt" : "@ignore",
                                    "updatedAt" : "@ignore",
-                                   "etag" : "0123",
+                                   "etag" : "@ignore",
                                    "author" : "EPM-RTC-RAIL",
                                    "contentLength" : 7864320,
                                    "contentType" : "application/x-binary"
@@ -753,7 +754,7 @@ public class FileApiTest extends ResourceBaseTest {
                   "url" : "files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.bin",
                   "action" : "CREATE",
                   "timestamp" : "@ignore",
-                  "etag" : "0123"
+                  "etag" : "@ignore"
                 }
                 """, events.take());
         verifyJsonNotExact("""
@@ -761,7 +762,7 @@ public class FileApiTest extends ResourceBaseTest {
                   "url" : "files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/file.bin",
                   "action" : "UPDATE",
                   "timestamp" : "@ignore",
-                  "etag" : "0124"
+                  "etag" : "@ignore"
                 }
                 """, events.take());
         verifyJsonNotExact("""

--- a/server/src/test/java/com/epam/aidial/core/server/limiter/RateLimiterTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/limiter/RateLimiterTest.java
@@ -106,7 +106,7 @@ public class RateLimiterTest {
         LockService lockService = new LockService(redissonClient, null);
         ResourceService.Settings settings = new ResourceService.Settings(64 * 1048576, 1048576, 60000, 120000, 4096, 300000, 256);
         ResourceService resourceService = new ResourceService(mock(TimerService.class), redissonClient, blobStorage,
-                lockService, () -> "123", settings, null);
+                lockService, settings, null);
         rateLimiter = new RateLimiter(vertx, resourceService);
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/security/ApiKeyStoreTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/security/ApiKeyStoreTest.java
@@ -96,7 +96,7 @@ public class ApiKeyStoreTest {
         LockService lockService = new LockService(redissonClient, null);
         ResourceService.Settings settings = new ResourceService.Settings(64 * 1048576, 1048576, 60000, 120000, 4096, 300000, 256);
         ResourceService resourceService = new ResourceService(mock(TimerService.class), redissonClient, blobStorage,
-                lockService, () -> "123", settings, null);
+                lockService, settings, null);
         store = new ApiKeyStore(resourceService, vertx);
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/token/TokenStatsTrackerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/token/TokenStatsTrackerTest.java
@@ -95,7 +95,7 @@ public class TokenStatsTrackerTest {
         LockService lockService = new LockService(redissonClient, null);
         ResourceService.Settings settings = new ResourceService.Settings(64 * 1048576, 1048576, 60000, 120000, 4096, 300000, 256);
         ResourceService resourceService = new ResourceService(mock(TimerService.class), redissonClient, blobStorage,
-                lockService, () -> "123", settings, null);
+                lockService, settings, null);
         tracker = new TokenStatsTracker(vertx, resourceService);
     }
 

--- a/storage/src/main/java/com/epam/aidial/core/storage/blobstore/BlobStorage.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/blobstore/BlobStorage.java
@@ -106,8 +106,8 @@ public class BlobStorage implements Closeable {
      * This method must be called after all parts/chunks uploaded
      */
     @SuppressWarnings("UnstableApiUsage") // multipart upload uses beta API
-    public void completeMultipartUpload(MultipartUpload multipart, List<MultipartPart> parts) {
-        blobStore.completeMultipartUpload(multipart, parts);
+    public String completeMultipartUpload(MultipartUpload multipart, List<MultipartPart> parts) {
+        return blobStore.completeMultipartUpload(multipart, parts);
     }
 
     /**

--- a/storage/src/main/java/com/epam/aidial/core/storage/data/ResourceUpload.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/data/ResourceUpload.java
@@ -18,17 +18,15 @@ public class ResourceUpload {
     private final MultipartUpload multipartUpload;
     private final BlobStorage blobStorage;
     private final List<MultipartPart> parts = new ArrayList<>();
-    private final String etag;
     private final String contentType;
     private final long updatedAt;
     private final long createdAt;
     private long contentLength;
     private int chunkNumber = 0;
 
-    public ResourceUpload(BlobStorage blobStorage, MultipartUpload mpu, String etag, String contentType, long createdAt, long updatedAt) {
+    public ResourceUpload(BlobStorage blobStorage, MultipartUpload mpu, String contentType, long createdAt, long updatedAt) {
         this.multipartUpload = mpu;
         this.blobStorage = blobStorage;
-        this.etag = etag;
         this.contentType = contentType;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -854,7 +854,9 @@ public class ResourceService implements AutoCloseable {
 
     private static Map<String, String> toUserMetadata(String etag, Long createdAt, Long updatedAt, String resourceType, String author) {
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(ETAG_ATTRIBUTE, etag);
+        if (etag != null) {
+            metadata.put(ETAG_ATTRIBUTE, etag);
+        }
         if (createdAt != null) {
             metadata.put(CREATED_AT_ATTRIBUTE, Long.toString(createdAt));
         }

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -873,7 +873,7 @@ public class ResourceService implements AutoCloseable {
 
     private static String extractEtag(BlobMetadata meta) {
         Map<String, String> attributes = meta.getUserMetadata();
-        return attributes.computeIfAbsent(ETAG_ATTRIBUTE, key -> meta.getETag());
+        return attributes.getOrDefault(ETAG_ATTRIBUTE, meta.getETag());
     }
 
     @Builder

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -52,7 +52,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 @Slf4j
@@ -107,7 +106,6 @@ public class ResourceService implements AutoCloseable {
                            RedissonClient redis,
                            BlobStorage blobStore,
                            LockService lockService,
-                           Supplier<String> etagGenerator,
                            Settings settings,
                            String prefix) {
         this.redis = redis;

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -91,7 +91,6 @@ public class ResourceService implements AutoCloseable {
     private final RedissonClient redis;
     private final BlobStorage blobStore;
     private final LockService lockService;
-    private final Supplier<String> etagGenerator;
     private final ResourceTopic topic;
     @Getter
     private final int maxSize;
@@ -114,7 +113,6 @@ public class ResourceService implements AutoCloseable {
         this.redis = redis;
         this.blobStore = blobStore;
         this.lockService = lockService;
-        this.etagGenerator = etagGenerator;
         this.topic = new ResourceTopic(redis, "resource:" + BlobStorageUtil.toStoragePath(prefix, "topic"));
         this.maxSize = settings.maxSize;
         this.maxSizeToCache = settings.maxSizeToCache();
@@ -373,7 +371,7 @@ public class ResourceService implements AutoCloseable {
 
             Payload payload = blob.getPayload();
             BlobMetadata metadata = blob.getMetadata();
-            String etag = extractEtag(metadata.getUserMetadata());
+            String etag = extractEtag(metadata);
             String contentType = metadata.getContentMetadata().getContentType();
             Long length = metadata.getContentMetadata().getContentLength();
 
@@ -467,10 +465,9 @@ public class ResourceService implements AutoCloseable {
 
             long updatedAt = time();
             long createdAt = metadata == null ? updatedAt : metadata.getCreatedAt();
-            String newEtag = etagGenerator.get();
-            Map<String, String> userMetadata = toUserMetadata(newEtag, createdAt, updatedAt, resource.getType().name(), author);
+            Map<String, String> userMetadata = toUserMetadata(null, createdAt, updatedAt, resource.getType().name(), author);
             MultipartUpload mpu = blobStore.initMultipartUpload(resource.getAbsoluteFilePath(), contentType, userMetadata);
-            return new ResourceUpload(blobStore, mpu, newEtag, contentType, createdAt, updatedAt);
+            return new ResourceUpload(blobStore, mpu, contentType, createdAt, updatedAt);
         }
     }
 
@@ -487,9 +484,8 @@ public class ResourceService implements AutoCloseable {
 
             long updatedAt = resourceUpload.getUpdatedAt();
             Long createdAt = resourceUpload.getCreatedAt();
-            String etag = resourceUpload.getEtag();
 
-            blobStore.completeMultipartUpload(multipartUpload, resourceUpload.getParts());
+            String etag = blobStore.completeMultipartUpload(multipartUpload, resourceUpload.getParts());
 
             ResourceEvent.Action action = metadata == null
                     ? ResourceEvent.Action.CREATE
@@ -698,7 +694,7 @@ public class ResourceService implements AutoCloseable {
 
     @SneakyThrows
     private static Result blobToResult(Blob blob, BlobMetadata meta) {
-        String etag = extractEtag(meta.getUserMetadata());
+        String etag = extractEtag(meta);
         String contentType = meta.getContentMetadata().getContentType();
         Long contentLength = meta.getContentMetadata().getContentLength();
         Long createdAt = meta.getUserMetadata().containsKey(CREATED_AT_ATTRIBUTE)
@@ -877,8 +873,9 @@ public class ResourceService implements AutoCloseable {
         return metadata;
     }
 
-    private static String extractEtag(Map<String, String> attributes) {
-        return attributes.getOrDefault(ETAG_ATTRIBUTE, DEFAULT_ETAG);
+    private static String extractEtag(BlobMetadata meta) {
+        Map<String, String> attributes = meta.getUserMetadata();
+        return attributes.computeIfAbsent(ETAG_ATTRIBUTE, key -> meta.getETag());
     }
 
     @Builder


### PR DESCRIPTION
Use Etag to be calculated by blob storage provider instead of generating a new one per request