### PR TITLE
fix: remove empty `custom_content` field coming from the interceptor

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
@@ -31,6 +31,9 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Object
         ObjectNode customFields = (ObjectNode) tree.get("custom_fields");
         if (customFields != null) {
             customFields.remove("interceptor_configuration");
+            if (customFields.isEmpty()) {
+                tree.remove("custom_fields");
+            }
         }
         Deployment deployment = context.getDeployment();
         if (deployment instanceof Interceptor) {

--- a/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
@@ -190,7 +190,6 @@ public class ApplyDefaultDeploymentSettingsFnTest {
                 """);
 
         assertTrue(fn.apply((ObjectNode) result));
-        assertEquals("""
-                {"custom_fields":{}}""", result.toString());
+        assertEquals("{}", result.toString());
     }
 }


### PR DESCRIPTION
The implementation details of a configurable interceptor must not leak to the upstream. To guarantee this we need to modify the request before sending it to the upstream in the following way:
1. remove `custom_fields.interceptor_configuration`,
2. remove `custom_fields` if it's empty.

DIAL Core does (1) but doesn't do (2), which is equally important, since the upstream may be unaware or simply not accepting the DIAL-specific `custom_fields` field.

The fix supports (2).