### PR TITLE
fix: ToolSets API doesn't provide GET endpoint for calling MCP via SSE protocol

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -42,19 +42,13 @@ public class ResourceAuthSettingsService {
         ClientRegistration clientRegistration = resourceRegistrationService.register(
                 resourceId, resourceEndpoint, resourceAuthSettings);
 
-        CodeVerifier codeVerifier = new CodeVerifier();
-        CodeChallengeMethod codeChallengeMethod = CodeChallengeMethod.parse(clientRegistration.getCodeChallengeMethod());
-        CodeChallenge codeChallenge = CodeChallenge.compute(codeChallengeMethod, codeVerifier);
-
         resourceAuthSettings.setClientId(clientRegistration.getClientId());
         resourceAuthSettings.setClientSecret(clientRegistration.getClientSecret());
         resourceAuthSettings.setAuthorizationEndpoint(clientRegistration.getAuthorizationEndpoint());
         resourceAuthSettings.setTokenEndpoint(clientRegistration.getTokenEndpoint());
         resourceAuthSettings.setRedirectUri(clientRegistration.getRedirectUri());
-        resourceAuthSettings.setCodeChallenge(codeChallenge.getValue());
-        resourceAuthSettings.setCodeVerifier(codeVerifier.getValue());
-        resourceAuthSettings.setCodeChallengeMethod(codeChallengeMethod.getValue());
         resourceAuthSettings.setScopesSupported(clientRegistration.getScopesSupported());
+        setCodeChallengeProperties(resourceAuthSettings, clientRegistration.getCodeChallengeMethod());
     }
 
     public void setResourceAuthStatuses(String resourceId,
@@ -95,6 +89,19 @@ public class ResourceAuthSettingsService {
             resourceAuthSettings.setGlobalAuthStatus(ResourceAuthStatus.SIGNED_IN);
         } else {
             resourceAuthSettings.setGlobalAuthStatus(ResourceAuthStatus.SIGNED_OUT);
+        }
+    }
+
+    private void setCodeChallengeProperties(ResourceAuthSettings resourceAuthSettings,
+                                            String codeChallengeMethod) {
+        if (codeChallengeMethod != null) {
+            CodeVerifier codeVerifier = new CodeVerifier();
+            CodeChallengeMethod parsedCodeChallengeMethod = CodeChallengeMethod.parse(codeChallengeMethod);
+            CodeChallenge codeChallenge = CodeChallenge.compute(parsedCodeChallengeMethod, codeVerifier);
+
+            resourceAuthSettings.setCodeChallenge(codeChallenge.getValue());
+            resourceAuthSettings.setCodeVerifier(codeVerifier.getValue());
+            resourceAuthSettings.setCodeChallengeMethod(parsedCodeChallengeMethod.getValue());
         }
     }
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.http.ContentType;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Strategy for performing dynamic registration of a protected resource.
@@ -87,9 +88,12 @@ public class DynamicResourceRegistrationStrategy implements ResourceRegistration
                 .redirectUri(clientRegistrationResponse.getRedirectUris().getFirst())
                 .authorizationEndpoint(authServerMetadata.getAuthorizationEndpoint())
                 .tokenEndpoint(authServerMetadata.getTokenEndpoint())
-                .codeChallengeMethod(getCodeChallengeMethod(authServerMetadata))
                 .scopesSupported(supportedScopes)
                 .build();
+
+        Optional<String> codeChallengeMethod = getCodeChallengeMethod(authServerMetadata);
+        codeChallengeMethod.ifPresent(clientRegistration::setCodeChallengeMethod);
+
         log.info("Finished dynamic registration for Resource: {}", resourceId);
         return clientRegistration;
     }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/ResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/ResourceRegistrationStrategy.java
@@ -16,11 +16,22 @@ public interface ResourceRegistrationStrategy {
     ClientRegistration register(String resourceId, String resourceEndpoint, ResourceAuthSettings resourceAuthSettings);
 
     default Optional<String> getCodeChallengeMethod(AuthorizationServerMetadata metadata) {
-        return Optional.ofNullable(metadata.getCodeChallengeMethodsSupported())
-                .filter(codeChallengeMethodsSupported -> !codeChallengeMethodsSupported.isEmpty())
-                .map(codeChallengeMethodsSupported -> codeChallengeMethodsSupported.contains(CodeChallengeMethod.S256.getValue())
-                        ? CodeChallengeMethod.S256.getValue()
-                        : CodeChallengeMethod.PLAIN.getValue());
+        List<String> codeChallengeMethodsSupported = metadata.getCodeChallengeMethodsSupported();
+
+        if (codeChallengeMethodsSupported == null || codeChallengeMethodsSupported.isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolean containsS256 = codeChallengeMethodsSupported.contains(CodeChallengeMethod.S256.getValue());
+        boolean containsPlain = codeChallengeMethodsSupported.contains(CodeChallengeMethod.PLAIN.getValue());
+
+        if (!containsS256 && !containsPlain) {
+            throw new IllegalArgumentException("Unsupported code challenge methods detected: " + codeChallengeMethodsSupported);
+        }
+
+        return containsS256
+                ? Optional.of(CodeChallengeMethod.S256.getValue())
+                : Optional.of(CodeChallengeMethod.PLAIN.getValue());
     }
 
     default List<String> collectSupportedScopes(AuthorizationServerProtectedResourceMetadata protectedResourceMetadata,

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/ResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/ResourceRegistrationStrategy.java
@@ -9,29 +9,34 @@ import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ResourceRegistrationStrategy {
     ClientRegistration register(String resourceId, String resourceEndpoint, ResourceAuthSettings resourceAuthSettings);
 
-    default String getCodeChallengeMethod(AuthorizationServerMetadata metadata) {
-        List<String> supportedMethods = metadata.getCodeChallengeMethodsSupported();
-        return supportedMethods == null
-                || supportedMethods.isEmpty()
-                || supportedMethods.contains(CodeChallengeMethod.S256.getValue())
-                ? CodeChallengeMethod.S256.getValue()
-                : supportedMethods.getFirst();
+    default Optional<String> getCodeChallengeMethod(AuthorizationServerMetadata metadata) {
+        return Optional.ofNullable(metadata.getCodeChallengeMethodsSupported())
+                .filter(codeChallengeMethodsSupported -> !codeChallengeMethodsSupported.isEmpty())
+                .map(codeChallengeMethodsSupported -> codeChallengeMethodsSupported.contains(CodeChallengeMethod.S256.getValue())
+                        ? CodeChallengeMethod.S256.getValue()
+                        : CodeChallengeMethod.PLAIN.getValue());
     }
 
     default List<String> collectSupportedScopes(AuthorizationServerProtectedResourceMetadata protectedResourceMetadata,
                                                 AuthorizationServerMetadata metadata) {
         Set<String> supportedScopes = new HashSet<>();
-        if (protectedResourceMetadata != null && protectedResourceMetadata.getScopesSupported() != null) {
-            supportedScopes.addAll(protectedResourceMetadata.getScopesSupported());
-        }
 
-        if (metadata != null && metadata.getScopesSupported() != null) {
-            supportedScopes.addAll(metadata.getScopesSupported());
+        Optional.ofNullable(protectedResourceMetadata)
+                .map(AuthorizationServerProtectedResourceMetadata::getScopesSupported)
+                .filter(scopes -> !scopes.isEmpty())
+                .ifPresent(supportedScopes::addAll);
+
+        // Using AuthorizationServerMetadata as fallback
+        if (supportedScopes.isEmpty()) {
+            Optional.ofNullable(metadata)
+                    .map(AuthorizationServerMetadata::getScopesSupported)
+                    .ifPresent(supportedScopes::addAll);
         }
 
         return new ArrayList<>(supportedScopes);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
@@ -80,13 +80,13 @@ public class StaticResourceRegistrationStrategy implements ResourceRegistrationS
                         .orElse(authorizationEndpoint);
                 tokenEndpoint = Optional.ofNullable(authServerMetadata.getTokenEndpoint())
                         .orElse(tokenEndpoint);
-                codeChallengeMethod = Optional.ofNullable(getCodeChallengeMethod(authServerMetadata))
+                codeChallengeMethod = getCodeChallengeMethod(authServerMetadata)
                         .orElse(codeChallengeMethod);
             }
         }
 
-        if (authorizationEndpoint == null || tokenEndpoint == null || codeChallengeMethod == null) {
-            throw new IllegalArgumentException("Static resource registration requires: authorizationEndpoint, tokenEndpoint, codeChallengeMethod");
+        if (authorizationEndpoint == null || tokenEndpoint == null) {
+            throw new IllegalArgumentException("Static resource registration requires: authorizationEndpoint, tokenEndpoint");
         }
 
         ClientRegistration clientRegistration = ClientRegistration.builder()

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtil.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtil.java
@@ -9,7 +9,7 @@ import java.net.URISyntaxException;
 public class ResourceEndpointUtil {
 
     /**
-     * Extracts the base URL (scheme + host) from the given input URL, ignoring the path, query, and fragment components.
+     * Extracts the base URL (scheme + host + port (optional)) from the given input URL, ignoring the path, query, and fragment components.
      *
      * @param url The resource endpoint URL
      * @return The base URL
@@ -25,12 +25,17 @@ public class ResourceEndpointUtil {
 
             String scheme = uri.getScheme();
             String host = uri.getHost();
+            int port = uri.getPort();
 
             if (scheme == null || host == null) {
                 throw new IllegalArgumentException("Invalid URL: Missing scheme or host.");
             }
 
-            return scheme + "://" + host;
+            return String.format("%s://%s%s",
+                    scheme,
+                    host,
+                    (port > 0 ? ":" + port : "")
+            );
 
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid URL format: " + url, e);
@@ -40,27 +45,37 @@ public class ResourceEndpointUtil {
     /**
      * Builds the resource metadata endpoint based on a resource endpoint.
      *
-     * @param resourceEndpoint The resource endpoint
+     * @param url The resource endpoint URL
      * @param wellKnownSuffix The well-known URI suffix
      * @return The constructed metadata endpoint.
      */
-    public static String buildMetadataEndpoint(String resourceEndpoint,
+    public static String buildMetadataEndpoint(String url,
                                                String wellKnownSuffix,
                                                boolean ignorePathSuffix) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("URL cannot be null or empty.");
+        }
+
         try {
-            URI resourceUri = new URI(resourceEndpoint);
+            URI resourceUri = new URI(url);
 
             String scheme = resourceUri.getScheme();
             String host = resourceUri.getHost();
             String path = resourceUri.getPath();
+            int port = resourceUri.getPort();
+
+            if (scheme == null || host == null) {
+                throw new IllegalArgumentException("Invalid URL: Missing scheme or host.");
+            }
 
             if (path.endsWith("/")) {
                 path = path.substring(0, path.length() - 1);
             }
 
-            return String.format("%s://%s/.well-known/%s%s",
+            return String.format("%s://%s%s/.well-known/%s%s",
                     scheme,
                     host,
+                    (port > 0 ? ":" + port : ""),
                     wellKnownSuffix,
                     path.isEmpty() || ignorePathSuffix ? "" : path
             );

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
@@ -6,15 +6,31 @@ import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ResourceAuthStatus;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
-import org.junit.jupiter.api.Assertions;
+import com.epam.aidial.core.credentials.data.registration.ClientRegistration;
+import com.epam.aidial.core.credentials.service.registration.ResourceRegistrationService;
+import com.epam.aidial.core.credentials.validation.ResourceAuthSettingsValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class ResourceAuthSettingsServiceTest {
 
@@ -24,6 +40,12 @@ class ResourceAuthSettingsServiceTest {
     @Mock
     private ResourceCredentialsManager resourceCredentialsManager;
 
+    @Mock
+    private ResourceAuthSettingsValidator resourceAuthSettingsValidator;
+
+    @Mock
+    private ResourceRegistrationService resourceRegistrationService;
+
     @InjectMocks
     private ResourceAuthSettingsService resourceAuthSettingsService;
 
@@ -32,144 +54,219 @@ class ResourceAuthSettingsServiceTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    @Test
-    void testSetResourceAuthStatuses_User1SignedIn() {
+    private static Stream<Arguments> provideSetResourceAuthStatusesTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        createUserLevelResourceCredentials(true, USER_1),
+                        null,
+                        ResourceAuthStatus.SIGNED_IN,
+                        ResourceAuthStatus.SIGNED_OUT),
+
+                Arguments.of(
+                        createUserLevelResourceCredentials(false, USER_1),
+                        null,
+                        ResourceAuthStatus.SIGNED_OUT,
+                        ResourceAuthStatus.SIGNED_OUT),
+
+                Arguments.of(
+                        null,
+                        null,
+                        ResourceAuthStatus.SIGNED_OUT,
+                        ResourceAuthStatus.SIGNED_OUT),
+
+                Arguments.of(
+                        createUserLevelResourceCredentials(false, USER_1),
+                        createGlobalLevelResourceCredentials(true),
+                        ResourceAuthStatus.SIGNED_OUT,
+                        ResourceAuthStatus.SIGNED_IN),
+
+                Arguments.of(
+                        null,
+                        createGlobalLevelResourceCredentials(true),
+                        ResourceAuthStatus.SIGNED_OUT,
+                        ResourceAuthStatus.SIGNED_IN),
+
+                Arguments.of(
+                        createUserLevelResourceCredentials(true, USER_1),
+                        createGlobalLevelResourceCredentials(true),
+                        ResourceAuthStatus.SIGNED_IN,
+                        ResourceAuthStatus.SIGNED_IN),
+
+                Arguments.of(
+                        createUserLevelResourceCredentials(true, USER_1),
+                        createGlobalLevelResourceCredentials(false),
+                        ResourceAuthStatus.SIGNED_IN,
+                        ResourceAuthStatus.SIGNED_OUT),
+
+                Arguments.of(
+                        createUserLevelResourceCredentials(false, USER_1),
+                        createGlobalLevelResourceCredentials(false),
+                        ResourceAuthStatus.SIGNED_OUT,
+                        ResourceAuthStatus.SIGNED_OUT),
+
+                Arguments.of(
+                        createUserLevelResourceCredentials(true, USER_2),
+                        createGlobalLevelResourceCredentials(false),
+                        ResourceAuthStatus.SIGNED_OUT,
+                        ResourceAuthStatus.SIGNED_OUT)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSetResourceAuthStatusesTestCases")
+    void testSetResourceAuthStatuses(ResourceCredentials userCredentials,
+                                     ResourceCredentials globalCredentials,
+                                     ResourceAuthStatus expectedUserLevelStatus,
+                                     ResourceAuthStatus expectedGlobalLevelStatus) {
         // Given
         ToolSet toolSet = createToolSet();
-        ResourceCredentials expiredUserCredentials = createUserLevelResourceCredentials(false, USER_1);
-        ResourceCredentials nonExpiredUserCredentials = createUserLevelResourceCredentials(true, USER_1);
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
-                .thenReturn(List.of(expiredUserCredentials, nonExpiredUserCredentials));
+        when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
+                .thenReturn(
+                        Stream.of(userCredentials, globalCredentials)
+                                .filter(Objects::nonNull)
+                                .toList());
 
         // When
         resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
 
         // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_IN, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getGlobalAuthStatus());
+        assertEquals(expectedUserLevelStatus, toolSet.getAuthSettings().getUserLevelAuthStatus());
+        assertEquals(expectedGlobalLevelStatus, toolSet.getAuthSettings().getGlobalAuthStatus());
     }
 
     @Test
-    void testSetResourceAuthStatuses_User1SignedOut() {
+    void testEnrichResourceAuthSettings_NoAuthSettings() {
         // Given
-        ToolSet toolSet = createToolSet();
-        ResourceCredentials expiredUserCredentials = createUserLevelResourceCredentials(false, USER_2);
-        ResourceCredentials nonExpiredUserCredentials = createUserLevelResourceCredentials(true, USER_2);
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
-                .thenReturn(List.of(expiredUserCredentials, nonExpiredUserCredentials));
+        String resourceId = "resource-id";
+        String resourceEndpoint = "https://example.com";
 
-        // When
-        resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> resourceAuthSettingsService.enrichResourceAuthSettings(resourceId, resourceEndpoint, null)
+        );
 
-        // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getGlobalAuthStatus());
+        assertEquals("ResourceAuthSettings is not defined for Resource: " + resourceId, exception.getMessage());
     }
 
     @Test
-    void testSetResourceAuthStatuses_User1WithExpiredCredsSignedOut() {
+    void testEnrichResourceAuthSettings_Validated() {
         // Given
-        ToolSet toolSet = createToolSet();
-        ResourceCredentials expiredUserCredentials = createUserLevelResourceCredentials(false, USER_1);
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
-                .thenReturn(List.of(expiredUserCredentials));
+        String resourceId = "resource-id";
+        String resourceEndpoint = "https://example.com";
+        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
+        resourceAuthSettings.setAuthenticationType(AuthenticationType.OAUTH);
+
+        ClientRegistration mockClientRegistration = ClientRegistration.builder().build();
+        when(resourceRegistrationService.register(resourceId, resourceEndpoint, resourceAuthSettings))
+                .thenReturn(mockClientRegistration);
 
         // When
-        resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
+        resourceAuthSettingsService.enrichResourceAuthSettings(resourceId, resourceEndpoint, resourceAuthSettings);
 
         // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getGlobalAuthStatus());
+        verify(resourceAuthSettingsValidator, times(1)).validate(resourceAuthSettings);
     }
 
     @Test
-    void testSetResourceAuthStatuses_GlobalSignedIn() {
+    void testEnrichResourceAuthSettings_ApiKey() {
         // Given
-        ToolSet toolSet = createToolSet();
-        ResourceCredentials globalCredentials = createGlobalLevelResourceCredentials(true);
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
-                .thenReturn(List.of(globalCredentials));
+        String resourceId = "resource-id";
+        String resourceEndpoint = "https://example.com";
+        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
+        resourceAuthSettings.setAuthenticationType(AuthenticationType.API_KEY);
 
         // When
-        resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
+        resourceAuthSettingsService.enrichResourceAuthSettings(resourceId, resourceEndpoint, resourceAuthSettings);
 
         // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_IN, toolSet.getAuthSettings().getGlobalAuthStatus());
+        verifyNoInteractions(resourceRegistrationService);
+        assertNull(resourceAuthSettings.getClientId());
+        assertNull(resourceAuthSettings.getClientSecret());
     }
 
     @Test
-    void testSetResourceAuthStatuses_GlobalSignedOut() {
+    void testEnrichResourceAuthSettings_Success() {
         // Given
-        ToolSet toolSet = createToolSet();
-        ResourceCredentials globalCredentials = createGlobalLevelResourceCredentials(false);
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
-                .thenReturn(List.of(globalCredentials));
+        String resourceId = "resource-id";
+        String resourceEndpoint = "https://example.com";
+        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
+        resourceAuthSettings.setAuthenticationType(AuthenticationType.OAUTH);
+
+        ClientRegistration mockClientRegistration = ClientRegistration.builder()
+                .clientId("mock-client-id")
+                .clientSecret("mock-client-secret")
+                .authorizationEndpoint("mock-auth-endpoint")
+                .tokenEndpoint("mock-token-endpoint")
+                .redirectUri("mock-redirect-uri")
+                .scopesSupported(List.of("scope1", "scope2"))
+                .codeChallengeMethod("S256")
+                .build();
+
+        when(resourceRegistrationService.register(resourceId, resourceEndpoint, resourceAuthSettings))
+                .thenReturn(mockClientRegistration);
 
         // When
-        resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
+        resourceAuthSettingsService.enrichResourceAuthSettings(resourceId, resourceEndpoint, resourceAuthSettings);
 
         // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getGlobalAuthStatus());
+        verify(resourceRegistrationService, times(1)).register(resourceId, resourceEndpoint, resourceAuthSettings);
+        assertEquals("mock-client-id", resourceAuthSettings.getClientId());
+        assertEquals("mock-client-secret", resourceAuthSettings.getClientSecret());
+        assertEquals("mock-auth-endpoint", resourceAuthSettings.getAuthorizationEndpoint());
+        assertEquals("mock-token-endpoint", resourceAuthSettings.getTokenEndpoint());
+        assertEquals("mock-redirect-uri", resourceAuthSettings.getRedirectUri());
+        assertEquals(List.of("scope1", "scope2"), resourceAuthSettings.getScopesSupported());
     }
 
     @Test
-    void testSetResourceAuthStatuses_GlobalAndUserSignedIn() {
+    void shouldSetCodeChallengePropertiesWhenMethodIsProvided() {
         // Given
-        ToolSet toolSet = createToolSet();
-        ResourceCredentials userCredentials = createUserLevelResourceCredentials(true, USER_1);
-        ResourceCredentials globalCredentials = createGlobalLevelResourceCredentials(true);
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName()))
-                .thenReturn(List.of(userCredentials, globalCredentials));
+        String resourceId = "resource-id";
+        String resourceEndpoint = "https://example.com";
+        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
+        resourceAuthSettings.setAuthenticationType(AuthenticationType.OAUTH);
+
+        ClientRegistration mockClientRegistration = ClientRegistration.builder()
+                .codeChallengeMethod("S256")
+                .build();
+
+        when(resourceRegistrationService.register(resourceId, resourceEndpoint, resourceAuthSettings))
+                .thenReturn(mockClientRegistration);
 
         // When
-        resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
+        resourceAuthSettingsService.enrichResourceAuthSettings(resourceId, resourceEndpoint, resourceAuthSettings);
 
         // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_IN, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_IN, toolSet.getAuthSettings().getGlobalAuthStatus());
-    }
-
-    @Test
-    void testSetResourceAuthStatuses_NoCredentials() {
-        // Given
-        ToolSet toolSet = createToolSet();
-        Mockito.when(resourceCredentialsManager.getAllResourceCredentials(toolSet.getName())).thenReturn(List.of());
-
-        // When
-        resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), USER_1);
-
-        // Then
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getUserLevelAuthStatus());
-        Assertions.assertEquals(ResourceAuthStatus.SIGNED_OUT, toolSet.getAuthSettings().getGlobalAuthStatus());
+        assertNotNull(resourceAuthSettings.getCodeChallenge());
+        assertNotNull(resourceAuthSettings.getCodeVerifier());
+        assertEquals("S256", resourceAuthSettings.getCodeChallengeMethod());
     }
 
     private ToolSet createToolSet() {
         ResourceAuthSettings authSettings = new ResourceAuthSettings();
         ToolSet toolSet = Mockito.mock(ToolSet.class);
-        Mockito.when(toolSet.getName()).thenReturn("toolset-1");
-        Mockito.when(toolSet.getAuthSettings()).thenReturn(authSettings);
+        when(toolSet.getName()).thenReturn("toolset-1");
+        when(toolSet.getAuthSettings()).thenReturn(authSettings);
         return toolSet;
     }
 
-    private ResourceCredentials createGlobalLevelResourceCredentials(boolean isAlive) {
+    private static ResourceCredentials createGlobalLevelResourceCredentials(boolean isAlive) {
         return createResourceCredentials(CredentialsLevel.GLOBAL, AuthenticationType.OAUTH, isAlive, null);
     }
 
-    private ResourceCredentials createUserLevelResourceCredentials(boolean isAlive, String userSub) {
+    private static ResourceCredentials createUserLevelResourceCredentials(boolean isAlive, String userSub) {
         return createResourceCredentials(CredentialsLevel.USER, AuthenticationType.OAUTH, isAlive, userSub);
     }
 
-    private ResourceCredentials createResourceCredentials(CredentialsLevel level,
-                                                          AuthenticationType authenticationType,
-                                                          boolean isAlive,
-                                                          String userSub) {
+    private static ResourceCredentials createResourceCredentials(CredentialsLevel level,
+                                                                 AuthenticationType authenticationType,
+                                                                 boolean isAlive,
+                                                                 String userSub) {
         ResourceCredentials credentials = Mockito.mock(ResourceCredentials.class);
-        Mockito.when(credentials.getCredentialsLevel()).thenReturn(level);
-        Mockito.when(credentials.getAuthenticationType()).thenReturn(authenticationType);
-        Mockito.when(credentials.hasUnexpiredToken()).thenReturn(isAlive);
-        Mockito.when(credentials.getUserSub()).thenReturn(userSub);
+        when(credentials.getCredentialsLevel()).thenReturn(level);
+        when(credentials.getAuthenticationType()).thenReturn(authenticationType);
+        when(credentials.hasUnexpiredToken()).thenReturn(isAlive);
+        when(credentials.getUserSub()).thenReturn(userSub);
         return credentials;
     }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
@@ -97,7 +97,7 @@ class DynamicResourceRegistrationStrategyTest {
         assertEquals(resourceRedirectUri, result.getRedirectUri());
         List<String> actualScopesSupported = result.getScopesSupported();
         Collections.sort(actualScopesSupported);
-        assertEquals(List.of("scope1", "scope2", "scope3", "scope4"), actualScopesSupported);
+        assertEquals(List.of("scope1", "scope2"), actualScopesSupported);
         verify(authorizationServerMetadataService, times(1)).getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, true);
         verify(resourceAuthorizationClient, times(1)).executePost(

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/ResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/ResourceRegistrationStrategyTest.java
@@ -1,0 +1,64 @@
+package com.epam.aidial.core.credentials.service.registration;
+
+import com.epam.aidial.core.credentials.data.registration.AuthorizationServerMetadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResourceRegistrationStrategyTest {
+
+    private final TestResourceRegistrationStrategy resourceRegistrationStrategy = new TestResourceRegistrationStrategy();
+
+    static Stream<TestCase> provideTestCases() {
+        return Stream.of(
+                new TestCase(List.of("S256", "plain"), Optional.of("S256"), null),
+                new TestCase(List.of("plain"), Optional.of("plain"), null),
+                new TestCase(List.of(), Optional.empty(), null),
+                new TestCase(null, Optional.empty(), null),
+                new TestCase(List.of("INVALID_METHOD"), null, "Unsupported code challenge methods detected: [INVALID_METHOD]"),
+                new TestCase(List.of("plain", "INVALID_METHOD"), Optional.of("plain"), null),
+                new TestCase(List.of("S256", "INVALID_METHOD"), Optional.of("S256"), null),
+                new TestCase(List.of("INVALID_METHOD", "ANOTHER_INVALID"), null, "Unsupported code challenge methods detected: [INVALID_METHOD, ANOTHER_INVALID]")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testGetCodeChallengeMethod(TestCase testCase) {
+        AuthorizationServerMetadata metadata = mock(AuthorizationServerMetadata.class);
+
+        when(metadata.getCodeChallengeMethodsSupported()).thenReturn(testCase.codeChallengeMethodsSupported);
+
+        if (testCase.exceptionMessage != null) {
+            IllegalArgumentException exception = Assertions.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> resourceRegistrationStrategy.getCodeChallengeMethod(metadata)
+            );
+            Assertions.assertEquals(testCase.exceptionMessage, exception.getMessage());
+        } else {
+            Optional<String> result = resourceRegistrationStrategy.getCodeChallengeMethod(metadata);
+            Assertions.assertEquals(testCase.expectedResult, result);
+        }
+    }
+
+    /**
+     * @noinspection OptionalUsedAsFieldOrParameterType*/
+    private static class TestCase {
+        List<String> codeChallengeMethodsSupported;
+        Optional<String> expectedResult;
+        String exceptionMessage;
+
+        TestCase(List<String> codeChallengeMethodsSupported, Optional<String> expectedResult, String exceptionMessage) {
+            this.codeChallengeMethodsSupported = codeChallengeMethodsSupported;
+            this.expectedResult = expectedResult;
+            this.exceptionMessage = exceptionMessage;
+        }
+    }
+}

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
@@ -50,7 +50,7 @@ class StaticResourceRegistrationStrategyTest {
 
         AuthorizationServerProtectedResourceMetadata protectedResourceMetadata = mock(AuthorizationServerProtectedResourceMetadata.class);
         when(protectedResourceMetadata.getAuthorizationServers()).thenReturn(List.of("https://auth.server"));
-        when(protectedResourceMetadata.getScopesSupported()).thenReturn(List.of("scope1"));
+        when(protectedResourceMetadata.getScopesSupported()).thenReturn(List.of());
 
         when(protectedResourceMetadataService.getProtectedResourceMetadata(resourceId, resourceEndpoint)).thenReturn(protectedResourceMetadata);
 
@@ -75,7 +75,7 @@ class StaticResourceRegistrationStrategyTest {
         assertEquals("S256", result.getCodeChallengeMethod());
         List<String> actualScopesSupported = result.getScopesSupported();
         Collections.sort(actualScopesSupported);
-        assertEquals(List.of("scope1", "scope2", "scope3"), actualScopesSupported);
+        assertEquals(List.of("scope2", "scope3"), actualScopesSupported);
         verify(authorizationServerMetadataService, times(1)).getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, false);
     }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/TestResourceRegistrationStrategy.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/TestResourceRegistrationStrategy.java
@@ -1,0 +1,27 @@
+package com.epam.aidial.core.credentials.service.registration;
+
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.credentials.data.registration.AuthorizationServerMetadata;
+import com.epam.aidial.core.credentials.data.registration.AuthorizationServerProtectedResourceMetadata;
+import com.epam.aidial.core.credentials.data.registration.ClientRegistration;
+
+import java.util.List;
+import java.util.Optional;
+
+public class TestResourceRegistrationStrategy implements ResourceRegistrationStrategy {
+
+    @Override
+    public ClientRegistration register(String resourceId, String resourceEndpoint, ResourceAuthSettings resourceAuthSettings) {
+        return null;
+    }
+
+    @Override
+    public Optional<String> getCodeChallengeMethod(AuthorizationServerMetadata metadata) {
+        return ResourceRegistrationStrategy.super.getCodeChallengeMethod(metadata);
+    }
+
+    @Override
+    public List<String> collectSupportedScopes(AuthorizationServerProtectedResourceMetadata protectedResourceMetadata, AuthorizationServerMetadata metadata) {
+        return ResourceRegistrationStrategy.super.collectSupportedScopes(protectedResourceMetadata, metadata);
+    }
+}

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtilTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtilTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ResourceEndpointUtilTest {
 

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtilTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtilTest.java
@@ -1,0 +1,141 @@
+package com.epam.aidial.core.credentials.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourceEndpointUtilTest {
+
+    static Stream<TestCaseBuildBaseResourceEndpoint> provideTestCasesForBaseResourceEndpoint() {
+        return Stream.of(
+                new TestCaseBuildBaseResourceEndpoint("https://example.com/resource", "https://example.com", null),
+                new TestCaseBuildBaseResourceEndpoint("http://localhost:8080/path", "http://localhost:8080", null),
+                new TestCaseBuildBaseResourceEndpoint("https://example.com:8443/path", "https://example.com:8443", null),
+                new TestCaseBuildBaseResourceEndpoint("http://example.org/", "http://example.org", null),
+
+                new TestCaseBuildBaseResourceEndpoint(null, null, "URL cannot be null or empty."),
+                new TestCaseBuildBaseResourceEndpoint("", null, "URL cannot be null or empty."),
+                new TestCaseBuildBaseResourceEndpoint("not-a-valid-url", null, "Invalid URL: Missing scheme or host."),
+                new TestCaseBuildBaseResourceEndpoint("://missing-scheme.com", null, "Invalid URL format: ://missing-scheme.com"),
+                new TestCaseBuildBaseResourceEndpoint("http://", null, "Invalid URL format: http://")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForBaseResourceEndpoint")
+    void testBuildBaseResourceEndpoint(TestCaseBuildBaseResourceEndpoint testCase) {
+        if (testCase.expectedExceptionMessage != null) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> ResourceEndpointUtil.buildBaseResourceEndpoint(testCase.inputUrl),
+                    "Exception was expected but not thrown"
+            );
+            assertEquals(testCase.expectedExceptionMessage, exception.getMessage());
+        } else {
+            String result = ResourceEndpointUtil.buildBaseResourceEndpoint(testCase.inputUrl);
+            assertEquals(testCase.expectedOutput, result);
+        }
+    }
+
+    static Stream<TestCaseBuildMetadataEndpoint> provideTestCasesForMetadataEndpoint() {
+        return Stream.of(
+                new TestCaseBuildMetadataEndpoint(
+                        "https://example.com/resource",
+                        "openid-configuration",
+                        false,
+                        "https://example.com/.well-known/openid-configuration/resource",
+                        null
+                ),
+                new TestCaseBuildMetadataEndpoint(
+                        "http://localhost:8080/path/",
+                        "metadata",
+                        true,
+                        "http://localhost:8080/.well-known/metadata",
+                        null
+                ),
+                new TestCaseBuildMetadataEndpoint(
+                        "https://example.org:8443/",
+                        "discovery",
+                        true,
+                        "https://example.org:8443/.well-known/discovery",
+                        null
+                ),
+
+                new TestCaseBuildMetadataEndpoint(
+                        "invalid-url",
+                        "openid-configuration",
+                        false,
+                        null,
+                        "Invalid URL: Missing scheme or host."
+                ),
+                new TestCaseBuildMetadataEndpoint(
+                        null,
+                        "metadata",
+                        true,
+                        null,
+                        "URL cannot be null or empty."
+                ),
+                new TestCaseBuildMetadataEndpoint(
+                        "",
+                        "metadata",
+                        true,
+                        null,
+                        "URL cannot be null or empty."
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForMetadataEndpoint")
+    void testBuildMetadataEndpoint(TestCaseBuildMetadataEndpoint testCase) {
+        if (testCase.expectedExceptionMessage != null) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> ResourceEndpointUtil.buildMetadataEndpoint(
+                            testCase.resourceEndpoint,
+                            testCase.wellKnownSuffix,
+                            testCase.ignorePathSuffix
+                    )
+            );
+            assertEquals(testCase.expectedExceptionMessage, exception.getMessage());
+        } else {
+            String result = ResourceEndpointUtil.buildMetadataEndpoint(
+                    testCase.resourceEndpoint,
+                    testCase.wellKnownSuffix,
+                    testCase.ignorePathSuffix
+            );
+            assertEquals(testCase.expectedOutput, result);
+        }
+    }
+
+    private static class TestCaseBuildBaseResourceEndpoint {
+        String inputUrl;
+        String expectedOutput;
+        String expectedExceptionMessage;
+
+        TestCaseBuildBaseResourceEndpoint(String inputUrl, String expectedOutput, String expectedExceptionMessage) {
+            this.inputUrl = inputUrl;
+            this.expectedOutput = expectedOutput;
+            this.expectedExceptionMessage = expectedExceptionMessage;
+        }
+    }
+
+    private static class TestCaseBuildMetadataEndpoint {
+        String resourceEndpoint;
+        String wellKnownSuffix;
+        boolean ignorePathSuffix;
+        String expectedOutput;
+        String expectedExceptionMessage;
+
+        TestCaseBuildMetadataEndpoint(String resourceEndpoint, String wellKnownSuffix, boolean ignorePathSuffix, String expectedOutput, String expectedExceptionMessage) {
+            this.resourceEndpoint = resourceEndpoint;
+            this.wellKnownSuffix = wellKnownSuffix;
+            this.ignorePathSuffix = ignorePathSuffix;
+            this.expectedOutput = expectedOutput;
+            this.expectedExceptionMessage = expectedExceptionMessage;
+        }
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
@@ -147,6 +147,10 @@ public class ControllerSelector {
             ToolSetController controller = new ToolSetController(context);
             return controller::getToolSets;
         });
+        get(RouteTemplate.TOOL_SET_PROXY, ((proxy, context, pathMatcher) -> {
+            String toolSetId = UrlUtil.decodePath(pathMatcher.group(1));
+            return new ToolSetProxyController(proxy, context, toolSetId);
+        }));
 
         // POST routes
         post(RouteTemplate.POST_DEPLOYMENT, (proxy, context, pathMatcher) -> {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetController.java
@@ -79,7 +79,6 @@ public class ToolSetController {
             public ToolSet extract(ResourceDescriptor resource, ProxyContext context) {
                 ToolSet toolSet = toolSetService.getToolSet(context, resource).getValue();
                 toolSet.clearAuthSettings();
-                resourceAuthSettingsService.setResourceAuthStatuses(toolSet.getName(), toolSet.getAuthSettings(), context.getUserSub());
                 return toolSet;
             }
         });

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -272,7 +272,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
-    public void testProxyMcpCall() {
+    void testProxyMcpPostCall() {
         String mcpRequest = """
                 {
                    "payload": "foo"
@@ -289,6 +289,22 @@ public class ToolSetApiTest extends ResourceBaseTest {
         };
         try (TestWebServer ignore = new TestWebServer(9876, handler)) {
             Response resp = send(HttpMethod.POST, "/v1/toolset/git/mcp", null, mcpRequest);
+
+            assertEquals(200, resp.status());
+            assertEquals(mcpResponse, resp.body());
+        }
+    }
+
+    @Test
+    void testProxyMcpGetCall() {
+        String mcpResponse = """
+                    {
+                      "result": "success"
+                    }
+                    """;
+        TestWebServer.Handler handler = request -> new MockResponse().setBody(mcpResponse);
+        try (TestWebServer ignore = new TestWebServer(9876, handler)) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/git/mcp");
 
             assertEquals(200, resp.status());
             assertEquals(mcpResponse, resp.body());


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1056 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Adds GET /v1/toolset/{id}/mcp endpoint.
- Makes 'code_challenge_method' property optional on ToolSet creation.
- Makes 'scopes_supported' property retrieved from Protected resource metadata using Auth server metadata as fallback.
- Fixes format for ./well-known urls for getting Protected resource and Auth server metadata

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
