### PR TITLE
fix(toolset): toolset list fails if the encryption method changes

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsEncryptionService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsEncryptionService.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.credentials.service;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.encryption.CredentialEncryptionService;
+import com.epam.aidial.core.credentials.exception.EncryptionException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -50,15 +51,23 @@ public class ResourceAuthSettingsEncryptionService {
     }
 
     private String encryptValue(@Nonnull BucketInfo bucketInfo, @Nonnull String plainText, @Nullable byte[] aad) {
-        byte[] plain = plainText.getBytes(UTF_8);
-        byte[] encrypted = encryptionService.encrypt(bucketInfo, plain, aad);
-        return Base64.getEncoder().encodeToString(encrypted);
+        try {
+            byte[] plain = plainText.getBytes(UTF_8);
+            byte[] encrypted = encryptionService.encrypt(bucketInfo, plain, aad);
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (RuntimeException e) {
+            throw new EncryptionException("Failed to encrypt auth settings", e);
+        }
     }
 
     private String decryptValue(@Nonnull BucketInfo bucketInfo, @Nonnull String encryptedText, @Nullable byte[] aad) {
-        byte[] encrypted = Base64.getDecoder().decode(encryptedText);
-        byte[] plain = encryptionService.decrypt(bucketInfo, encrypted, aad);
-        return new String(plain, UTF_8);
+        try {
+            byte[] encrypted = Base64.getDecoder().decode(encryptedText);
+            byte[] plain = encryptionService.decrypt(bucketInfo, encrypted, aad);
+            return new String(plain, UTF_8);
+        } catch (RuntimeException e) {
+            throw new EncryptionException("Failed to decrypt auth setting", e);
+        }
     }
 
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Toolsets encrypted with an outdated method can no longer be decrypted.
Instead of returning a corrupted result, we now treat them as not found and do not return them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
