### PR TITLE
chore: code re-factoring of deployment post controller. Move common methods to base class.

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -1,0 +1,98 @@
+package com.epam.aidial.core.server.controller;
+
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.function.CollectResponseAttachmentsFn;
+import com.epam.aidial.core.server.function.CollectResponseChatCompletionAttachmentsFn;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.netty.buffer.ByteBufInputStream;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.InputStream;
+
+@Slf4j
+@AllArgsConstructor
+public class BaseDeploymentPostController {
+
+    protected final Proxy proxy;
+    protected final ProxyContext context;
+
+    protected BufferingReadStream createResponseStream(HttpClientResponse proxyResponse) {
+        String contentType = proxyResponse.getHeader(HttpHeaders.CONTENT_TYPE);
+        boolean isEventStreamResponse = "text/event-stream".equalsIgnoreCase(contentType) && context.isStreamingRequest();
+        CollectResponseAttachmentsFn handler = isEventStreamResponse ? new CollectResponseChatCompletionAttachmentsFn(proxy, context) : null;
+        return new BufferingReadStream(proxyResponse, ProxyUtil.contentLength(proxyResponse, 1024), handler);
+    }
+
+    protected Future<Void> collectResponseAttachments(Buffer responseBody) {
+        if (context.isStreamingRequest()) {
+            return Future.succeededFuture();
+        }
+        try (InputStream stream = new ByteBufInputStream(responseBody.getByteBuf())) {
+            ObjectNode tree = (ObjectNode) ProxyUtil.MAPPER.readTree(stream);
+            var fn = new CollectResponseChatCompletionAttachmentsFn(proxy, context);
+            return fn.apply(tree);
+        } catch (Throwable e) {
+            log.warn("Can't parse JSON response body. Error:", e);
+            return Future.failedFuture(e);
+        }
+    }
+
+    protected Future<?> respond(HttpStatus status, String errorMessage) {
+        finalizeRequest();
+        return context.respond(status, errorMessage);
+    }
+
+    protected void respond(HttpException exception) {
+        finalizeRequest();
+        context.respond(exception);
+    }
+
+    protected void respond(HttpStatus status) {
+        finalizeRequest();
+        context.respond(status);
+    }
+
+    protected void respond(HttpStatus status, Object result) {
+        finalizeRequest();
+        context.respond(status, result);
+    }
+
+    protected void finalizeRequest() {
+        proxy.getTokenStatsTracker().endSpan(context).onFailure(error -> log.error("Error occurred at completing span", error));
+        ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
+        if (proxyApiKeyData != null) {
+            proxy.getApiKeyStore().invalidatePerRequestApiKey(proxyApiKeyData)
+                    .onSuccess(invalidated -> {
+                        if (!invalidated) {
+                            log.warn("Per request is not removed: {}", proxyApiKeyData.getPerRequestKey());
+                        }
+                    }).onFailure(error -> log.error("error occurred on invalidating per-request key", error));
+        }
+    }
+
+    /**
+     * Called when proxy failed to connect to the origin.
+     */
+    protected void handleProxyConnectionError(Throwable error) {
+        respond(HttpStatus.BAD_GATEWAY, "Failed to connect to origin");
+        log.warn("Can't connect to origin.  Deployment: {}. Address: {}. Error: {}",
+                context.getDeployment().getName(),
+                context.getDeployment().getEndpoint(), error.getMessage());
+    }
+
+    protected void handleRequestBodyError(Throwable error) {
+        respond(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to receive body");
+        log.warn("Failed to receive client body. Error: {}", error.getMessage());
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -16,8 +16,6 @@ import com.epam.aidial.core.server.function.BuildUpstreamCacheFn;
 import com.epam.aidial.core.server.function.CollectRequestApplicationFilesFn;
 import com.epam.aidial.core.server.function.CollectRequestChatCompletionAttachmentsFn;
 import com.epam.aidial.core.server.function.CollectRequestDataFn;
-import com.epam.aidial.core.server.function.CollectResponseAttachmentsFn;
-import com.epam.aidial.core.server.function.CollectResponseChatCompletionAttachmentsFn;
 import com.epam.aidial.core.server.function.CollectToolSetsFn;
 import com.epam.aidial.core.server.function.enhancement.ApplyDefaultDeploymentSettingsFn;
 import com.epam.aidial.core.server.function.enhancement.EnhanceAssistantRequestFn;
@@ -48,7 +46,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -59,19 +56,16 @@ import static com.epam.aidial.core.server.Proxy.HEADER_APPLICATION_ID;
 import static com.epam.aidial.core.server.Proxy.HEADER_APPLICATION_PROPERTIES;
 
 @Slf4j
-public class DeploymentPostController {
+public class DeploymentPostController extends BaseDeploymentPostController {
 
     private static final Set<Integer> DEFAULT_RETRIABLE_HTTP_CODES = Set.of(HttpStatus.TOO_MANY_REQUESTS.getCode(),
             HttpStatus.BAD_GATEWAY.getCode(), HttpStatus.GATEWAY_TIMEOUT.getCode(),
             HttpStatus.SERVICE_UNAVAILABLE.getCode());
 
-    private final Proxy proxy;
-    private final ProxyContext context;
     private final List<BaseRequestFunction<ObjectNode>> enhancementFunctions;
 
     public DeploymentPostController(Proxy proxy, ProxyContext context) {
-        this.proxy = proxy;
-        this.context = context;
+        super(proxy, context);
         this.enhancementFunctions = List.of(new CollectRequestChatCompletionAttachmentsFn(proxy, context),
                 new CollectRequestDataFn(proxy, context),
                 new ApplyDefaultDeploymentSettingsFn(proxy, context),
@@ -374,10 +368,7 @@ public class DeploymentPostController {
             upstreamRoute.fail(proxyResponse);
         }
 
-        CollectResponseAttachmentsFn handler = context.isStreamingRequest() ? new CollectResponseChatCompletionAttachmentsFn(proxy, context) : null;
-
-        BufferingReadStream responseStream = new BufferingReadStream(proxyResponse,
-                ProxyUtil.contentLength(proxyResponse, 1024), handler);
+        BufferingReadStream responseStream = createResponseStream(proxyResponse);
 
         context.setProxyResponse(proxyResponse);
         context.setProxyResponseTimestamp(System.currentTimeMillis());
@@ -461,20 +452,6 @@ public class DeploymentPostController {
         return tokenUsageFuture;
     }
 
-    private Future<Void> collectResponseAttachments(Buffer responseBody) {
-        if (context.isStreamingRequest()) {
-            return Future.succeededFuture();
-        }
-        try (InputStream stream = new ByteBufInputStream(responseBody.getByteBuf())) {
-            ObjectNode tree = (ObjectNode) ProxyUtil.MAPPER.readTree(stream);
-            var fn = new CollectResponseChatCompletionAttachmentsFn(proxy, context);
-            return fn.apply(tree);
-        } catch (IOException e) {
-            log.warn("Can't parse JSON response body. Error:", e);
-            return Future.failedFuture(e);
-        }
-    }
-
     private void completeProxyResponse(BufferingReadStream responseStream) {
         HttpServerResponse response = context.getResponse();
         responseStream.end(response);
@@ -496,24 +473,6 @@ public class DeploymentPostController {
                 currentUpstream == null ? "N/A" : currentUpstream.getExtraData());
 
         finalizeRequest();
-    }
-
-    /**
-     * Called when proxy failed to receive request body from the client.
-     */
-    private void handleRequestBodyError(Throwable error) {
-        respond(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to receive body");
-        log.warn("Failed to receive client body. Error: {}", error.getMessage());
-    }
-
-    /**
-     * Called when proxy failed to connect to the origin.
-     */
-    private void handleProxyConnectionError(Throwable error) {
-        respond(HttpStatus.BAD_GATEWAY, "Failed to connect to origin");
-        log.warn("Can't connect to origin. Deployment: {}. Address: {}. Error: {}",
-                context.getDeployment().getName(),
-                buildUri(context), error.getMessage());
     }
 
     /**
@@ -576,38 +535,5 @@ public class DeploymentPostController {
             return false;
         }
         return true;
-    }
-
-    private Future<?> respond(HttpStatus status, String errorMessage) {
-        finalizeRequest();
-        return context.respond(status, errorMessage);
-    }
-
-    private void respond(HttpException exception) {
-        finalizeRequest();
-        context.respond(exception);
-    }
-
-    private void respond(HttpStatus status) {
-        finalizeRequest();
-        context.respond(status);
-    }
-
-    private void respond(HttpStatus status, Object result) {
-        finalizeRequest();
-        context.respond(status, result);
-    }
-
-    private void finalizeRequest() {
-        proxy.getTokenStatsTracker().endSpan(context).onFailure(error -> log.error("Error occurred at completing span", error));
-        ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
-        if (proxyApiKeyData != null) {
-            proxy.getApiKeyStore().invalidatePerRequestApiKey(proxyApiKeyData)
-                    .onSuccess(invalidated -> {
-                        if (!invalidated) {
-                            log.warn("Per request is not removed: {}", proxyApiKeyData.getPerRequestKey());
-                        }
-                    }).onFailure(error -> log.error("error occurred on invalidating per-request key", error));
-        }
     }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/InterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/InterceptorController.java
@@ -7,8 +7,6 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.function.BaseRequestFunction;
 import com.epam.aidial.core.server.function.CollectRequestChatCompletionAttachmentsFn;
 import com.epam.aidial.core.server.function.CollectRequestDataFn;
-import com.epam.aidial.core.server.function.CollectResponseAttachmentsFn;
-import com.epam.aidial.core.server.function.CollectResponseChatCompletionAttachmentsFn;
 import com.epam.aidial.core.server.function.enhancement.ApplyDefaultDeploymentSettingsFn;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
@@ -30,16 +28,12 @@ import java.io.InputStream;
 import java.util.List;
 
 @Slf4j
-public class InterceptorController {
-
-    private final Proxy proxy;
-    private final ProxyContext context;
+public class InterceptorController extends BaseDeploymentPostController {
 
     private final List<BaseRequestFunction<ObjectNode>> enhancementFunctions;
 
     public InterceptorController(Proxy proxy, ProxyContext context) {
-        this.proxy = proxy;
-        this.context = context;
+        super(proxy, context);
         this.enhancementFunctions = List.of(new ApplyDefaultDeploymentSettingsFn(proxy, context),
                 new CollectRequestChatCompletionAttachmentsFn(proxy, context),
                 new CollectRequestDataFn(proxy, context));
@@ -110,21 +104,6 @@ public class InterceptorController {
                 .onFailure(this::handleProxyConnectionError);
     }
 
-    private void handleRequestBodyError(Throwable error) {
-        respond(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to receive body");
-        log.warn("Failed to receive client body. Error: {}", error.getMessage());
-    }
-
-    /**
-     * Called when proxy failed to connect to the origin.
-     */
-    private void handleProxyConnectionError(Throwable error) {
-        respond(HttpStatus.BAD_GATEWAY, "Failed to connect to origin");
-        log.warn("Can't connect to origin.  Deployment: {}. Address: {}. Error: {}",
-                context.getDeployment().getName(),
-                context.getDeployment().getEndpoint(), error.getMessage());
-    }
-
 
     void handleProxyRequest(HttpClientRequest proxyRequest) {
         log.info("Connected to interceptor. Deployment: {}. Address: {}",
@@ -162,10 +141,7 @@ public class InterceptorController {
                 context.getDeployment().getEndpoint(),
                 proxyResponse.statusCode(), proxyResponse.headers().size());
 
-        CollectResponseAttachmentsFn handler = context.isStreamingRequest() ? new CollectResponseChatCompletionAttachmentsFn(proxy, context) : null;
-
-        BufferingReadStream responseStream = new BufferingReadStream(proxyResponse,
-                ProxyUtil.contentLength(proxyResponse, 1024), handler);
+        BufferingReadStream responseStream = createResponseStream(proxyResponse);
 
         context.setProxyResponse(proxyResponse);
         context.setProxyResponseTimestamp(System.currentTimeMillis());
@@ -196,20 +172,6 @@ public class InterceptorController {
         });
     }
 
-    private Future<Void> collectResponseAttachments(Buffer responseBody) {
-        if (context.isStreamingRequest()) {
-            return Future.succeededFuture();
-        }
-        try (InputStream stream = new ByteBufInputStream(responseBody.getByteBuf())) {
-            ObjectNode tree = (ObjectNode) ProxyUtil.MAPPER.readTree(stream);
-            var fn = new CollectResponseChatCompletionAttachmentsFn(proxy, context);
-            return fn.apply(tree);
-        } catch (Throwable e) {
-            log.warn("Can't parse JSON response body. Error:", e);
-            return Future.failedFuture(e);
-        }
-    }
-
     private void completeProxyResponse(BufferingReadStream responseStream) {
         HttpServerResponse response = context.getResponse();
         responseStream.end(response);
@@ -225,29 +187,6 @@ public class InterceptorController {
         context.getProxyRequest().reset(); // drop connection to stop origin response
         context.getResponse().reset();     // drop connection, so that partial client response won't seem complete
         finalizeRequest();
-    }
-
-    private void respond(HttpStatus status) {
-        finalizeRequest();
-        context.respond(status);
-    }
-
-    private void respond(HttpStatus status, Object result) {
-        finalizeRequest();
-        context.respond(status, result);
-    }
-
-    private void finalizeRequest() {
-        proxy.getTokenStatsTracker().endSpan(context).onFailure(error -> log.error("Error occurred at completing span", error));
-        ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
-        if (proxyApiKeyData != null) {
-            proxy.getApiKeyStore().invalidatePerRequestApiKey(proxyApiKeyData)
-                    .onSuccess(invalidated -> {
-                        if (!invalidated) {
-                            log.warn("Per request is not removed: {}", proxyApiKeyData.getPerRequestKey());
-                        }
-                    }).onFailure(error -> log.error("error occurred on invalidating per-request key", error));
-        }
     }
 
 }

--- a/server/src/main/java/com/epam/aidial/core/server/util/EventStreamParser.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/EventStreamParser.java
@@ -78,7 +78,7 @@ public class EventStreamParser {
                 }
             }
         } catch (Throwable e) {
-            log.warn("Error occurred at parsing chunk", e);
+            log.debug("Error occurred at parsing chunk", e);
             return Future.failedFuture(e);
         }
 

--- a/server/src/main/java/com/epam/aidial/core/server/util/EventStreamParser.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/EventStreamParser.java
@@ -78,7 +78,7 @@ public class EventStreamParser {
                 }
             }
         } catch (Throwable e) {
-            log.debug("Error occurred at parsing chunk", e);
+            log.error("Error occurred at parsing chunk", e);
             return Future.failedFuture(e);
         }
 


### PR DESCRIPTION
That's a normal case when LLM provider may return response not in SSE format despite on the flag `streaming` is set to `true`, e.g. in case of bad request 400 or something else.
