### PR TITLE
fix: DIAL file properties are not updated correctly after schema-rich application publication(if there are percent-encoding symbols in file path)

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
@@ -752,7 +752,8 @@ public class ApplicationService {
             for (int i = 0; i < node.size(); i++) {
                 JsonNode childNode = node.get(i);
                 if (childNode.isTextual()) {
-                    String replacement = replacementMap.get(childNode.textValue());
+                    String decodedUrl = UrlUtil.tryDecodePath(childNode.textValue());
+                    String replacement = replacementMap.get(decodedUrl);
                     if (replacement != null) {
                         ((ArrayNode) node).set(i, replacement);
                     }
@@ -761,7 +762,8 @@ public class ApplicationService {
                 }
             }
         } else if (node.isTextual()) {
-            String replacement = replacementMap.get(node.textValue());
+            String decodedUrl = UrlUtil.tryDecodePath(node.textValue());
+            String replacement = replacementMap.get(decodedUrl);
             if (replacement != null && parent.isObject()) {
                 ((ObjectNode) parent).put(fieldName, replacement);
             }

--- a/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
@@ -2135,7 +2135,7 @@ class PublicationApiTest extends ResourceBaseTest {
     }
 
     @Test
-    void testApplicationWithTypeSchemaPublish_Ok_MindMapCase() {
+    void testApplicationWithTypeSchemaPublish_Ok_MindMapCase() throws JsonProcessingException {
 
         List<String> filePaths = List.of(
                 "Unt 26__0.0.1/generate.json",
@@ -2203,6 +2203,39 @@ class PublicationApiTest extends ResourceBaseTest {
                 }""";
 
 
+        verifyJsonNotExact(response, 200, correctResponse);
+
+        response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
+        verify(response, 200);
+
+        JsonNode responseJson = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode resources = responseJson.get("resources");
+        String targetUrl = resources.get(0).get("targetUrl").asText();
+        response = send(HttpMethod.GET, "/v1/" + targetUrl, null, null, "authorization", "admin");
+        correctResponse = """
+                {
+                   "name" : "applications/public/xyz%20app%204",
+                   "display_name" : "test%20app%202",
+                   "icon_url" : "https://mydial.somewhere.com/app-icon.svg",
+                   "description" : "My application description",
+                   "reference" : "@ignore",
+                   "forward_auth_token" : false,
+                   "defaults" : { },
+                   "interceptors" : [ ],
+                   "description_keywords" : [ ],
+                   "max_retry_attempts" : 1,
+                   "author" : "EPM-RTC-GPT",
+                   "created_at" : "@ignore",
+                   "updated_at" : "@ignore",
+                   "dependencies" : [ ],
+                   "application_properties" : {
+                     "property1" : "test property1",
+                     "property2" : "test property2",
+                     "property3" : [ "files/public/.xyz%20app%204/Unt%2026__0.0.1/", "files/public/.xyz%20app%204/Unt%2026__0.0_2.1" ]
+                   },
+                   "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                   "routes" : { }
+                 }""";
         verifyJsonNotExact(response, 200, correctResponse);
 
     }

--- a/storage/src/main/java/com/epam/aidial/core/storage/util/UrlUtil.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/util/UrlUtil.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 @UtilityClass
 public class UrlUtil {
@@ -24,11 +25,17 @@ public class UrlUtil {
     private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^[a-z][a-z0-9-+.]*?://", Pattern.CASE_INSENSITIVE);
 
     @SneakyThrows
-    public String encodePathSegment(String segment) {
+    public String encodePathSegment(@Nullable String segment) {
+        if (segment == null) {
+            return null;
+        }
         return ENCODER.escape(segment);
     }
 
-    public String encodePath(String path) {
+    public String encodePath(@Nullable String path) {
+        if (path == null) {
+            return null;
+        }
         StringBuilder builder = new StringBuilder();
 
         for (int i = 0; i < path.length(); i++) {
@@ -46,12 +53,15 @@ public class UrlUtil {
         return builder.toString();
     }
 
-    public String decodePath(String path) {
+    public String decodePath(@Nullable String path) {
         return decodePath(path, true);
     }
 
     @SneakyThrows
-    public String decodePath(String path, boolean checkUri) {
+    public String decodePath(@Nullable String path, boolean checkUri) {
+        if (path == null) {
+            return null;
+        }
         if (checkUri) {
             try {
                 URI uri = new URI(path);
@@ -65,23 +75,23 @@ public class UrlUtil {
         return new String(DECODER.decode(path.getBytes(Charset.defaultCharset())));
     }
 
-    public String tryDecodePath(String path) {
+    public String tryDecodePath(@Nullable String path) {
         try {
-            return decodePath(path);
+            return decodePath(path, false);
         } catch (RuntimeException e) {
             return path; // Return original path if decoding fails
         }
     }
 
-    public boolean isAbsoluteUrl(String url) {
-        return ABSOLUTE_URL_PATTERN.matcher(url).find();
+    public boolean isAbsoluteUrl(@Nullable String url) {
+        return url != null && ABSOLUTE_URL_PATTERN.matcher(url).find();
     }
 
-    public boolean isDataUrl(String url) {
-        return url.startsWith("data:");
+    public boolean isDataUrl(@Nullable String url) {
+        return url != null && url.startsWith("data:");
     }
 
-    public boolean isFolder(String url) {
-        return url.endsWith(ResourceDescriptor.PATH_SEPARATOR);
+    public boolean isFolder(@Nullable String url) {
+        return url != null && url.endsWith(ResourceDescriptor.PATH_SEPARATOR);
     }
 }

--- a/storage/src/test/java/com/epam/aidial/core/storage/util/UrlUtilTest.java
+++ b/storage/src/test/java/com/epam/aidial/core/storage/util/UrlUtilTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -11,6 +12,7 @@ public class UrlUtilTest {
 
     @Test
     public void testPathSegmentEncoding() {
+        assertNull(UrlUtil.encodePathSegment(null));
         assertEquals("folder%201", UrlUtil.encodePathSegment("folder 1"));
         assertEquals("folder%20%23", UrlUtil.encodePathSegment("folder #"));
         assertEquals("%D1%84%D0%B0%D0%B9%D0%BB.txt", UrlUtil.encodePathSegment("файл.txt"));
@@ -22,6 +24,7 @@ public class UrlUtilTest {
 
     @Test
     public void testPathEncoding() {
+        assertNull(UrlUtil.encodePath(null));
         assertEquals("", UrlUtil.encodePath(""));
         assertEquals("/", UrlUtil.encodePath("/"));
         assertEquals("//", UrlUtil.encodePath("//"));
@@ -36,6 +39,7 @@ public class UrlUtilTest {
 
     @Test
     public void testPathDecoding() {
+        assertNull(UrlUtil.decodePath(null));
         assertEquals("folder 1", UrlUtil.decodePath("folder%201"));
         assertEquals("folder #", UrlUtil.decodePath("folder%20%23"));
         assertEquals("fo$l+=d,e#r 1", UrlUtil.decodePath("fo$l+=d,e%23r%201"));
@@ -48,6 +52,7 @@ public class UrlUtilTest {
 
     @Test
     public void testIsAbsoluteUrl() {
+        assertFalse(UrlUtil.isAbsoluteUrl(null));
         assertTrue(UrlUtil.isAbsoluteUrl("test://example.com"));
         assertTrue(UrlUtil.isAbsoluteUrl("TEST://EXAMPLE.COM"));
         assertTrue(UrlUtil.isAbsoluteUrl("test1+test2://example.com/item"));
@@ -60,6 +65,7 @@ public class UrlUtilTest {
 
     @Test
     public void testIsDataUrl() {
+        assertFalse(UrlUtil.isDataUrl(null));
         assertTrue(UrlUtil.isDataUrl("data:whatever"));
         assertTrue(UrlUtil.isDataUrl("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAIAAADZSiLoAAAAF0lEQVR4nGNkYPjPwMDAwMDAxAADCBYAG10BBdmz9y8AAAAASUVORK5CYII="));
         assertFalse(UrlUtil.isDataUrl("data"));
@@ -67,5 +73,12 @@ public class UrlUtilTest {
         assertFalse(UrlUtil.isDataUrl(" data:whatever"));
         assertFalse(UrlUtil.isDataUrl("data;whatever"));
         assertFalse(UrlUtil.isDataUrl("https://example.com"));
+    }
+
+    @Test
+    public void testIsFolder() {
+        assertFalse(UrlUtil.isFolder(null));
+        assertTrue(UrlUtil.isFolder("files/1224/folder/"));
+        assertFalse(UrlUtil.isFolder("files/1224/folder/file"));
     }
 }


### PR DESCRIPTION

### Applicable issues

1. Create mind map application with name containing percent encoding symbols like space ` `
2. Optional. Specify a path to the mind map folder containing percent encoding symbols like space ` `
3. Create publish request
4. Send the publish request
5. Admin approves the publish request

The published app has the old path to the mind map folder but should be updated.

### Description of changes

Try to decode a text value of the property in the app to make sure it's matched to replacement link.

