### PR TITLE
fix: Indefinite spinner when creating ToolSet for MCP, which doesn't provide 'resource_metadata' in response header

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -71,8 +71,12 @@ public class ResourceAuthorizationClient {
         if (status != 200 && status != 201) {
             log.debug("Error executing request {}: status {}, response {}, headers: {}",
                     request.uri(), response.statusCode(), response.body(), response.headers());
-            throw new HttpException(status, "Authorization server returns error code",
-                    httpHeadersHandler.convertHttpHeadersToMap(response.headers()));
+            if (status == 401) {
+                throw new HttpException(status, "Authorization server returns 401 error code",
+                        httpHeadersHandler.convertHttpHeadersToMap(response.headers()));
+            } else {
+                throw new HttpException(status, "Authorization server returns error code");
+            }
         }
 
         return JsonMapperUtil.convertToObject(body, responseType);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/metadata/ProtectedResourceMetadataService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/metadata/ProtectedResourceMetadataService.java
@@ -104,10 +104,10 @@ public class ProtectedResourceMetadataService {
      *
      * @param resourceEndpoint The base URL of the resource endpoint.
      * @return The {@link AuthorizationServerProtectedResourceMetadata}, or {@code null} if metadata cannot be resolved.
-     * @throws HttpException If the HTTP request fails with a non-recoverable status.
      */
     private AuthorizationServerProtectedResourceMetadata tryFetchMetadataUsingHeader(String resourceEndpoint) {
         try {
+            log.debug("Resolving Resource Metadata endpoint for resource: {}", resourceEndpoint);
             resourceAuthorizationClient.executePost(resourceEndpoint, "{}", ContentType.APPLICATION_JSON.toString(), Object.class);
         } catch (HttpException e) {
             HttpStatus httpExceptionStatus = e.getStatus();
@@ -117,15 +117,9 @@ public class ProtectedResourceMetadataService {
                     log.debug("Retrieved metadata URL from WWW-Authenticate header: {}", metadataUrl.get());
                     return tryFetchMetadata(metadataUrl.get());
                 }
-                log.debug("401 Unauthorized at endpoint: {}. Proceeding to next fallback.", resourceEndpoint);
-            } else if (httpExceptionStatus.is4xx()) {
-                log.debug("{} at endpoint: {}. Proceeding to next fallback.", httpExceptionStatus.getCode(), resourceEndpoint);
-            } else {
-                throw e;
             }
-            return null;
+            log.debug("{} at endpoint: {}. Proceeding to next fallback.", httpExceptionStatus.getCode(), resourceEndpoint);
         }
-        log.debug("Resolving Resource Metadata endpoint for resource: {}", resourceEndpoint);
         return null;
     }
 
@@ -154,6 +148,7 @@ public class ProtectedResourceMetadataService {
                     || httpExceptionStatus.equals(HttpStatus.NOT_FOUND)) {
                 log.debug("401 Unauthorized at endpoint: {}. Proceeding to next fallback.", endpoint);
             } else {
+                log.debug("Error {} getting metadata from endpoint: {}.", httpExceptionStatus.getCode(), endpoint);
                 throw e;
             }
         }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -17,11 +17,13 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -98,7 +100,7 @@ class ResourceAuthorizationClientTest {
 
         //Then
         assertEquals(401, exception.getStatus().getCode());
-        assertEquals("Authorization server returns error code", exception.getMessage());
+        assertEquals("Authorization server returns 401 error code", exception.getMessage());
     }
 
     @Test
@@ -106,6 +108,7 @@ class ResourceAuthorizationClientTest {
         // Given
         String url = "https://example.com/resource";
         TestRequest requestPayload = new TestRequest("testValue");
+
         String jsonResponse = "{\"key\":\"responseValue\"}";
         HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
@@ -119,6 +122,58 @@ class ResourceAuthorizationClientTest {
         // Then
         assertNotNull(actualResponse);
         assertEquals("responseValue", actualResponse.getKey());
+    }
+
+    @Test
+    void testExecutePost_NotFoundStatusStatus() throws Exception {
+        // Given
+        String url = "https://example.com/resource";
+        TestRequest requestPayload = new TestRequest("testValue");
+
+        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(404);
+
+        HttpHeaders httpHeadersMock = mock(HttpHeaders.class);
+        when(httpHeadersMock.map()).thenReturn(Map.of("header_1", List.of("header_1_value")));
+        when(httpResponseMock.headers()).thenReturn(httpHeadersMock);
+
+        // When
+        HttpException exception = assertThrows(HttpException.class, () ->
+                resourceAuthorizationClient.executePost(url, requestPayload,
+                        ContentType.APPLICATION_JSON.toString(), TestResponse.class));
+
+        // Then
+        assertEquals(404, exception.getStatus().getCode());
+        assertEquals("Authorization server returns error code", exception.getMessage());
+        assertTrue(exception.getHeaders().isEmpty());
+    }
+
+    @Test
+    void testExecutePost_UnauthorizedStatus() throws Exception {
+        // Given
+        String url = "https://example.com/resource";
+        TestRequest requestPayload = new TestRequest("testValue");
+
+        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(401);
+
+        HttpHeaders httpHeadersMock = mock(HttpHeaders.class);
+        when(httpHeadersMock.map()).thenReturn(Map.of("header_1", List.of("header_1_value")));
+        when(httpResponseMock.headers()).thenReturn(httpHeadersMock);
+        Map<String, String> expectedResponseHeaders = Map.of("header_1", "header_1_value");
+        when(httpHeadersHandler.convertHttpHeadersToMap(httpHeadersMock)).thenReturn(expectedResponseHeaders);
+
+        // When
+        HttpException exception = assertThrows(HttpException.class, () ->
+                resourceAuthorizationClient.executePost(url, requestPayload,
+                        ContentType.APPLICATION_JSON.toString(), TestResponse.class));
+
+        // Then
+        assertEquals(401, exception.getStatus().getCode());
+        assertEquals("Authorization server returns 401 error code", exception.getMessage());
+        assertEquals(expectedResponseHeaders, exception.getHeaders());
     }
 
     @Data


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1050 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
