### PR TITLE
fix: Core fails to create invitation #847

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/SharedByMeDto.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/SharedByMeDto.java
@@ -126,6 +126,9 @@ public class SharedByMeDto {
 
     @JsonIgnore
     public void updateLimit(String resourceUrl, ShareResourceLimit limit) {
+        if (limits == null) {
+            limits = new HashMap<>();
+        }
         limits.put(resourceUrl, limit);
     }
 


### PR DESCRIPTION
The issue is reproduced for any users who created invitations earlier.
