### PR TITLE
fix: Application schemas with mixed property types ("oneOf" keyword and mixing arrays with plane types)

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/metaschemas/DialFileFormat.java
+++ b/config/src/main/java/com/epam/aidial/core/metaschemas/DialFileFormat.java
@@ -17,6 +17,22 @@ public class DialFileFormat implements Format {
     @Override
     public boolean matches(ExecutionContext executionContext, ValidationContext validationContext, JsonNode value) {
         JsonType nodeType = TypeFactory.getValueNodeType(value, validationContext.getConfig());
+        return switch (nodeType) {
+            case STRING -> validateStringNode(validationContext, value);
+            case ARRAY -> {
+                for (JsonNode node : value) {
+                    if (!validateStringNode(validationContext, node)) {
+                        yield false;
+                    }
+                }
+                yield true;
+            }
+            default -> false;
+        };
+    }
+
+    private static boolean validateStringNode(ValidationContext validationContext, JsonNode value) {
+        JsonType nodeType = TypeFactory.getValueNodeType(value, validationContext.getConfig());
         if (nodeType != JsonType.STRING) {
             return false;
         }

--- a/config/src/test/java/com/epam/aidial/core/metaschemas/DialFileFormatTest.java
+++ b/config/src/test/java/com/epam/aidial/core/metaschemas/DialFileFormatTest.java
@@ -19,24 +19,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DialFileFormatTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String customSchemaStr = "{"
-            + "\"$schema\": \"https://dial.epam.com/application_type_schemas/schema#\","
-            + "\"$id\": \"https://mydial.epam.com/custom_application_schemas/specific_application_type\","
-            + "\"dial:applicationTypeEditorUrl\": \"https://mydial.epam.com/specific_application_type_editor\","
-            + "\"dial:applicationTypeDisplayName\": \"Specific Application Type\","
-            + "\"dial:applicationTypeCompletionEndpoint\": \"http://specific_application_service/opeani/v1/completion\","
-            + "\"properties\": {"
-            + "  \"file\": {"
-            + "    \"type\": \"string\","
-            + "    \"format\": \"dial-file-encoded\","
-            + "    \"dial:meta\": {"
-            + "      \"dial:propertyKind\": \"client\","
-            + "      \"dial:propertyOrder\": 1"
-            + "    }"
-            + "  }"
-            + "},"
-            + "\"required\": [\"file\"]"
-            + "}";
+    private static final String customSchemaStr = """
+            {\
+            "$schema": "https://dial.epam.com/application_type_schemas/schema#",\
+            "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
+            "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
+            "dial:applicationTypeDisplayName": "Specific Application Type",\
+            "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
+            "properties": {\
+              "file": {\
+                "type": "string",\
+                "format": "dial-file-encoded",\
+                "dial:meta": {\
+                  "dial:propertyKind": "client",\
+                  "dial:propertyOrder": 1\
+                }\
+              }\
+            },\
+            "required": ["file"]\
+            }""";
     private JsonSchemaFactory schemaFactory;
 
     @BeforeEach

--- a/config/src/test/java/com/epam/aidial/core/metaschemas/MetaSchemaHolderTest.java
+++ b/config/src/test/java/com/epam/aidial/core/metaschemas/MetaSchemaHolderTest.java
@@ -42,7 +42,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -68,7 +68,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -91,7 +91,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "object",\
@@ -119,7 +119,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -146,7 +146,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -173,7 +173,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "foo": {\
                     "type": "object",\
@@ -210,7 +210,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -237,7 +237,7 @@ public class MetaSchemaHolderTest {
                 "$schema": "https://dial.epam.com/application_type_schemas/schema#",\
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -263,7 +263,7 @@ public class MetaSchemaHolderTest {
                 "$schema": "https://dial.epam.com/application_type_schemas/schema#",\
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "properties": {\
                   "file": {\
                     "type": "string",\
@@ -318,7 +318,7 @@ public class MetaSchemaHolderTest {
                 "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
                 "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
                 "dial:applicationTypeDisplayName": "Specific Application Type",\
-                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
                 "dial:applicationTypeConfigurationEndpoint": "!wrong",\
                 "dial:applicationTypeRateEndpoint": "!wrong",\
                 "dial:applicationTypeTokenizeEndpoint": "!wrong",\

--- a/config/src/test/java/com/epam/aidial/core/metaschemas/MetaSchemaHolderTest.java
+++ b/config/src/test/java/com/epam/aidial/core/metaschemas/MetaSchemaHolderTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import static com.epam.aidial.core.metaschemas.MetaSchemaHolder.CUSTOM_APPLICATION_META_SCHEMA_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetaSchemaHolderTest {
@@ -80,7 +81,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -108,7 +109,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -135,7 +136,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -162,7 +163,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -199,7 +200,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -227,7 +228,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -280,7 +281,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -307,7 +308,7 @@ public class MetaSchemaHolderTest {
         JsonNode customSchemaNode = MAPPER.readTree(invalidCustomSchemaStr);
         Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
         assertEquals(1, metaSchemaValidationMessages.size(), "Custom schema should be invalid against"
-                + " meta schema because of a single reason");
+                                                             + " meta schema because of a single reason");
     }
 
     @Test
@@ -357,6 +358,88 @@ public class MetaSchemaHolderTest {
                   "file": {\
                     "type": "string",\
                     "format": "dial-file-encoded",\
+                    "dial:meta": {\
+                      "dial:propertyKind": "client",\
+                      "dial:propertyOrder": 1\
+                    }\
+                  }\
+                },\
+                "required": ["file"]\
+                }""";
+        JsonNode customSchemaNode = MAPPER.readTree(customSchemaStr);
+        Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
+        assertTrue(metaSchemaValidationMessages.isEmpty(), "Custom schema should be valid against meta schema");
+    }
+
+
+    @Test
+    void customSchema_validatesAgainstMetaSchema_fails_wrongDialFileFormat() throws Exception {
+        final String customSchemaStr = """
+                {\
+                "$schema": "https://dial.epam.com/application_type_schemas/schema#",\
+                "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
+                "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
+                "dial:applicationTypeDisplayName": "Specific Application Type",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
+                "properties": {\
+                  "file": {\
+                    "oneOf": [\
+                        {\
+                            "type": "string",\
+                            "format": "dial-file-encoded",\
+                            "dial:file": true\
+                        },\
+                        {\
+                            "type": "array",\
+                            "items": {\
+                                "type": "string",\
+                                "dial:file": true\
+                            }\
+                        },\
+                        {\
+                            "type": "null"\
+                        }],\
+                    "dial:meta": {\
+                      "dial:propertyKind": "client",\
+                      "dial:propertyOrder": 1\
+                    }\
+                  }\
+                },\
+                "required": ["file"]\
+                }""";
+        JsonNode customSchemaNode = MAPPER.readTree(customSchemaStr);
+        Set<ValidationMessage> metaSchemaValidationMessages = jsonMetaSchema.validate(customSchemaNode);
+        assertFalse(metaSchemaValidationMessages.isEmpty(), "Custom schema should be invalid against meta schema with bad dial file format");
+    }
+
+    @Test
+    void customSchema_validatesAgainstMetaSchema_om_correctDialFileOneOfFormat() throws Exception {
+        final String customSchemaStr = """
+                {\
+                "$schema": "https://dial.epam.com/application_type_schemas/schema#",\
+                "$id": "https://mydial.epam.com/custom_application_schemas/specific_application_type",\
+                "dial:applicationTypeEditorUrl": "https://mydial.epam.com/specific_application_type_editor",\
+                "dial:applicationTypeDisplayName": "Specific Application Type",\
+                "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",\
+                "properties": {\
+                  "file": {\
+                    "oneOf": [\
+                        {\
+                            "type": "string",\
+                            "format": "dial-file-encoded",\
+                            "dial:file": true\
+                        },\
+                        {\
+                            "type": "array",\
+                            "items": {\
+                                "type": "string",\
+                                "dial:file": true,\
+                                "format": "dial-file-encoded"\
+                            }\
+                        },\
+                        {\
+                            "type": "null"\
+                        }],\
                     "dial:meta": {\
                       "dial:propertyKind": "client",\
                       "dial:propertyOrder": 1\

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
@@ -188,7 +188,7 @@ public class ResourceController extends AccessControlBaseController {
                         resourceService);
                 files.stream().filter(resource -> !(accessService.hasReadAccess(resource, context)))
                         .findAny().ifPresent(file -> {
-                            throw new HttpException(BAD_REQUEST, "No read access to file: " + file.getUrl());
+                            throw new HttpException(FORBIDDEN, "No read access to file: " + file.getUrl());
                         });
             }
         } catch (IllegalArgumentException | ValidationException e) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
@@ -182,15 +182,19 @@ public class ResourceController extends AccessControlBaseController {
     private void validateCustomApplication(Application application) {
         try {
             checkCreateCodeApp(application);
-            Config config = context.getConfig();
-            List<ResourceDescriptor> files = ApplicationTypeSchemaUtils.getFiles(config, application, encryptionService,
-                    resourceService);
-            files.stream().filter(resource -> !(accessService.hasReadAccess(resource, context)))
-                    .findAny().ifPresent(file -> {
-                        throw new HttpException(BAD_REQUEST, "No read access to file: " + file.getUrl());
-                    });
-        } catch (ValidationException | IllegalArgumentException | ApplicationTypeSchemaValidationException e) {
-            throw new HttpException(BAD_REQUEST, "Custom application validation failed", e);
+            if (application.getApplicationProperties() != null) {
+                Config config = context.getConfig();
+                List<ResourceDescriptor> files = ApplicationTypeSchemaUtils.getFiles(config, application, encryptionService,
+                        resourceService);
+                files.stream().filter(resource -> !(accessService.hasReadAccess(resource, context)))
+                        .findAny().ifPresent(file -> {
+                            throw new HttpException(BAD_REQUEST, "No read access to file: " + file.getUrl());
+                        });
+            }
+        } catch (IllegalArgumentException | ValidationException e) {
+            throw new HttpException(BAD_REQUEST, String.format("Custom application validation failed %s", e.getMessage()), e);
+        } catch (ApplicationTypeSchemaValidationException e) {
+            throw new HttpException(BAD_REQUEST, String.format("Custom application validation failed %s", e.validationMessages), e);
         } catch (ApplicationTypeResourceException e) {
             throw new HttpException(FORBIDDEN, "Failed to access application resource " + e.getResourceUri(), e);
         } catch (ApplicationTypeSchemaProcessingException e) {

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
@@ -42,7 +42,7 @@ public class CollectRequestApplicationFilesFn extends BaseRequestFunction<Object
         } catch (HttpException ex) {
             throw ex;
         } catch (ApplicationTypeResourceException ex) {
-            throw new HttpException(HttpStatus.FORBIDDEN, ex.getMessage());
+            throw new HttpException(HttpStatus.FORBIDDEN, ex.getMessage() + " : " + ex.getResourceUri());
         } catch (Exception e) {
             throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeSchemaValidationException.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/ApplicationTypeSchemaValidationException.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 @Getter
 public class ApplicationTypeSchemaValidationException extends RuntimeException {
-    private Set<ValidationMessage> validationMessages = Set.of();
+    public Set<ValidationMessage> validationMessages = Set.of();
 
     public ApplicationTypeSchemaValidationException(String message, Set<ValidationMessage> validationMessages) {
         super(message);

--- a/server/src/main/java/com/epam/aidial/core/server/validation/DialFileKeyword.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/DialFileKeyword.java
@@ -64,11 +64,15 @@ public class DialFileKeyword implements Keyword {
                 CollectorContext collectorContext = executionContext.getCollectorContext();
                 ListCollector<String> fileCollector = (ListCollector<String>) collectorContext.getCollectorMap()
                         .computeIfAbsent(ListCollector.FileCollectorType.ALL_FILES.getValue(), k -> new ListCollector<String>());
-                fileCollector.combine(List.of(jsonNode.asText()));
+                String nodeValue = jsonNode.asText();
+                if (nodeValue == null || nodeValue.isEmpty()) {
+                    return Set.of();
+                }
+                fileCollector.combine(List.of(nodeValue));
                 if (isServerProp) {
                     ListCollector<String> serverFileCollector = (ListCollector<String>) collectorContext.getCollectorMap()
                             .computeIfAbsent(ListCollector.FileCollectorType.ONLY_SERVER_FILES.getValue(), k -> new ListCollector<String>());
-                    serverFileCollector.combine(List.of(jsonNode.asText()));
+                    serverFileCollector.combine(List.of(nodeValue));
                 }
             }
             return Set.of();

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -1209,4 +1209,41 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
         Assertions.assertEquals(200, response.status());
     }
 
+    @Test
+    void testApplicationWithTypeSchemaCreationAndThenUpdate_Ok_WhenApplicationPropertiesCreatedEmptyAndThenUpdated() {
+
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "application_properties" : null,
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app_files", null, """
+                  {
+                      "displayName": "test_app",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "application_properties" : {
+                        "property1" : "test property11",
+                        "property2" : "test property21"
+                       },
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+    }
+
 }

--- a/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ApplicationTypeSchemaUtilsTest.java
@@ -410,4 +410,84 @@ public class ApplicationTypeSchemaUtilsTest {
         Assertions.assertThrows(ApplicationTypeResourceException.class, () ->
                 ApplicationTypeSchemaUtils.getServerFiles(config, application, encryptionService, resourceService));
     }
+
+    @Test
+    public void getServerFiles_returnsListOfServerFiles_whenOneOfSchema() {
+        final String schema = """
+                {
+                  "$schema" : "https://dial.epam.com/application_type_schemas/schema#",
+                  "$id" : "https://mydial.epam.com/custom_application_schemas/specific_application_type",
+                  "dial:applicationTypeEditorUrl" : "https://mydial.epam.com/specific_application_type_editor",
+                  "dial:applicationTypeDisplayName" : "Specific Application Type",
+                  "dial:applicationTypeCompletionEndpoint" : "http://specific_application_service/opeani/v1/completion",
+                  "properties" : {
+                    "clientFile" : {
+                      "type" : "string",
+                      "format" : "dial-file-encoded",
+                      "dial:meta" : {
+                        "dial:propertyKind" : "client",
+                        "dial:propertyOrder" : 1
+                      },
+                      "dial:file" : true
+                    },
+                    "serverFile" : {
+                       "oneOf": [
+                           {
+                             "type": "string",
+                             "format": "dial-file-encoded",
+                             "dial:file": true
+                           },
+                           {
+                             "type": "array",
+                             "items": {
+                               "type": "string",
+                               "dial:file": true,
+                               "format": "dial-file-encoded"
+                             }
+                           },
+                           {
+                              "type": null
+                           }
+                         ],
+                       "dial:meta": {
+                         "dial:propertyKind": "server",
+                         "dial:propertyOrder": 2
+                       }
+                    }
+                  },
+                  "required" : [ "clientFile", "serverFile" ]
+                }""";
+
+        final Map<String, Object> customServerProperties = Map.of(
+                "serverFile",
+                List.of("files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext", "files/public/valid-file-path/valid-sub-path/valid%20file%20name3.ext"));
+        final Map<String, Object> customProperties = new HashMap<>();
+        customProperties.putAll(customServerProperties);
+        customProperties.putAll(clientProperties);
+
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        application.setApplicationProperties(customProperties);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+
+        EncryptionService encryptionService = mock(EncryptionService.class);
+        ResourceService resourceService = mock(ResourceService.class);
+
+        when(resourceService.hasResource(any())).thenReturn(true);
+
+        List<ResourceDescriptor> resultServer = ApplicationTypeSchemaUtils.getServerFiles(config, application, encryptionService, resourceService);
+        List<ResourceDescriptor> resultAll = ApplicationTypeSchemaUtils.getFiles(config, application, encryptionService, resourceService);
+
+        //check server files
+        List<?> serverFiles = (List<?>) customServerProperties.get("serverFile");
+        Assertions.assertEquals(serverFiles.size(), resultServer.size());
+        for (int i = 0; i < resultServer.size(); i++) {
+            Assertions.assertEquals(serverFiles.get(i), resultServer.get(i).getUrl());
+        }
+
+        //check all files
+        Assertions.assertEquals(3, resultAll.size());
+        Assertions.assertEquals(clientProperties.get("clientFile"), resultAll.get(0).getUrl());
+        Assertions.assertEquals(serverFiles.get(0), resultAll.get(1).getUrl());
+        Assertions.assertEquals(serverFiles.get(1), resultAll.get(2).getUrl());
+    }
 }

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -185,7 +185,7 @@
       "dial:applicationTypeEditorUrl": "https://mydial.somewhere.com/custom_application_schemas/schema",
       "dial:applicationTypeViewerUrl": "https://mydial.somewhere.com/custom_application_schemas/viewer",
       "dial:applicationTypeDisplayName": "Specific Application Type",
-      "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/opeani/v1/completion",
+      "dial:applicationTypeCompletionEndpoint": "http://specific_application_service/openai/v1/completion",
       "properties": {
         "property1": {
           "title": "Property 1",


### PR DESCRIPTION
### Applicable issues

Now core does not work correctly with application schemas that contain mixed property types like
```json
"document_relative_url": {
                    "oneOf": [
                        {
                            "type": "string",
                            "format": "dial-file-encoded",
                            "dial:file": true
                        },
                        {
                            "type": "array",
                            "items": {
                                "type": "string",
                                "dial:file": true,
                                "format": "dial-file-encoded"
                            }
                        }
                    ],
                    "dial:meta": {
                        "dial:propertyKind": "server",
                        "dial:propertyOrder": 5
                    }
                }
```

### Description of changes

I added test cases for such schemas and changed the code to meet them.

### Checklist

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
