### PR TITLE
fix: dial-core returns 'Internale Server Error' if to approve publication with quick app after updating its targetUrl #883

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -145,7 +145,7 @@ public class AiDial {
             ResourceOperationService resourceOperationService = new ResourceOperationService(applicationService,
                     resourceService, invitationService, shareService, lockService);
             PublicationService publicationService = new PublicationService(encryptionService, resourceService, accessService,
-                    ruleService, notificationService, applicationService, resourceOperationService, generator, clock, configStore);
+                    ruleService, notificationService, applicationService, resourceOperationService, generator, clock);
             RateLimiter rateLimiter = new RateLimiter(vertx, resourceService);
             CodeInterpreterService codeInterpreterService = new CodeInterpreterService(vertx, redis, resourceService,
                     accessService, encryptionService, operatorService, generator, settings("codeInterpreter"));

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
@@ -41,14 +41,13 @@ import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import static com.epam.aidial.core.server.service.PublicationService.getTargetFolderForCustomAppFiles;
 
 @Slf4j
 public class ApplicationService {
@@ -97,6 +96,22 @@ public class ApplicationService {
         if (controller.isActive()) {
             long checkPeriod = settings.getLong("checkPeriod", 300000L);
             vertx.setPeriodic(checkPeriod, checkPeriod, ignore -> vertx.executeBlocking(this::checkApplications));
+        }
+    }
+
+    private static String getTargetFolderForCustomAppFiles(ResourceDescriptor target) {
+        if (target.isFolder()) {
+            throw new IllegalArgumentException("Target url must be a file");
+        }
+        if (target.getType() != ResourceTypes.APPLICATION) {
+            throw new IllegalArgumentException("Target url must be an application type");
+        }
+        String appName = target.getName();
+        String appPath = target.getParentPath();
+        if (appPath == null) {
+            return "." + appName + ResourceDescriptor.PATH_SEPARATOR;
+        } else {
+            return appPath + ResourceDescriptor.PATH_SEPARATOR + "." + appName + ResourceDescriptor.PATH_SEPARATOR;
         }
     }
 
@@ -154,10 +169,7 @@ public class ApplicationService {
             Application existing = ProxyUtil.convertToObject(json, Application.class);
             Application.Function function = application.getFunction();
 
-            if (application.getApplicationTypeSchemaId() != null && existing != null
-                    && existing.getApplicationProperties() != null && application.getApplicationProperties() == null) {
-                throw new HttpException(HttpStatus.BAD_REQUEST, "The application with schema can not be updated to the one without properties");
-            }
+            verifySchemaRichApp(application, existing);
 
             if (function != null) {
                 if (existing == null || existing.getFunction() == null) {
@@ -190,6 +202,13 @@ public class ApplicationService {
         });
 
         return Pair.of(meta, application);
+    }
+
+    private static void verifySchemaRichApp(Application application, Application existing) {
+        if (application.getApplicationTypeSchemaId() != null && existing != null
+                && existing.getApplicationProperties() != null && application.getApplicationProperties() == null) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "The application with schema can not be updated to the one without properties");
+        }
     }
 
     public void deleteApplication(ResourceDescriptor resource, EtagHeader etag) {
@@ -236,8 +255,26 @@ public class ApplicationService {
         boolean isPublicOrReview = isPublicOrReview(destination);
         String sourceFolder = (function == null) ? null : function.getSourceFolder();
 
+        Map<String, String> fileReplacementLinks;
+        List<ResourceDescriptor> sourceAppFiles = List.of();
+        List<ResourceDescriptor> destAppFiles = List.of();
+        if (isPublicOrReview) {
+            sourceAppFiles = ApplicationTypeSchemaUtils.getFiles(configStore.get(), application, encryptionService, resourceService);
+            destAppFiles = toDestAppFiles(source, destination, sourceAppFiles);
+            fileReplacementLinks = new HashMap<>();
+            for (int i = 0; i < sourceAppFiles.size(); i++) {
+                ResourceDescriptor sourceFile = sourceAppFiles.get(i);
+                ResourceDescriptor destFile = destAppFiles.get(i);
+                fileReplacementLinks.put(sourceFile.getDecodedUrl(), destFile.getUrl());
+            }
+        } else {
+            fileReplacementLinks = Map.of();
+        }
+
         resourceService.computeResource(destination, etag, author, json -> {
             Application existing = ProxyUtil.convertToObject(json, Application.class);
+
+            verifySchemaRichApp(application, existing);
 
             if (function != null) {
                 if (existing == null || existing.getFunction() == null) {
@@ -267,14 +304,67 @@ public class ApplicationService {
                 }
             }
 
+            if (isPublicOrReview) {
+                replaceLinksInAppProperties(application, fileReplacementLinks);
+            }
+
             return ProxyUtil.convertToString(application);
         });
 
-        // for public/review application source folder is equal to target folder
-        // source files are copied to read-only deployment bucket for such applications
-        if (isPublicOrReview && function != null) {
-            copyFolder(sourceFolder, function.getSourceFolder(), false);
+        if (isPublicOrReview) {
+            if (function != null) {
+                // for public/review application source folder is equal to target folder
+                // source files are copied to read-only deployment bucket for such applications
+                copyFolder(sourceFolder, function.getSourceFolder());
+            }
+            for (int i = 0; i < sourceAppFiles.size(); i++) {
+                ResourceDescriptor sourceFile = sourceAppFiles.get(i);
+                ResourceDescriptor destFile = destAppFiles.get(i);
+                if (sourceFile.isFolder()) {
+                    resourceService.copyFolder(sourceFile, destFile, false);
+                } else {
+                    resourceService.copyResource(source, destFile);
+                }
+            }
         }
+    }
+
+    private static List<ResourceDescriptor> toDestAppFiles(ResourceDescriptor source, ResourceDescriptor dest, List<ResourceDescriptor> sourceAppFiles) {
+        if (sourceAppFiles.isEmpty()) {
+            return List.of();
+        }
+        String targetFolder = getTargetFolderForCustomAppFiles(dest);
+        List<ResourceDescriptor> result = new ArrayList<>();
+        if (isPublicOrReview(source)) {
+            for (ResourceDescriptor file : sourceAppFiles) {
+                String path = targetFolder + file.getName();
+                if (file.isFolder()) {
+                    path += ResourceDescriptor.PATH_SEPARATOR;
+                }
+                ResourceDescriptor target = ResourceDescriptorFactory.fromDecoded(
+                        ResourceTypes.FILE,
+                        dest.getBucketName(),
+                        dest.getBucketLocation(),
+                        path);
+                result.add(target);
+            }
+        } else {
+            Map<String, Integer> fileNameToCount = new HashMap<>();
+            for (ResourceDescriptor file : sourceAppFiles) {
+                String fileName = createUniqueFileName(file, fileNameToCount);
+                String path = targetFolder + fileName;
+                if (file.isFolder()) {
+                    path += ResourceDescriptor.PATH_SEPARATOR;
+                }
+                ResourceDescriptor target = ResourceDescriptorFactory.fromDecoded(
+                        ResourceTypes.FILE,
+                        dest.getBucketName(),
+                        dest.getBucketLocation(),
+                        path);
+                result.add(target);
+            }
+        }
+        return result;
     }
 
     public Application redeployApplication(ProxyContext context, ResourceDescriptor resource) {
@@ -491,7 +581,7 @@ public class ApplicationService {
             // for public/review application source folder is equal to target folder
             // source files are copied to read-only deployment bucket for such applications
             if (!isPublicOrReview(resource)) {
-                copyFolder(function.getSourceFolder(), function.getTargetFolder(), false);
+                copyFolder(function.getSourceFolder(), function.getTargetFolder());
             }
 
             ApiKeyData key = new ApiKeyData();
@@ -632,15 +722,15 @@ public class ApplicationService {
         }
     }
 
-    private void copyFolder(String sourceFolderUrl, String targetFolderUrl, boolean overwrite) {
+    private void copyFolder(String sourceFolderUrl, String targetFolderUrl) {
         ResourceDescriptor sourceFolder = ResourceDescriptorFactory.fromAnyUrl(sourceFolderUrl, encryptionService);
         ResourceDescriptor targetFolder = ResourceDescriptorFactory.fromAnyUrl(targetFolderUrl, encryptionService);
-        resourceService.copyFolder(sourceFolder, targetFolder, overwrite);
+        resourceService.copyFolder(sourceFolder, targetFolder, false);
     }
 
-    private boolean deleteFolder(String folderUrl) {
+    private void deleteFolder(String folderUrl) {
         ResourceDescriptor folder = ResourceDescriptorFactory.fromAnyUrl(folderUrl, encryptionService);
-        return resourceService.deleteFolder(folder);
+        resourceService.deleteFolder(folder);
     }
 
     private static String buildMapping(String endpoint, String path) {
@@ -651,59 +741,7 @@ public class ApplicationService {
         return resource.isPublic() || PublicationService.isReviewBucket(resource);
     }
 
-    public void replaceSchemaRichAppOwnResources(Application application, String targetApplicationUrl, Map<String, String> replacementLinks) {
-        if (application.getApplicationTypeSchemaId() == null) {
-            return;
-        }
-        String targetApplicationResourceFolderUrl = getTargetFolderForCustomAppFiles(targetApplicationUrl, encryptionService);
-        replacementLinks = extractApplicationOwnResourcesMapping(application, targetApplicationResourceFolderUrl, replacementLinks);
-        applyApplicationOwnResourcesMapping(application, replacementLinks);
-    }
-
-    public Map<String, String> extractApplicationOwnResourcesMapping(Application application, String targetApplicationResourceFolderUrl, Map<String, String> replacementLinks) {
-        List<ResourceDescriptor> applicationOwnResources = ApplicationTypeSchemaUtils.getFiles(
-                configStore.get(), application, encryptionService, resourceService);
-
-        Map<String, String> resultMapping = new HashMap<>();
-
-        for (ResourceDescriptor resource : applicationOwnResources) {
-            String resourceUrl = resource.getUrl();
-            String decodedResourceUrl = UrlUtil.decodePath(resourceUrl);
-            if (resource.isFolder()) {
-                String replacement = replacementLinks.entrySet().stream()
-                        .filter(entry -> entry.getKey().startsWith(decodedResourceUrl))
-                        .map(Map.Entry::getValue)
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Missing replacement link for folder: " + resourceUrl));
-                resultMapping.put(resourceUrl, extractTargetPath(targetApplicationResourceFolderUrl, replacement) + ResourceDescriptor.PATH_SEPARATOR);
-            } else {
-                String replacement = replacementLinks.get(decodedResourceUrl);
-                if (replacement == null) {
-                    throw new IllegalStateException("Missing replacement link for file: " + resourceUrl);
-                }
-                resultMapping.put(resourceUrl, extractTargetPath(targetApplicationResourceFolderUrl, replacement));
-            }
-        }
-
-        return resultMapping;
-    }
-
-    private static String extractTargetPath(String basePath, String fullPathEncoded) {
-        String fullPath = UrlUtil.decodePath(fullPathEncoded);
-        int basePathIndex = fullPath.indexOf(basePath);
-        if (basePathIndex == -1) {
-            throw new IllegalStateException(
-                    "Base path '" + basePath + "' not found in full path '" + fullPath + "'");
-        }
-
-        String prefixPath = fullPath.substring(0, basePathIndex);
-        String relativePath = fullPath.substring(basePathIndex + basePath.length());
-        String firstComponent = relativePath.split(ResourceDescriptor.PATH_SEPARATOR, 2)[0];
-
-        return UrlUtil.encodePath(prefixPath + basePath + firstComponent);
-    }
-
-    public static void applyApplicationOwnResourcesMapping(Application application, Map<String, String> replacementLinks) {
+    public static void replaceLinksInAppProperties(Application application, Map<String, String> replacementLinks) {
         JsonNode customProperties = ProxyUtil.MAPPER.convertValue(application.getApplicationProperties(), JsonNode.class);
         replaceTextNodes(customProperties, replacementLinks, null, null);
         Map<String, Object> customPropertiesMap = ProxyUtil.MAPPER.convertValue(customProperties, new TypeReference<>() {
@@ -732,5 +770,22 @@ public class ApplicationService {
                 ((ObjectNode) parent).put(fieldName, replacement);
             }
         }
+    }
+
+    private static String createUniqueFileName(ResourceDescriptor sourceDescriptor, Map<String, Integer> fileNamesTaken) {
+        String fileName = sourceDescriptor.getName();
+        int count = fileNamesTaken.getOrDefault(fileName, 0) + 1;
+        fileNamesTaken.put(fileName, count);
+
+        if (count > 1) {
+            if (sourceDescriptor.isFolder() || !fileName.contains(".")) {
+                // File has no extension or folder
+                fileName = fileName + "_" + count;
+            } else {
+                // File has extension
+                fileName = fileName.replaceFirst("(\\.[^.]+)$", "_" + count + "$1");
+            }
+        }
+        return fileName;
     }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -334,35 +335,30 @@ public class ApplicationService {
             return List.of();
         }
         String targetFolder = getTargetFolderForCustomAppFiles(dest);
-        List<ResourceDescriptor> result = new ArrayList<>();
         if (isPublicOrReview(source)) {
-            for (ResourceDescriptor file : sourceAppFiles) {
-                String path = targetFolder + file.getName();
-                if (file.isFolder()) {
-                    path += ResourceDescriptor.PATH_SEPARATOR;
-                }
-                ResourceDescriptor target = ResourceDescriptorFactory.fromDecoded(
-                        ResourceTypes.FILE,
-                        dest.getBucketName(),
-                        dest.getBucketLocation(),
-                        path);
-                result.add(target);
-            }
+            return toDestAppFiles(dest, sourceAppFiles, targetFolder, ResourceDescriptor::getName);
         } else {
             Map<String, Integer> fileNameToCount = new HashMap<>();
-            for (ResourceDescriptor file : sourceAppFiles) {
-                String fileName = createUniqueFileName(file, fileNameToCount);
-                String path = targetFolder + fileName;
-                if (file.isFolder()) {
-                    path += ResourceDescriptor.PATH_SEPARATOR;
-                }
-                ResourceDescriptor target = ResourceDescriptorFactory.fromDecoded(
-                        ResourceTypes.FILE,
-                        dest.getBucketName(),
-                        dest.getBucketLocation(),
-                        path);
-                result.add(target);
+            Function<ResourceDescriptor, String> fn = file -> createUniqueFileName(file, fileNameToCount);
+            return toDestAppFiles(dest, sourceAppFiles, targetFolder, fn);
+        }
+    }
+
+    private static List<ResourceDescriptor> toDestAppFiles(ResourceDescriptor dest,
+                                                           List<ResourceDescriptor> sourceAppFiles, String targetFolder,
+                                                           Function<ResourceDescriptor, String> fn) {
+        List<ResourceDescriptor> result = new ArrayList<>();
+        for (ResourceDescriptor file : sourceAppFiles) {
+            String path = targetFolder + fn.apply(file);
+            if (file.isFolder()) {
+                path += ResourceDescriptor.PATH_SEPARATOR;
             }
+            ResourceDescriptor target = ResourceDescriptorFactory.fromDecoded(
+                    ResourceTypes.FILE,
+                    dest.getBucketName(),
+                    dest.getBucketLocation(),
+                    path);
+            result.add(target);
         }
         return result;
     }

--- a/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
@@ -2,7 +2,6 @@ package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.server.ProxyContext;
-import com.epam.aidial.core.server.config.ConfigStore;
 import com.epam.aidial.core.server.controller.ApplicationUtil;
 import com.epam.aidial.core.server.data.ListPublishedResourcesRequest;
 import com.epam.aidial.core.server.data.Notification;
@@ -13,17 +12,13 @@ import com.epam.aidial.core.server.data.ResourceUrl;
 import com.epam.aidial.core.server.data.Rule;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
-import com.epam.aidial.core.server.util.ApplicationTypeSchemaUtils;
 import com.epam.aidial.core.server.util.BucketBuilder;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.storage.data.MetadataBase;
-import com.epam.aidial.core.storage.data.NodeType;
 import com.epam.aidial.core.storage.data.ResourceFolderMetadata;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.data.UserMetadata;
-import com.epam.aidial.core.storage.http.HttpException;
-import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceType;
 import com.epam.aidial.core.storage.service.ResourceService;
@@ -46,7 +41,6 @@ import java.util.Set;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 @Slf4j
@@ -73,7 +67,6 @@ public class PublicationService {
     private final ResourceOperationService resourceOperationService;
     private final Supplier<String> ids;
     private final LongSupplier clock;
-    private final ConfigStore configStore;
 
     public static boolean isReviewBucket(ResourceDescriptor resource) {
         return resource.isPrivate() && resource.getBucketLocation().contains(PUBLICATIONS_NAME);
@@ -215,7 +208,7 @@ public class PublicationService {
             return encodePublications(publications);
         });
 
-        Publication publication = reference.getValue();
+        Publication publication = reference.get();
 
         if (publication.getStatus() == Publication.Status.PENDING) {
             List<Publication.Resource> resourcesToAdd = publication.getResources().stream()
@@ -431,7 +424,7 @@ public class PublicationService {
             return (publication == null) ? body : encodePublications(publications);
         });
 
-        Publication publication = reference.getValue();
+        Publication publication = reference.get();
         List<Publication.Resource> resourcesToAdd = publication.getResources().stream()
                 .filter(i -> i.getAction() == Publication.ResourceAction.ADD || i.getAction() == Publication.ResourceAction.ADD_IF_ABSENT)
                 .toList();
@@ -453,8 +446,6 @@ public class PublicationService {
         String id = UrlUtil.encodePathSegment(ids.get());
         String publicationUrl = String.join(ResourceDescriptor.PATH_SEPARATOR, "publications", bucketName, id);
         String reviewBucket = encodeReviewBucket(bucketLocation, id);
-
-        addSchemaRichApplicationFiles(publication);
 
         validatePublicationResources(context, publication, bucketName, reviewBucket, isAdmin);
 
@@ -688,7 +679,6 @@ public class PublicationService {
 
             if (from.getType() == ResourceTypes.APPLICATION) {
                 applicationService.copyApplication(from, to, null, false, app -> {
-                    applicationService.replaceSchemaRichAppOwnResources(app, to.getUrl(), replacementLinks);
                     app.setReference(ApplicationUtil.generateReference());
                     app.setIconUrl(replaceLink(replacementLinks, app.getIconUrl()));
                 });
@@ -730,7 +720,6 @@ public class PublicationService {
 
             if (from.getType() == ResourceTypes.APPLICATION) {
                 applicationService.copyApplication(from, to, publication.getDisplayAuthor(), false, app -> {
-                    applicationService.replaceSchemaRichAppOwnResources(app, to.getUrl(), replacementLinks);
                     app.setReference(ApplicationUtil.generateReference());
                     app.setIconUrl(replaceLink(replacementLinks, app.getIconUrl()));
                 });
@@ -842,173 +831,4 @@ public class PublicationService {
         return url;
     }
 
-    public void addSchemaRichApplicationFiles(Publication publication) {
-        if (publication.getResources().isEmpty()) {
-            return;
-        }
-
-        List<String> sourceUrlsFromRequest = publication.getResources().stream()
-                .map(Publication.Resource::getSourceUrl)
-                .toList();
-
-        Map<String, Integer> fileNamesTaken = new HashMap<>();
-
-        List<Publication.Resource> newResources = publication.getResources().stream()
-                .filter(resource -> resource.getAction() != Publication.ResourceAction.DELETE)
-                .filter(this::isApplicationResource)
-                .flatMap(resource -> getApplicationFilesAndFolders(resource, fileNamesTaken))
-                .toList();
-
-        // Check for duplicates in newResources (overlap folder's content with files alone)
-        Map<String, Publication.Resource> sourceUrlMap = new HashMap<>();
-        for (Publication.Resource resource : newResources) {
-            String sourceUrl = resource.getSourceUrl();
-            if (sourceUrlMap.containsKey(sourceUrl)) {
-                throw new HttpException(HttpStatus.BAD_REQUEST, "Handling resource twice while publishing application's own resources: " + sourceUrl);
-            }
-            if (sourceUrlsFromRequest.contains(sourceUrl)) {
-                throw new HttpException(HttpStatus.BAD_REQUEST, "Application own resource was already present in the publication request: " + sourceUrl);
-            }
-            sourceUrlMap.put(sourceUrl, resource);
-        }
-
-        publication.getResources().addAll(newResources);
-    }
-
-    private boolean isApplicationResource(Publication.Resource resource) {
-        ResourceDescriptor resourceDescriptor = ResourceDescriptorFactory.fromAnyUrl(resource.getSourceUrl(), encryption);
-        return !resourceDescriptor.isFolder() && resourceDescriptor.getType() == ResourceTypes.APPLICATION;
-    }
-
-    private Stream<Publication.Resource> getApplicationFilesAndFolders(Publication.Resource pubicationResource, Map<String, Integer> fileNamesTaken) {
-        ResourceDescriptor resourceToPublish = ResourceDescriptorFactory.fromAnyUrl(pubicationResource.getSourceUrl(), encryption);
-        if (resourceToPublish.getType() != ResourceTypes.APPLICATION) {
-            return Stream.empty();
-        }
-
-        Application applicationToPublish = applicationService.getApplication(resourceToPublish).getValue();
-        if (applicationToPublish.getApplicationTypeSchemaId() == null) {
-            return Stream.empty();
-        }
-
-        String targetFolder = getTargetFolderForCustomAppFiles(pubicationResource.getTargetUrl(), encryption);
-
-        List<ResourceDescriptor> applicationsOwnDescriptors = ApplicationTypeSchemaUtils.getFiles(configStore.get(), applicationToPublish, encryption, resourceService);
-
-        Stream<Publication.Resource> folderDescriptors = applicationsOwnDescriptors.stream()
-                .filter(ResourceDescriptor::isFolder)
-                .flatMap(folder -> createResourcesForFolderFiles(folder, targetFolder, fileNamesTaken, pubicationResource.getAction()));
-
-        Stream<Publication.Resource> fileDescriptors = applicationsOwnDescriptors.stream()
-                .filter(descriptor -> !descriptor.isFolder())
-                .map(file -> createResourceForStandaloneFile(file, targetFolder, fileNamesTaken, pubicationResource.getAction()));
-
-        return Stream.concat(folderDescriptors, fileDescriptors);
-    }
-
-    private Stream<Publication.Resource> createResourcesForFolderFiles(ResourceDescriptor sourceFolderDescriptor, String targetFolderUrl,
-                                                                       Map<String, Integer> fileNamesTaken, Publication.ResourceAction action) {
-        String targetSubFolderUrl = createUniqueTargetResourceUrl(sourceFolderDescriptor, targetFolderUrl, fileNamesTaken);
-        return listPrivateFilesFromFolderWithSubFolders(sourceFolderDescriptor)
-                .map(sourceFileDescriptor ->
-                        createResourceForFileInFolder(
-                                sourceFileDescriptor, sourceFolderDescriptor, targetSubFolderUrl, action)
-                );
-    }
-
-    private static Publication.Resource createResourceForStandaloneFile(ResourceDescriptor sourceFileDescriptor,
-                                                                        String targetFolderUrl,
-                                                                        Map<String, Integer> fileNamesTaken,
-                                                                        Publication.ResourceAction action) {
-        String targetUrl = createUniqueTargetResourceUrl(sourceFileDescriptor, targetFolderUrl, fileNamesTaken);
-
-        return new Publication.Resource()
-                .setAction(action)
-                .setSourceUrl(sourceFileDescriptor.getUrl())
-                .setTargetUrl(targetUrl);
-    }
-
-    private static String createUniqueTargetResourceUrl(ResourceDescriptor sourceDescriptor, String targetFolderUrl, Map<String, Integer> fileNamesTaken) {
-        String fileName = sourceDescriptor.getName();
-        int count = fileNamesTaken.getOrDefault(fileName, 0) + 1;
-        fileNamesTaken.put(fileName, count);
-
-        if (count > 1) {
-            if (sourceDescriptor.isFolder() || !fileName.contains(".")) {
-                // File has no extension or folder
-                fileName = fileName + "_" + count;
-            } else {
-                // File has extension
-                fileName = fileName.replaceFirst("(\\.[^.]+)$", "_" + count + "$1");
-            }
-        }
-
-        return ResourceDescriptorFactory.fromDecoded(
-                sourceDescriptor.getType(),
-                ResourceDescriptor.PUBLIC_BUCKET,
-                ResourceDescriptor.PATH_SEPARATOR,
-                targetFolderUrl + fileName).getUrl();
-    }
-
-    private static Publication.Resource createResourceForFileInFolder(ResourceDescriptor sourceFileDescriptor,
-                                                                      ResourceDescriptor sourceFolderDescriptor,
-                                                                      String targetFolderUrl,
-                                                                      Publication.ResourceAction action) {
-        String relativeFilePath = sourceFolderDescriptor.getRelativePath(sourceFileDescriptor);
-        String targetUrl = targetFolderUrl + ResourceDescriptor.PATH_SEPARATOR + relativeFilePath;
-        return new Publication.Resource()
-                .setAction(action)
-                .setSourceUrl(sourceFileDescriptor.getUrl())
-                .setTargetUrl(targetUrl);
-    }
-
-    public Stream<ResourceDescriptor> listPrivateFilesFromFolderWithSubFolders(ResourceDescriptor folderDescriptor) {
-        if (!folderDescriptor.isFolder()) {
-            return Stream.empty();
-        }
-
-        List<ResourceDescriptor> fileDescriptors = new ArrayList<>();
-        String nextToken = null;
-
-        do {
-            try {
-                ResourceFolderMetadata folderMetadata =
-                        resourceService.getFolderMetadata(folderDescriptor, nextToken, 1000, true);
-
-                if (folderMetadata == null || folderMetadata.getItems() == null) {
-                    break;
-                }
-
-                // Process all files in this page
-                folderMetadata.getItems().stream()
-                        .filter(item -> item.getNodeType() != NodeType.FOLDER)
-                        .map(item -> ResourceDescriptorFactory.fromPrivateUrl(item.getUrl(), encryption))
-                        .forEach(fileDescriptors::add);
-
-                nextToken = folderMetadata.getNextToken();
-            } catch (Exception e) {
-                log.warn("Failed to list files in folder while publishing: {}", folderDescriptor.getUrl(), e);
-                throw new RuntimeException(e);
-            }
-        } while (nextToken != null);
-
-        return fileDescriptors.stream();
-    }
-
-    public static String getTargetFolderForCustomAppFiles(String targetUrl, EncryptionService encryptionService) {
-        ResourceDescriptor targetResourceDescriptor = ResourceDescriptorFactory.fromAnyUrl(targetUrl, encryptionService);
-        if (targetResourceDescriptor.isFolder()) {
-            throw new IllegalArgumentException("Target url must be a file");
-        }
-        if (targetResourceDescriptor.getType() != ResourceTypes.APPLICATION) {
-            throw new IllegalArgumentException("Target url must be an application type");
-        }
-        String appName = targetResourceDescriptor.getName();
-        String appPath = targetResourceDescriptor.getParentPath();
-        if (appPath == null) {
-            return "." + appName + ResourceDescriptor.PATH_SEPARATOR;
-        } else {
-            return appPath + ResourceDescriptor.PATH_SEPARATOR + "." + appName + ResourceDescriptor.PATH_SEPARATOR;
-        }
-    }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
@@ -11,6 +11,7 @@ import io.vertx.core.http.HttpMethod;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -1708,25 +1709,15 @@ class PublicationApiTest extends ResourceBaseTest {
                     "sourceUrl" : "applications/%s/test_app",
                     "targetUrl" : "applications/public/folder/with_apps/test_app",
                     "reviewUrl" : "applications/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/test_app"
-                  }, {
-                    "action" : "ADD",
-                    "sourceUrl" : "files/%s/test_file.txt",
-                    "targetUrl" : "files/public/folder/with_apps/.test_app/test_file.txt",
-                    "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app/test_file.txt"
-                  }, {
-                    "action" : "ADD",
-                    "sourceUrl" : "files/%s/xyz/test_file.txt",
-                    "targetUrl" : "files/public/folder/with_apps/.test_app/test_file_2.txt",
-                    "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app/test_file_2.txt"
-                  } ],
-                  "resourceTypes" : [ "FILE", "APPLICATION" ],
+                  }],
+                  "resourceTypes" : [ "APPLICATION" ],
                   "rules" : [ {
                     "function" : "TRUE",
                     "source" : "roles",
                     "targets" : null
                   } ],
                   "author" : "EPM-RTC-GPT"
-                }""".formatted(bucket, bucket, bucket, bucket);
+                }""".formatted(bucket, bucket);
 
 
         verifyJsonNotExact(response, 200, correctResponse);
@@ -1801,44 +1792,9 @@ class PublicationApiTest extends ResourceBaseTest {
                             "sourceUrl" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app2",
                             "targetUrl" : "applications/public/folder/with_apps/test_app2",
                             "reviewUrl" : "applications/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/test_app2"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/xyz/abc/test_file1.txt",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz/abc/test_file1.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz/abc/test_file1.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/xyz/abc/test_file2.txt",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz/abc/test_file2.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz/abc/test_file2.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/xyz/test_file1.txt",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz/test_file1.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz/test_file1.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/xyz/test_file2.txt",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz/test_file2.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz/test_file2.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/some/xyz/abc/test_file1.txt",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz_2/abc/test_file1.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz_2/abc/test_file1.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/some/xyz/abc/test_file2.txt",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz_2/abc/test_file2.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz_2/abc/test_file2.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/another/xyz",
-                            "targetUrl" : "files/public/folder/with_apps/.test_app2/xyz_3",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/.test_app2/xyz_3"
                           }
                   ],
-                  "resourceTypes" : [ "APPLICATION", "FILE" ],
+                  "resourceTypes" : [ "APPLICATION" ],
                   "rules" : [ {
                     "function" : "TRUE",
                     "source" : "roles",
@@ -1883,14 +1839,6 @@ class PublicationApiTest extends ResourceBaseTest {
                 }""";
         verifyJsonNotExact(response, 200, correctResponse);
 
-        for (int i = 1; i < resources.size(); i++) {
-            reviewUrl = resources.get(i).get("reviewUrl").asText();
-            if (reviewUrl.startsWith("files/")) {
-                Response fileResponse = send(HttpMethod.GET, "/v1/" + reviewUrl, null, null, "authorization", "admin");
-                Assertions.assertEquals(200, fileResponse.status(), "File should exist at review path: " + reviewUrl);
-            }
-        }
-
         response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
         verify(response, 200);
 
@@ -1925,13 +1873,30 @@ class PublicationApiTest extends ResourceBaseTest {
         verifyJsonNotExact(response, 200, correctResponse);
 
         // After approval, verify files exist at target paths
-        for (int i = 1; i < resources.size(); i++) {
-            targetUrl = resources.get(i).get("targetUrl").asText();
-            if (targetUrl.startsWith("files/")) {
-                Response fileResponse = send(HttpMethod.GET, "/v1/" + targetUrl, null, null, "authorization", "admin");
-                Assertions.assertEquals(200, fileResponse.status(), "File should exist at target path: " + targetUrl);
+        response = send(HttpMethod.GET, "/v1/metadata/files/public/folder/with_apps/.test_app2/", "recursive=true", null, "authorization", "admin");
+        verify(response, 200);
+        responseJson = ProxyUtil.MAPPER.readTree(response.body());
+        List<String> files = new ArrayList<>();
+        for (var item : responseJson.get("items")) {
+            String url = item.get("url").textValue();
+            if (!url.endsWith("/")) {
+                files.add(url);
             }
         }
+        assertEquals(7, files.size());
+        List<String> appFiles = List.of("files/public/folder/with_apps/.test_app2/xyz/",
+                "files/public/folder/with_apps/.test_app2/xyz_2/",
+                "files/public/folder/with_apps/.test_app2/xyz_3");
+        int count = 0;
+        for (var file : files) {
+            for (var parent : appFiles) {
+                if (file.startsWith(parent)) {
+                    count++;
+                    break;
+                }
+            }
+        }
+        assertEquals(count, files.size(), "Application files are missed");
     }
 
     @Test
@@ -1991,19 +1956,9 @@ class PublicationApiTest extends ResourceBaseTest {
                             "sourceUrl" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app3",
                             "targetUrl" : "applications/public/abc_app",
                             "reviewUrl" : "applications/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/abc_app"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test.txt",
-                            "targetUrl" : "files/public/.abc_app/test.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.abc_app/test.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test/test.txt",
-                            "targetUrl" : "files/public/.abc_app/test_2.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.abc_app/test_2.txt"
                           }
                   ],
-                  "resourceTypes" : [ "APPLICATION", "FILE" ],
+                  "resourceTypes" : [ "APPLICATION" ],
                   "author" : "EPM-RTC-GPT"
                 }""";
 
@@ -2042,14 +1997,6 @@ class PublicationApiTest extends ResourceBaseTest {
                 }""";
         verifyJsonNotExact(response, 200, correctResponse);
 
-        for (int i = 1; i < resources.size(); i++) {
-            reviewUrl = resources.get(i).get("reviewUrl").asText();
-            if (reviewUrl.startsWith("files/")) {
-                response = send(HttpMethod.GET, "/v1/" + reviewUrl, null, null, "authorization", "admin");
-                Assertions.assertEquals(200, response.status(), "File should exist at review path: " + reviewUrl);
-            }
-        }
-
         response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
         verify(response, 200);
 
@@ -2080,15 +2027,6 @@ class PublicationApiTest extends ResourceBaseTest {
                   "routes" : { }
                 }""";
         verifyJsonNotExact(response, 200, correctResponse);
-
-        // After approval, verify files exist at target paths
-        for (int i = 1; i < resources.size(); i++) {
-            targetUrl = resources.get(i).get("targetUrl").asText();
-            if (targetUrl.startsWith("files/")) {
-                response = send(HttpMethod.GET, "/v1/" + targetUrl, null, null, "authorization", "admin");
-                Assertions.assertEquals(200, response.status(), "File should exist at target path: " + targetUrl);
-            }
-        }
     }
 
     @Test
@@ -2150,19 +2088,9 @@ class PublicationApiTest extends ResourceBaseTest {
                             "sourceUrl" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test",
                             "targetUrl" : "applications/public/test",
                             "reviewUrl" : "applications/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/test"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test/test.txt",
-                            "targetUrl" : "files/public/.test/test/test.txt",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.test/test/test.txt"
-                          }, {
-                            "action" : "ADD",
-                            "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test1/test",
-                            "targetUrl" : "files/public/.test/test_2",
-                            "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.test/test_2"
                           }
                   ],
-                  "resourceTypes" : [ "APPLICATION", "FILE" ],
+                  "resourceTypes" : [ "APPLICATION" ],
                   "author" : "EPM-RTC-GPT"
                 }""";
 
@@ -2201,14 +2129,6 @@ class PublicationApiTest extends ResourceBaseTest {
                 }""";
         verifyJsonNotExact(response, 200, correctResponse);
 
-        for (int i = 1; i < resources.size(); i++) {
-            reviewUrl = resources.get(i).get("reviewUrl").asText();
-            if (reviewUrl.startsWith("files/")) {
-                Response fileResponse = send(HttpMethod.GET, "/v1/" + reviewUrl, null, null, "authorization", "admin");
-                Assertions.assertEquals(200, fileResponse.status(), "File should exist at review path: " + reviewUrl);
-            }
-        }
-
         response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
         verify(response, 200);
 
@@ -2239,15 +2159,6 @@ class PublicationApiTest extends ResourceBaseTest {
                   "routes" : { }
                 }""";
         verifyJsonNotExact(response, 200, correctResponse);
-
-        // After approval, verify files exist at target paths
-        for (int i = 1; i < resources.size(); i++) {
-            targetUrl = resources.get(i).get("targetUrl").asText();
-            if (targetUrl.startsWith("files/")) {
-                response = send(HttpMethod.GET, "/v1/" + targetUrl, null, null, "authorization", "admin");
-                Assertions.assertEquals(200, response.status(), "File should exist at target path: " + targetUrl);
-            }
-        }
     }
 
     @Test
@@ -2313,89 +2224,13 @@ class PublicationApiTest extends ResourceBaseTest {
                        "sourceUrl" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test%20app%202",
                        "targetUrl" : "applications/public/xyz%20app%204",
                        "reviewUrl" : "applications/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/xyz%20app%204"
-                     }, {
-                       "action" : "ADD",
-                       "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/Unt%2026__0.0.1/generate.json",
-                       "targetUrl" : "files/public/.xyz%20app%204/Unt%2026__0.0.1/generate.json",
-                       "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.xyz%20app%204/Unt%2026__0.0.1/generate.json"
-                     }, {
-                       "action" : "ADD",
-                       "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/Unt%2026__0.0.1/nodes/1743404608.101931_1.json",
-                       "targetUrl" : "files/public/.xyz%20app%204/Unt%2026__0.0.1/nodes/1743404608.101931_1.json",
-                       "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.xyz%20app%204/Unt%2026__0.0.1/nodes/1743404608.101931_1.json"
-                     }, {
-                       "action" : "ADD",
-                       "sourceUrl" : "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/abc/Unt%2026__0.0.1",
-                       "targetUrl" : "files/public/.xyz%20app%204/Unt%2026__0.0_2.1",
-                       "reviewUrl" : "files/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/.xyz%20app%204/Unt%2026__0.0_2.1"
-                     } ],
-                  "resourceTypes" : [ "APPLICATION", "FILE" ],
+                     }],
+                  "resourceTypes" : [ "APPLICATION" ],
                   "author" : "EPM-RTC-GPT"
                 }""";
 
 
         verifyJsonNotExact(response, 200, correctResponse);
-
-    }
-
-    @Test
-    void testApplicationWithTypeSchemaPublish_BadRequest_SchemaRichDuplicateFile() {
-
-        List<String> filePaths = List.of(
-                "Unt 26__0.0.1/generate.json",
-                "Unt 26__0.0.1/nodes/1743404608.101931_1.json",
-                "abc/Unt 26__0.0.1"
-        );
-        String basePath = "/v1/files/%s/appdata/mindmap/".formatted(bucket);
-        Response response;
-        for (String filePath : filePaths) {
-            String resourceUrl = basePath + UrlUtil.encodePath(filePath);
-            response = upload(HttpMethod.PUT, resourceUrl, null, "Test");
-            Assertions.assertEquals(200, response.status());
-        }
-
-        response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test%20app%202", null, """
-                  {
-                      "displayName": "test%20app%202",
-                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
-                      "applicationProperties": {
-                        "property1": "test property1",
-                        "property2": "test property2",
-                        "property3": [
-                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/Unt%2026__0.0.1/",
-                                "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/abc/Unt%2026__0.0.1"
-                        ]
-                       },
-                       "userRoles": [
-                            "Admin"
-                       ],
-                       "forwardAuthToken": true,
-                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
-                       "description": "My application description"
-                  }
-                """);
-        Assertions.assertEquals(200, response.status());
-
-        response = operationRequest("/v1/ops/publication/create", """
-                {
-                      "name": "Publication of my application",
-                      "targetFolder": "public/",
-                      "resources": [
-                        {
-                          "action": "ADD",
-                          "sourceUrl": "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test%20app%202",
-                          "targetUrl": "applications/public/xyz%20app%204"
-                        },
-                        {
-                          "action": "ADD",
-                          "sourceUrl": "files/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/appdata/mindmap/abc/Unt%2026__0.0.1",
-                          "targetUrl": "files/public/Unt%2026__0.0.1"
-                        }
-                      ]
-                    }
-                """);
-
-        verify(response, 400);
 
     }
 
@@ -2665,24 +2500,24 @@ class PublicationApiTest extends ResourceBaseTest {
 
         // Update as admin
         response = operationRequest("/v1/ops/publication/update", """
-            {
-              "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
-              "name": "Publication name",
-              "targetFolder": "public/folder/",
-              "resources": [
                 {
-                  "action": "ADD",
-                  "sourceUrl": "conversations/%s/my/folder/conversation%s",
-                  "targetUrl": "conversations/public/folder/conversation%s"
-                },
-                {
-                  "action": "ADD",
-                  "sourceUrl": "files/%s/file",
-                  "targetUrl": "files/public/folder/new_file"
+                  "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
+                  "name": "Publication name",
+                  "targetFolder": "public/folder/",
+                  "resources": [
+                    {
+                      "action": "ADD",
+                      "sourceUrl": "conversations/%s/my/folder/conversation%s",
+                      "targetUrl": "conversations/public/folder/conversation%s"
+                    },
+                    {
+                      "action": "ADD",
+                      "sourceUrl": "files/%s/file",
+                      "targetUrl": "files/public/folder/new_file"
+                    }
+                  ]
                 }
-              ]
-            }
-            """.formatted(bucket, "1", "1", bucket), "authorization", "admin");
+                """.formatted(bucket, "1", "1", bucket), "authorization", "admin");
         verify(response, 200);
 
         response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
@@ -2735,46 +2570,46 @@ class PublicationApiTest extends ResourceBaseTest {
 
         // Update as admin - bad source file
         response = operationRequest("/v1/ops/publication/update", """
-            {
-              "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
-              "name": "Publication name",
-              "targetFolder": "public/folder/",
-              "resources": [
                 {
-                  "action": "ADD",
-                  "sourceUrl": "conversations/%s/my/folder/conversation%s",
-                  "targetUrl": "conversations/public/folder/conversation%s"
-                },
-                {
-                  "action": "ADD",
-                  "sourceUrl": "files/%s/invalid_file",
-                  "targetUrl": "files/public/folder/new_file"
+                  "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
+                  "name": "Publication name",
+                  "targetFolder": "public/folder/",
+                  "resources": [
+                    {
+                      "action": "ADD",
+                      "sourceUrl": "conversations/%s/my/folder/conversation%s",
+                      "targetUrl": "conversations/public/folder/conversation%s"
+                    },
+                    {
+                      "action": "ADD",
+                      "sourceUrl": "files/%s/invalid_file",
+                      "targetUrl": "files/public/folder/new_file"
+                    }
+                  ]
                 }
-              ]
-            }
-            """.formatted(bucket, "", "1", bucket), "authorization", "admin");
+                """.formatted(bucket, "", "1", bucket), "authorization", "admin");
         verify(response, 400);
 
         // Update as admin
         response = operationRequest("/v1/ops/publication/update", """
-            {
-              "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
-              "name": "Publication name",
-              "targetFolder": "public/folder/",
-              "resources": [
                 {
-                  "action": "ADD",
-                  "sourceUrl": "conversations/%s/my/folder/conversation%s",
-                  "targetUrl": "conversations/public/folder/conversation%s"
-                },
-                {
-                  "action": "ADD",
-                  "sourceUrl": "files/%s/file",
-                  "targetUrl": "files/public/folder/new_file"
+                  "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
+                  "name": "Publication name",
+                  "targetFolder": "public/folder/",
+                  "resources": [
+                    {
+                      "action": "ADD",
+                      "sourceUrl": "conversations/%s/my/folder/conversation%s",
+                      "targetUrl": "conversations/public/folder/conversation%s"
+                    },
+                    {
+                      "action": "ADD",
+                      "sourceUrl": "files/%s/file",
+                      "targetUrl": "files/public/folder/new_file"
+                    }
+                  ]
                 }
-              ]
-            }
-            """.formatted(bucket, "", "1", bucket), "authorization", "admin");
+                """.formatted(bucket, "", "1", bucket), "authorization", "admin");
         verify(response, 200);
 
         // list publications
@@ -2806,6 +2641,168 @@ class PublicationApiTest extends ResourceBaseTest {
         response = send(HttpMethod.GET, "/v1/conversations/public/folder/conversation1");
         verifyJsonNotExact(response, 200, conversationTemplate.formatted("conversations/public/folder/conversation1",
                 "conversations/public/folder", "files/public/folder/new_file"));
+    }
+
+    @Test
+    void testApplicationWithTypeSchemaPublish_Ok_FolderWithSubfolder_WhenUpdate() throws JsonProcessingException {
+
+        List<String> filePaths =
+                List.of("/v1/files/%s/xyz/test_file1.txt", "/v1/files/%s/xyz/test_file2.txt", "/v1/files/%s/xyz/abc/test_file1.txt", "/v1/files/%s/xyz/abc/test_file2.txt",
+                        "/v1/files/%s/some/xyz/abc/test_file1.txt", "/v1/files/%s/some/xyz/abc/test_file2.txt", "/v1/files/%s/another/xyz");
+
+        Response response;
+        for (String filePath : filePaths) {
+            response = upload(HttpMethod.PUT, filePath.formatted(bucket), null, "Test");
+            Assertions.assertEquals(200, response.status());
+        }
+
+        response = send(HttpMethod.PUT, "/v1/applications/%s/test_app2".formatted(bucket), null, """
+                  {
+                      "displayName": "test_app2",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/%s/xyz/", "files/%s/some/xyz/", "files/%s/another/xyz"
+                        ]
+                       },
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """.formatted(bucket, bucket, bucket));
+        Assertions.assertEquals(200, response.status());
+
+        response = operationRequest("/v1/ops/publication/create", """
+                {
+                      "name": "Publication of my application",
+                      "targetFolder": "public/folder/",
+                      "resources": [
+                        {
+                          "action": "ADD",
+                          "sourceUrl": "applications/%s/test_app2",
+                          "targetUrl": "applications/public/folder/with_apps/test_app2"
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "source": "roles",
+                          "function": "TRUE"
+                        }
+                      ]
+                    }
+                """.formatted(bucket));
+        String correctResponse = """
+                {
+                  "url" : "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
+                  "name" : "Publication of my application",
+                  "targetFolder" : "public/folder/",
+                  "status" : "PENDING",
+                  "createdAt" : 0,
+                  "resources" : [ {
+                            "action" : "ADD",
+                            "sourceUrl" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app2",
+                            "targetUrl" : "applications/public/folder/with_apps/test_app2",
+                            "reviewUrl" : "applications/2CZ9i2bcBACFts8JbBu3MdTHfU5imDZBmDVomBuDCkbhEstv1KXNzCiw693js8BLmo/with_apps/test_app2"
+                          }
+                  ],
+                  "resourceTypes" : [ "APPLICATION" ],
+                  "rules" : [ {
+                    "function" : "TRUE",
+                    "source" : "roles",
+                    "targets" : null
+                  } ],
+                  "author" : "EPM-RTC-GPT"
+                }""";
+
+
+        verifyJsonNotExact(response, 200, correctResponse);
+
+        // Update as admin
+        response = operationRequest("/v1/ops/publication/update", """
+                {
+                "url": "publications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/0123",
+                "name": "Publication of my application",
+                 "targetFolder": "public/folder2/",
+                 "resources" : [ {
+                            "action" : "ADD",
+                            "sourceUrl" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/test_app2",
+                            "targetUrl" : "applications/public/folder2/with_apps/test_app3"
+                          }
+                  ],
+                      "rules": [
+                        {
+                          "source": "roles",
+                          "function": "TRUE"
+                        }
+                      ]
+                    }
+                """, "authorization", "admin");
+        verify(response, 200);
+        JsonNode responseJson = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode resources = responseJson.get("resources");
+
+        response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
+        verify(response, 200);
+
+        String targetUrl = resources.get(0).get("targetUrl").asText();
+        response = send(HttpMethod.GET, "/v1/" + targetUrl, null, null, "authorization", "admin");
+        correctResponse = """
+                {
+                  "name" : "applications/public/folder2/with_apps/test_app3",
+                  "display_name" : "test_app2",
+                  "icon_url" : "https://mydial.somewhere.com/app-icon.svg",
+                  "description" : "My application description",
+                  "reference" : "@ignore",
+                  "forward_auth_token" : false,
+                  "defaults" : { },
+                  "interceptors" : [ ],
+                  "description_keywords" : [ ],
+                  "max_retry_attempts" : 1,
+                  "author" : "EPM-RTC-GPT",
+                  "created_at" : "@ignore",
+                  "updated_at" : "@ignore",
+                  "dependencies" : [ ],
+                  "application_properties" : {
+                    "property1" : "test property1",
+                    "property2" : "test property2",
+                    "property3" : [ "files/public/folder2/with_apps/.test_app3/xyz/",
+                    "files/public/folder2/with_apps/.test_app3/xyz_2/",
+                    "files/public/folder2/with_apps/.test_app3/xyz_3" ]
+                  },
+                  "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                  "routes" : { }
+                }""";
+        verifyJsonNotExact(response, 200, correctResponse);
+
+        response = send(HttpMethod.GET, "/v1/metadata/files/public/folder2/with_apps/.test_app3/", "recursive=true", null, "authorization", "admin");
+        verify(response, 200);
+        responseJson = ProxyUtil.MAPPER.readTree(response.body());
+        List<String> files = new ArrayList<>();
+        for (var item : responseJson.get("items")) {
+            String url = item.get("url").textValue();
+            if (!url.endsWith("/")) {
+                files.add(url);
+            }
+        }
+        assertEquals(7, files.size());
+        List<String> appFiles = List.of("files/public/folder2/with_apps/.test_app3/xyz/",
+                "files/public/folder2/with_apps/.test_app3/xyz_2/",
+                "files/public/folder2/with_apps/.test_app3/xyz_3");
+        int count = 0;
+        for (var file : files) {
+            for (var parent : appFiles) {
+                if (file.startsWith(parent)) {
+                    count++;
+                    break;
+                }
+            }
+        }
+        assertEquals(count, files.size(), "Application files are missed");
     }
 
 }

--- a/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
@@ -996,16 +996,7 @@ class PublicationApiTest extends ResourceBaseTest {
                   "nodeType" : "FOLDER",
                   "resourceType" : "CONVERSATION",
                   "permissions" : [ "READ" ],
-                  "items" : [ {
-                     "name" : "folder1",
-                     "parentPath" : null,
-                     "bucket" : "public",
-                     "url" : "conversations/public/folder1/",
-                     "nodeType" : "FOLDER",
-                     "resourceType" : "CONVERSATION",
-                     "permissions" : [ "READ" ],
-                     "items" : null
-                    }, {
+                  "items" : [{
                      "name" : "conversation1",
                      "parentPath" : "folder1",
                      "bucket" : "public",
@@ -1082,16 +1073,7 @@ class PublicationApiTest extends ResourceBaseTest {
                   "nodeType" : "FOLDER",
                   "resourceType" : "CONVERSATION",
                   "permissions" : [ "READ", "WRITE", "SHARE" ],
-                  "items" : [ {
-                    "name" : "folder1",
-                    "parentPath" : null,
-                    "bucket" : "public",
-                    "url" : "conversations/public/folder1/",
-                    "nodeType" : "FOLDER",
-                    "resourceType" : "CONVERSATION",
-                    "permissions" : [ "READ", "WRITE", "SHARE" ],
-                    "items" : null
-                    }, {
+                  "items" : [{
                     "name" : "conversation1",
                     "parentPath" : "folder1",
                     "bucket" : "public",
@@ -1100,16 +1082,7 @@ class PublicationApiTest extends ResourceBaseTest {
                     "resourceType" : "CONVERSATION",
                     "permissions" : [ "READ", "WRITE", "SHARE" ],
                     "updatedAt" : "@ignore"
-                    }, {
-                    "name" : "folder2",
-                    "parentPath" : null,
-                    "bucket" : "public",
-                    "url" : "conversations/public/folder2/",
-                    "nodeType" : "FOLDER",
-                    "resourceType" : "CONVERSATION",
-                    "permissions" : [ "READ", "WRITE", "SHARE" ],
-                    "items" : null
-                    }, {
+                    },{
                     "name" : "conversation2",
                     "parentPath" : "folder2",
                     "bucket" : "public",

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -4,6 +4,7 @@ import com.epam.aidial.core.storage.blobstore.BlobStorage;
 import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
 import com.epam.aidial.core.storage.data.FileMetadata;
 import com.epam.aidial.core.storage.data.MetadataBase;
+import com.epam.aidial.core.storage.data.NodeType;
 import com.epam.aidial.core.storage.data.ResourceEvent;
 import com.epam.aidial.core.storage.data.ResourceFolderMetadata;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
@@ -163,6 +164,9 @@ public class ResourceService implements AutoCloseable {
             }
 
             for (MetadataBase item : folder.getItems()) {
+                if (item.getNodeType() == NodeType.FOLDER) {
+                    continue;
+                }
                 String sourceFileUrl = item.getUrl();
                 String targetFileUrl = targetFolder + sourceFileUrl.substring(sourceFolder.getUrl().length());
 

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -164,9 +164,6 @@ public class ResourceService implements AutoCloseable {
             }
 
             for (MetadataBase item : folder.getItems()) {
-                if (item.getNodeType() == NodeType.FOLDER) {
-                    continue;
-                }
                 String sourceFileUrl = item.getUrl();
                 String targetFileUrl = targetFolder + sourceFileUrl.substring(sourceFolder.getUrl().length());
 
@@ -217,44 +214,49 @@ public class ResourceService implements AutoCloseable {
             return null;
         }
 
-        List<MetadataBase> resources = set.stream().map(meta -> {
-            Map<String, String> metadata = meta.getUserMetadata();
-            String path = meta.getName();
-            ResourceDescriptor description = descriptor.resolveByPath(path);
-
-            if (meta.getType() != StorageType.BLOB) {
-                return new ResourceFolderMetadata(description);
-            }
-
-            Long createdAt = null;
-            Long updatedAt = null;
-            String author = null;
-
-            if (metadata != null) {
-                createdAt = metadata.containsKey(CREATED_AT_ATTRIBUTE) ? Long.parseLong(metadata.get(CREATED_AT_ATTRIBUTE)) : null;
-                updatedAt = metadata.containsKey(UPDATED_AT_ATTRIBUTE) ? Long.parseLong(metadata.get(UPDATED_AT_ATTRIBUTE)) : null;
-                author = decode(metadata.get(AUTHOR_ATTRIBUTE));
-            }
-
-            if (createdAt == null && meta.getCreationDate() != null) {
-                createdAt = meta.getCreationDate().getTime();
-            }
-
-            if (updatedAt == null && meta.getLastModified() != null) {
-                updatedAt = meta.getLastModified().getTime();
-            }
-
-            if (description.getType().requireCompression()) {
-                return new ResourceItemMetadata(description).setCreatedAt(createdAt).setUpdatedAt(updatedAt).setAuthor(author);
-            }
-
-            return new FileMetadata(description, meta.getSize(), BlobStorage.resolveContentType((BlobMetadata) meta))
-                    .setCreatedAt(createdAt)
-                    .setAuthor(author)
-                    .setUpdatedAt(updatedAt);
-        }).toList();
+        List<MetadataBase> resources = set.stream()
+                // blob store never returns folder however local FS provider may return
+                .filter(meta -> !recursive || meta.getType() == StorageType.BLOB)
+                .map(meta -> storageToResourceMetadata(meta, descriptor)).toList();
 
         return new ResourceFolderMetadata(descriptor, resources, set.getNextMarker());
+    }
+
+    private static MetadataBase storageToResourceMetadata(StorageMetadata meta, ResourceDescriptor folder) {
+        Map<String, String> metadata = meta.getUserMetadata();
+        String path = meta.getName();
+        ResourceDescriptor description = folder.resolveByPath(path);
+
+        if (meta.getType() != StorageType.BLOB) {
+            return new ResourceFolderMetadata(description);
+        }
+
+        Long createdAt = null;
+        Long updatedAt = null;
+        String author = null;
+
+        if (metadata != null) {
+            createdAt = metadata.containsKey(CREATED_AT_ATTRIBUTE) ? Long.parseLong(metadata.get(CREATED_AT_ATTRIBUTE)) : null;
+            updatedAt = metadata.containsKey(UPDATED_AT_ATTRIBUTE) ? Long.parseLong(metadata.get(UPDATED_AT_ATTRIBUTE)) : null;
+            author = decode(metadata.get(AUTHOR_ATTRIBUTE));
+        }
+
+        if (createdAt == null && meta.getCreationDate() != null) {
+            createdAt = meta.getCreationDate().getTime();
+        }
+
+        if (updatedAt == null && meta.getLastModified() != null) {
+            updatedAt = meta.getLastModified().getTime();
+        }
+
+        if (description.getType().requireCompression()) {
+            return new ResourceItemMetadata(description).setCreatedAt(createdAt).setUpdatedAt(updatedAt).setAuthor(author);
+        }
+
+        return new FileMetadata(description, meta.getSize(), BlobStorage.resolveContentType((BlobMetadata) meta))
+                .setCreatedAt(createdAt)
+                .setAuthor(author)
+                .setUpdatedAt(updatedAt);
     }
 
     @Nullable


### PR DESCRIPTION

### Applicable issues

1. User wants publish schema rich app with dependent files.
2. Admin changes targetUrl of the app or/and target folder of the publication
3. Admin updates publication and approves it later.

### Description of changes

We shouldn't expose files of the schema rich app as publication resources any longer and let Core manages them internally 

