### PR TITLE
fix: Nimbus JOSE + JWT is vulnerable to DoS attacks when processing deeply nested JSON #8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ allprojects {
         resolutionStrategy {
             force 'com.google.code.gson:gson:2.11.0'
             force 'net.minidev:json-smart:2.5.2'
+            force 'com.nimbusds:nimbus-jose-jwt:10.0.2'
         }
     }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.663'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.663'
     implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.23.0'
-    implementation group: 'com.azure', name: 'azure-identity', version: '1.13.2'
+    implementation group: 'com.azure', name: 'azure-identity', version: '1.16.2'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
     implementation 'org.glassfish:jakarta.el:4.0.2'
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2' // Ensure you have Jakarta Validation API dependency


### PR DESCRIPTION
azure-identity of the version 1.16.2 has affected library nimbus-jose-jwt:10.0.1. We need to force Core to use a patched version 0.10.2