### PR TITLE
feat: Allow sequential calls of schema-rich applications, enabling access to their containing files during completion calls

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -223,22 +223,20 @@ public class AccessService {
 
     public Map<ResourceDescriptor, Set<ResourceAccessType>> getOwnResourcesAccessForChainedSchemaRichApplication(
             Set<ResourceDescriptor> resources, ProxyContext context) {
-        if (!(context.getDeployment() instanceof Application application)) {
-            return Map.of();
-        }
-        if (!application.hasApplicationTypeSchemaId()) {
-            return Map.of();
-        }
-        List<ResourceDescriptor> applicationFiles = ApplicationTypeSchemaUtils.getFiles(context.getConfig(), application, context.getProxy().getEncryptionService(),
-                context.getProxy().getResourceService());
-        String location = BucketBuilder.buildInitiatorBucket(context);
-        Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
-        for (ResourceDescriptor resource : resources) {
-            if (resource.getBucketLocation().equals(location) && applicationFiles.contains(resource)) {
-                result.put(resource, ResourceAccessType.READ_ONLY);
+        if (context.getDeployment() instanceof Application application && application.hasApplicationTypeSchemaId()) {
+            List<ResourceDescriptor> applicationFiles = ApplicationTypeSchemaUtils.getFiles(context.getConfig(), application, context.getProxy().getEncryptionService(),
+                    context.getProxy().getResourceService());
+            String location = BucketBuilder.buildInitiatorBucket(context);
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
+            for (ResourceDescriptor resource : resources) {
+                if (resource.getBucketLocation().equals(location) && applicationFiles.contains(resource)) {
+                    result.put(resource, ResourceAccessType.READ_ONLY);
+                }
             }
+            return result;
+        } else {
+            return Map.of();
         }
-        return result;
     }
 
     public static Map<ResourceDescriptor, Set<ResourceAccessType>> getAppResourceAccess(

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -233,6 +233,7 @@ public class AccessService {
                     result.put(resource, ResourceAccessType.READ_ONLY);
                 }
             }
+
             return result;
         } else {
             return Map.of();

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -233,7 +233,6 @@ public class AccessService {
                     result.put(resource, ResourceAccessType.READ_ONLY);
                 }
             }
-
             return result;
         } else {
             return Map.of();

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server.security;
 
+import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.AutoSharedData;
 import com.epam.aidial.core.server.data.ResourceTypes;
@@ -7,6 +8,7 @@ import com.epam.aidial.core.server.data.Rule;
 import com.epam.aidial.core.server.service.PublicationService;
 import com.epam.aidial.core.server.service.RuleService;
 import com.epam.aidial.core.server.service.ShareService;
+import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
 import com.epam.aidial.core.server.util.BucketBuilder;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
@@ -47,7 +49,8 @@ public class AccessService {
             this::getReviewAccess,
             this::getPublicAccess,
             this::getSharedAccess,
-            AccessService::getAppSelfAccess);
+            AccessService::getAppSelfAccess,
+            this::getOwnResourcesAccessForChainedSchemaRichApplication);
 
     public AccessService(EncryptionService encryptionService,
                          ShareService shareService,
@@ -215,6 +218,26 @@ public class AccessService {
             }
         }
 
+        return result;
+    }
+
+    private Map<ResourceDescriptor, Set<ResourceAccessType>> getOwnResourcesAccessForChainedSchemaRichApplication(
+            Set<ResourceDescriptor> resources, ProxyContext context) {
+        if (!(context.getDeployment() instanceof Application application)) {
+            return Map.of();
+        }
+        if (!application.hasApplicationTypeSchemaId()) {
+            return Map.of();
+        }
+        List<ResourceDescriptor> applicationFiles = ApplicationTypeSchemaUtils.getFiles(context.getConfig(), application, context.getProxy().getEncryptionService(),
+                context.getProxy().getResourceService());
+        String location = BucketBuilder.buildInitiatorBucket(context);
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
+        for (ResourceDescriptor resource : resources) {
+            if (resource.getBucketLocation().equals(location) && applicationFiles.contains(resource)) {
+                result.put(resource, ResourceAccessType.READ_ONLY);
+            }
+        }
         return result;
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -221,7 +221,7 @@ public class AccessService {
         return result;
     }
 
-    private Map<ResourceDescriptor, Set<ResourceAccessType>> getOwnResourcesAccessForChainedSchemaRichApplication(
+    public Map<ResourceDescriptor, Set<ResourceAccessType>> getOwnResourcesAccessForChainedSchemaRichApplication(
             Set<ResourceDescriptor> resources, ProxyContext context) {
         if (!(context.getDeployment() instanceof Application application)) {
             return Map.of();

--- a/server/src/test/java/com/epam/aidial/core/server/service/AccessServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/AccessServiceTest.java
@@ -234,7 +234,7 @@ public class AccessServiceTest {
 
 
         try (MockedStatic<ApplicationTypeSchemaUtils> appSchemaUtilsMock = Mockito.mockStatic(ApplicationTypeSchemaUtils.class);
-               MockedStatic<BucketBuilder> bucketBuilderMock = Mockito.mockStatic(BucketBuilder.class)) {
+                MockedStatic<BucketBuilder> bucketBuilderMock = Mockito.mockStatic(BucketBuilder.class)) {
 
             List<ResourceDescriptor> applicationFiles = List.of(resource);
             appSchemaUtilsMock.when(() -> ApplicationTypeSchemaUtils.getFiles(

--- a/server/src/test/java/com/epam/aidial/core/server/service/AccessServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/AccessServiceTest.java
@@ -1,16 +1,24 @@
 package com.epam.aidial.core.server.service;
 
+import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.data.ResourceTypes;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
+import com.epam.aidial.core.server.util.BucketBuilder;
 import com.epam.aidial.core.storage.data.ResourceAccessType;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.service.ResourceService;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -204,5 +212,90 @@ public class AccessServiceTest {
                 }
                 """));
         assertTrue(service.canCreateCodeApps(context));
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_ApplicationHasTypeSchemaId() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(true);
+        when(context.getDeployment()).thenReturn(application);
+
+        String initiatorBucket = "Users/user-sub-id/";
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", initiatorBucket, false);
+
+        Config config = mock(Config.class);
+        when(context.getConfig()).thenReturn(config);
+
+        Proxy proxy = mock(Proxy.class);
+        when(context.getProxy()).thenReturn(proxy);
+        when(proxy.getEncryptionService()).thenReturn(encryptionService);
+        ResourceService resourceService = mock(ResourceService.class);
+        when(proxy.getResourceService()).thenReturn(resourceService);
+
+
+        try (MockedStatic<ApplicationTypeSchemaUtils> appSchemaUtilsMock = Mockito.mockStatic(ApplicationTypeSchemaUtils.class);
+               MockedStatic<BucketBuilder> bucketBuilderMock = Mockito.mockStatic(BucketBuilder.class)) {
+
+            List<ResourceDescriptor> applicationFiles = List.of(resource);
+            appSchemaUtilsMock.when(() -> ApplicationTypeSchemaUtils.getFiles(
+                            config, application, encryptionService, resourceService))
+                    .thenReturn(applicationFiles);
+
+            bucketBuilderMock.when(() -> BucketBuilder.buildInitiatorBucket(context))
+                    .thenReturn(initiatorBucket);
+
+            AccessService accessService = new AccessService(encryptionService, shareService, ruleService,
+                    new JsonObject("""
+                            {
+                             "admin": {
+                                "rules": [{"source": "roles", "function": "EQUAL", "targets": ["admin"]}]
+                             },
+                             "createCodeAppRoles": ["admin"]
+                            }
+                            """));
+
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result =
+                    accessService.getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(resource), context);
+
+            assertTrue(result.containsKey(resource));
+            assertEquals(ResourceAccessType.READ_ONLY, result.get(resource));
+        }
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_ApplicationHasNoTypeSchemaId() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(false);
+        when(context.getDeployment()).thenReturn(application);
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", "Users/user/", false);
+        AccessService accessService = new AccessService(encryptionService, shareService, ruleService, new JsonObject("""
+                {
+                 "admin": {
+                    "rules": [{"source": "roles", "function": "EQUAL", "targets": ["admin"]}]
+                 },
+                 "createCodeAppRoles": ["admin"]
+                }
+                """));
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService.getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(resource), context);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_NotAnApplication() {
+        Deployment application = mock(Deployment.class);
+        when(context.getDeployment()).thenReturn(application);
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", "Users/user/", false);
+        AccessService accessService = new AccessService(encryptionService, shareService, ruleService, new JsonObject("""
+                {
+                 "admin": {
+                    "rules": [{"source": "roles", "function": "EQUAL", "targets": ["admin"]}]
+                 },
+                 "createCodeAppRoles": ["admin"]
+                }
+                """));
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService.getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(resource), context);
+
+        assertTrue(result.isEmpty());
     }
 }


### PR DESCRIPTION
### Description of changes

This PR enables schema-rich applications to be called sequentially by enabling read access to `dial:file` marked resources during completion calls to the schema-rich applications.

### Checklist

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
