### PR TITLE
fix(toolset): toolset list fails if the encryption method changes

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/encryption/CredentialEncryptionService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/encryption/CredentialEncryptionService.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.credentials.encryption;
 
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
+import com.epam.aidial.core.credentials.exception.EncryptionException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -10,13 +11,21 @@ public class CredentialEncryptionService {
     private final DataEncryptionService dataEncryptionService;
 
     public byte[] encrypt(BucketInfo bucketInfo, byte[] data, byte[] aad) {
-        byte[] contentEncryptionKey = contentEncryptionKeyService.getOrCreateKey(bucketInfo);
-        return dataEncryptionService.encrypt(data, contentEncryptionKey, aad);
+        try {
+            byte[] contentEncryptionKey = contentEncryptionKeyService.getOrCreateKey(bucketInfo);
+            return dataEncryptionService.encrypt(data, contentEncryptionKey, aad);
+        } catch (RuntimeException e) {
+            throw new EncryptionException("Failed to encrypt data", e);
+        }
     }
 
     public byte[] decrypt(BucketInfo bucketInfo, byte[] data, byte[] aad) {
-        byte[] contentEncryptionKey = contentEncryptionKeyService.getOrCreateKey(bucketInfo);
-        return dataEncryptionService.decrypt(data, contentEncryptionKey, aad);
+        try {
+            byte[] contentEncryptionKey = contentEncryptionKeyService.getOrCreateKey(bucketInfo);
+            return dataEncryptionService.decrypt(data, contentEncryptionKey, aad);
+        } catch (RuntimeException e) {
+            throw new EncryptionException("Failed to decrypt data", e);
+        }
     }
 
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/exception/EncryptionException.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/exception/EncryptionException.java
@@ -1,0 +1,7 @@
+package com.epam.aidial.core.credentials.exception;
+
+public class EncryptionException extends RuntimeException {
+    public EncryptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetController.java
@@ -4,6 +4,7 @@ import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
+import com.epam.aidial.core.credentials.exception.EncryptionException;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsService;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ListData;
@@ -81,9 +82,14 @@ public class ToolSetController {
             @SuppressWarnings("unchecked")
             @Override
             public ToolSet extract(ResourceDescriptor resource, ProxyContext context) {
-                ToolSet toolSet = toolSetService.getToolSet(context, resource).getValue();
-                toolSet.clearAuthSettings();
-                return toolSet;
+                try {
+                    ToolSet toolSet = toolSetService.getToolSet(context, resource).getValue();
+                    toolSet.clearAuthSettings();
+                    return toolSet;
+                } catch (EncryptionException ex) {
+                    // If a toolset can't be decrypted, it means the encryption method has changed. Let's assume for now that the toolset was not found.
+                    throw new ResourceNotFoundException("Failed to decrypt toolset: " + resource.getUrl(), ex);
+                }
             }
         });
     }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Toolsets encrypted with an outdated method can no longer be decrypted.  
Instead of returning a corrupted result, we now treat them as not found and do not return them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
