### PR TITLE
chore: enhance error handling for duplicate application resources during publication

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
@@ -759,9 +759,7 @@ public class PublicationService {
 
         String targetFolder = getTargetFolderForCustomAppFiles(pubicationResource.getTargetUrl(), encryption);
 
-        List<ResourceDescriptor> applicationsOwnDescriptors = ApplicationTypeSchemaUtils.getFiles(configStore.get(), applicationToPublish, encryption, resourceService)
-                .stream()
-                .toList();
+        List<ResourceDescriptor> applicationsOwnDescriptors = ApplicationTypeSchemaUtils.getFiles(configStore.get(), applicationToPublish, encryption, resourceService);
 
         Stream<Publication.Resource> folderDescriptors = applicationsOwnDescriptors.stream()
                 .filter(ResourceDescriptor::isFolder)

--- a/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
@@ -729,7 +729,10 @@ public class PublicationService {
         for (Publication.Resource resource : newResources) {
             String sourceUrl = resource.getSourceUrl();
             if (sourceUrlMap.containsKey(sourceUrl)) {
-                throw new HttpException(HttpStatus.BAD_REQUEST, "Duplicate source URL found: " + sourceUrl);
+                throw new HttpException(HttpStatus.BAD_REQUEST, "Handling resource twice while publishing application's own resources: " + sourceUrl);
+            }
+            if (sourceUrlsFromRequest.contains(sourceUrl)) {
+                throw new HttpException(HttpStatus.BAD_REQUEST, "Application own resource was already present in the publication request: " + sourceUrl);
             }
             sourceUrlMap.put(sourceUrl, resource);
         }
@@ -758,7 +761,6 @@ public class PublicationService {
 
         List<ResourceDescriptor> applicationsOwnDescriptors = ApplicationTypeSchemaUtils.getFiles(configStore.get(), applicationToPublish, encryption, resourceService)
                 .stream()
-                .filter(descriptor -> !otherSourceUrlsFromRequest.contains(descriptor.getUrl()))
                 .toList();
 
         Stream<Publication.Resource> folderDescriptors = applicationsOwnDescriptors.stream()

--- a/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
@@ -2325,4 +2325,65 @@ class PublicationApiTest extends ResourceBaseTest {
 
     }
 
+    @Test
+    void testApplicationWithTypeSchemaPublish_BadRequest_SchemaRichDuplicateFile() {
+
+        List<String> filePaths = List.of(
+                "Unt 26__0.0.1/generate.json",
+                "Unt 26__0.0.1/nodes/1743404608.101931_1.json",
+                "abc/Unt 26__0.0.1"
+        );
+        String basePath = "/v1/files/%s/appdata/mindmap/".formatted(bucket);
+        Response response;
+        for (String filePath : filePaths) {
+            String resourceUrl = basePath + UrlUtil.encodePath(filePath);
+            response = upload(HttpMethod.PUT, resourceUrl, null, "Test");
+            Assertions.assertEquals(200, response.status());
+        }
+
+        response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test%20app%202", null, """
+                  {
+                      "displayName": "test%20app%202",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/Unt%2026__0.0.1/",
+                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/abc/Unt%2026__0.0.1"
+                        ]
+                       },
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        response = operationRequest("/v1/ops/publication/create", """
+                {
+                      "name": "Publication of my application",
+                      "targetFolder": "public/",
+                      "resources": [
+                        {
+                          "action": "ADD",
+                          "sourceUrl": "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test%20app%202",
+                          "targetUrl": "applications/public/xyz%20app%204"
+                        },
+                        {
+                          "action": "ADD",
+                          "sourceUrl": "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/abc/Unt%2026__0.0.1",
+                          "targetUrl": "files/public/Unt%2026__0.0.1"
+                        }
+                      ]
+                    }
+                """);
+
+        verify(response, 400);
+
+    }
+
 }


### PR DESCRIPTION
### Applicable issues

If the publication request contains references to the resources from the application core, return a 500 status; however, it should return a 400 status.

### Description of changes

Changed checks and added a test

### Checklist

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
