### PR TITLE
fix: Toolsets with spaces in name respond with error in Quick app 2.0

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
@@ -23,6 +23,7 @@ import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -71,7 +72,7 @@ public class ToolSetProxyController implements Controller {
         this.context = context;
         this.authorizationHeaderProvider = proxy.getAuthorizationHeaderProvider();
         this.toolSetId = toolSetId;
-        this.credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(toolSetId, context);
+        this.credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(UrlUtil.encodePath(toolSetId), context);
     }
 
     @Override

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ToolSetProxyControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ToolSetProxyControllerTest.java
@@ -1,0 +1,86 @@
+package com.epam.aidial.core.server.controller;
+
+import com.epam.aidial.core.credentials.service.AuthorizationHeaderProvider;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.limiter.RateLimiter;
+import com.epam.aidial.core.server.log.LogStore;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.service.DeploymentService;
+import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
+import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
+import io.vertx.core.http.HttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ToolSetProxyControllerTest {
+
+    @Mock
+    private Proxy proxy;
+
+    @Mock
+    private ProxyContext context;
+
+    @Mock
+    private AsyncTaskExecutor taskExecutor;
+
+    @Mock
+    private DeploymentService deploymentService;
+
+    @Mock
+    private RateLimiter rateLimiter;
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private UpstreamRouteProvider upstreamRouteProvider;
+
+    @Mock
+    private LogStore logStore;
+
+    @Mock
+    private AuthorizationHeaderProvider authorizationHeaderProvider;
+
+    @Mock
+    private EncryptionService encryptionService;
+
+    @BeforeEach
+    void setUp() {
+        when(context.getProxy()).thenReturn(proxy);
+        when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
+        when(context.getUserSub()).thenReturn("userSub");
+        when(proxy.getAuthorizationHeaderProvider()).thenReturn(authorizationHeaderProvider);
+        when(proxy.getEncryptionService()).thenReturn(encryptionService);
+        when(proxy.getTaskExecutor()).thenReturn(taskExecutor);
+        when(proxy.getDeploymentService()).thenReturn(deploymentService);
+        when(proxy.getRateLimiter()).thenReturn(rateLimiter);
+        when(proxy.getClient()).thenReturn(httpClient);
+        when(proxy.getUpstreamRouteProvider()).thenReturn(upstreamRouteProvider);
+        when(proxy.getLogStore()).thenReturn(logStore);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"toolset-1", "toolset 1"})
+    void testCreateToolSetProxyController(String toolSetName) {
+        // Given
+        String toolSetId = "toolsets/encrypted-bucket/%s".formatted(toolSetName);
+        when(encryptionService.decrypt("encrypted-bucket")).thenReturn("decrypted-bucket/");
+
+        // When
+        ToolSetProxyController toolSetProxyController = new ToolSetProxyController(proxy, context, toolSetId);
+
+        // Then
+        assertNotNull(toolSetProxyController);
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1081 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
