### PR TITLE
feat: add supported scopes to resource metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Priority order:
 | identityProviders.*.audience                  |         -          |    No    |If the setting is set it will be validated against the claim `aud` in JWT
 | identityProviders.*.userDisplayName           |         -          |    No    |Path to the claim in JWT token or user info response where user display name can be taken.
 | toolsets.security.authorizationServers        |         -          |    No    |Path(s) to the authorization server URLs trusted to issue access tokens for MCP clients.
+| toolsets.security.resourceSchema              |       https        |    No    |Schema of the resource server. This URL schema is used to construct the resource identifier for token validation, as defined in RFC 9728. If not specified, the default value will be applied.
 | toolsets.security.resourceHost                |         -          |    No    |The public, fully-qualified hostname of this resource server (e.g., api.example.com). This is used to construct the resource identifier for token validation per RFC 9728. If not set, the host is derived from the incoming request.
+| toolsets.security.scopesSupported             |         -          |    No    |List of scope values, as defined in OAuth 2.0 [RFC6749], that are used in authorization requests to request access to this protected resource.
 | vertx.*                                       |         -          |    No    |Vertx settings. Refer to [vertx.io](https://vertx.io/docs/apidocs/io/vertx/core/VertxOptions.html) to learn more.
 | server.*                                      |         -          |    No    |Vertx HTTP server settings for incoming requests.
 | client.*                                      |         -          |    No    |Vertx HTTP client settings for outbound requests.

--- a/server/src/main/java/com/epam/aidial/core/server/data/wellknown/ResourceMetadata.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/wellknown/ResourceMetadata.java
@@ -15,4 +15,6 @@ public class ResourceMetadata {
     private String resource;
     @JsonProperty("authorization_servers")
     private List<String> authorizationServers;
+    @JsonProperty("scopes_supported")
+    private List<String> scopesSupported;
 }

--- a/server/src/main/java/com/epam/aidial/core/server/service/WellKnownResourceMetadataService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/WellKnownResourceMetadataService.java
@@ -7,7 +7,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.HostAndPort;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,32 +30,42 @@ public class WellKnownResourceMetadataService {
 
     private static final String RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource";
 
-    private final List<String> authorizationServers;
+    private final String resourceSchema;
     private final String resourceHost;
+    private final List<String> authorizationServers;
+    private final List<String> scopesSupported;
 
     public WellKnownResourceMetadataService(JsonObject toolsetSettings) {
         JsonObject security = toolsetSettings != null ? toolsetSettings.getJsonObject("security") : null;
 
-        this.authorizationServers = (security != null && security.containsKey("authorizationServers"))
-                ? parseAuthorizationServers(security.getValue("authorizationServers"))
-                : Collections.emptyList();
+        this.resourceSchema = getStr(security, "resourceSchema", "https");
+        this.resourceHost = getStr(security, "resourceHost", null);
 
-        this.resourceHost = (security != null) ? security.getString("resourceHost") : null;
+        this.authorizationServers = getStrOrList(security, "authorizationServers", null);
+        this.scopesSupported = getStrOrList(security, "scopesSupported", null);
     }
 
-    private static List<String> parseAuthorizationServers(Object authServerValue) {
-        if (authServerValue instanceof String str) {
-            return List.of(str);
+    private static String getStr(JsonObject object, String key, String defaultValue) {
+        if (object == null) {
+            return defaultValue;
         }
-        if (authServerValue instanceof JsonArray array) {
-            return array.stream()
+        return object.containsKey(key) ? object.getString(key) : defaultValue;
+    }
+
+    private static List<String> getStrOrList(JsonObject object, String key, List<String> defaultValue) {
+        if (object == null) {
+            return defaultValue;
+        }
+
+        Object strOrList = object.getValue(key);
+        return switch (strOrList) {
+            case null -> defaultValue;
+            case String str -> List.of(str);
+            case JsonArray array -> array.stream()
                     .map(Object::toString)
                     .toList();
-        }
-        if (authServerValue == null) {
-            return Collections.emptyList();
-        }
-        throw new IllegalArgumentException("'authorizationServers' must be either a String or an Array");
+            default -> throw new IllegalArgumentException("'%s' must be either a String or an Array".formatted(key));
+        };
     }
 
     /**
@@ -64,8 +73,8 @@ public class WellKnownResourceMetadataService {
      *
      * <p>The URI is constructed by:
      * <ol>
-     *   <li>Using the scheme <code>https</code> and the configured {@code resourceHost}
-     *       (or the request authority if not configured).</li>
+     *   <li>Using the configured {@code resourceScheme} (defaults to {@code https})
+     *       and {@code resourceHost} (defaults to the request authority).</li>
      *   <li>Appending the well-known metadata path:
      *       <code>/.well-known/oauth-protected-resource</code>.</li>
      *   <li>Appending the original request path.</li>
@@ -90,7 +99,7 @@ public class WellKnownResourceMetadataService {
         HostAndPort authority = request.authority();
         String host = resourceHost != null ? resourceHost : authority.toString();
 
-        return Optional.of("https://" + host + RESOURCE_METADATA_PATH + path);
+        return Optional.of(resourceSchema + "://" + host + RESOURCE_METADATA_PATH + path);
     }
 
     /**
@@ -111,8 +120,9 @@ public class WellKnownResourceMetadataService {
         }
 
         ResourceMetadata metadata = new ResourceMetadata();
-        metadata.setAuthorizationServers(authorizationServers);
         metadata.setResource(resolveResource(request));
+        metadata.setAuthorizationServers(authorizationServers);
+        metadata.setScopesSupported(scopesSupported);
         return Optional.of(metadata);
     }
 
@@ -153,11 +163,11 @@ public class WellKnownResourceMetadataService {
         HostAndPort authority = request.authority();
         String host = resourceHost != null ? resourceHost : authority.toString();
 
-        return "https://" + host + resourceSegment;
+        return resourceSchema + "://" + host + resourceSegment;
     }
 
     private boolean isDisabled() {
-        return authorizationServers.isEmpty();
+        return authorizationServers == null;
     }
 
 }

--- a/server/src/test/java/com/epam/aidial/core/server/service/WellKnownResourceMetadataServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/WellKnownResourceMetadataServiceTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -38,6 +39,22 @@ public class WellKnownResourceMetadataServiceTest {
         Optional<String> pathOptional = service.resolveResourceMetadataPath(request);
         assertTrue(pathOptional.isPresent());
         assertEquals("https://custom.com/.well-known/oauth-protected-resource/abc", pathOptional.get());
+    }
+
+    @Test
+    void resolveResourceMetadataPath_withResourceSchema() {
+        JsonObject mcp = new JsonObject()
+                .put("security", new JsonObject()
+                        .put("authorizationServers", "https://auth.example.com")
+                        .put("resourceSchema", "http"));
+        WellKnownResourceMetadataService service = new WellKnownResourceMetadataService(mcp);
+
+        when(request.path()).thenReturn("/x");
+        when(request.authority()).thenReturn(HostAndPort.create("host.com", -1));
+
+        Optional<String> pathOptional = service.resolveResourceMetadataPath(request);
+        assertTrue(pathOptional.isPresent());
+        assertEquals("http://host.com/.well-known/oauth-protected-resource/x", pathOptional.get());
     }
 
     @Test
@@ -81,6 +98,27 @@ public class WellKnownResourceMetadataServiceTest {
         ResourceMetadata metadata = metadataOptional.get();
         assertEquals("https://custom.com", metadata.getResource());
         assertEquals(List.of("https://auth.example.com"), metadata.getAuthorizationServers());
+        assertNull(metadata.getScopesSupported());
+    }
+
+    @Test
+    void resolveResourceMetadata_withSupportedScopes_setsRootResource() {
+        JsonObject mcp = new JsonObject()
+                .put("security", new JsonObject()
+                        .put("authorizationServers", "https://auth.example.com")
+                        .put("resourceHost", "custom.com")
+                        .put("scopesSupported", List.of("scope1", "scope2")));
+        WellKnownResourceMetadataService service = new WellKnownResourceMetadataService(mcp);
+
+        when(request.path()).thenReturn("/.well-known/oauth-protected-resource");
+        when(request.authority()).thenReturn(HostAndPort.create("ignored.com", -1));
+
+        Optional<ResourceMetadata> metadataOptional = service.resolveResourceMetadata(request);
+        assertTrue(metadataOptional.isPresent());
+        ResourceMetadata metadata = metadataOptional.get();
+        assertEquals("https://custom.com", metadata.getResource());
+        assertEquals(List.of("https://auth.example.com"), metadata.getAuthorizationServers());
+        assertEquals(List.of("scope1", "scope2"), metadata.getScopesSupported());
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1023

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added support for configuring the `supported_resources` field in the response of the Protected Resource Metadata endpoint.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
