### PR TITLE
feat: support WebSocket protocol in custom routes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@ build/
 bin/
 .tmp/
 *.log
+*.md
 Dockerfile

--- a/docs/dynamic-settings/routes.md
+++ b/docs/dynamic-settings/routes.md
@@ -4,7 +4,9 @@ Routes in DIAL are used for communication through registered endpoints in the DI
 
 ## routes
 
-A list of registered routes in AI DIAL Core. A route is used to proxy request through AI DIAL Core to upstream server.<br />AI DIAL Core provides capabilities: rate limiting, role based authorization, request balancing and access to AI DIAL Core resources such as LLMs, applications, file storage.
+A list of registered routes in AI DIAL Core. A route is used to proxy request through AI DIAL Core to upstream server.
+
+AI DIAL Core provides capabilities: rate limiting, role based authorization, request balancing and access to AI DIAL Core resources such as LLMs, applications, file storage.
 
 * `<route_name>`: A unique route name.
 
@@ -14,8 +16,8 @@ An object containing parameters for each [route](#routes).
 
 * `userRoles`: A list of user roles that can access this route. If the list is empty, the route is accessible by all users.
 * `response`: Pre-configured route's response. If the `response` is set then AI DIAL Core returns the response immediately. Available parameters:
-    - `status` - http status code
-    - `body` - http response body.
+  * `status` - http status code
+  * `body` - http response body.
 * `rewritePath`: A boolean flag that indicates that the path to the upstream server will be replaced with the path of the original request, if this flag is set to `true`.
 * `paths`: A list of paths to be matched request's path. If any path is matched, the request will be processed by this route. **Note**. A path can be a plain string or a regular expression.
 * `methods`: A list of HTTP methods supported by this route.

--- a/docs/dynamic-settings/routes.md
+++ b/docs/dynamic-settings/routes.md
@@ -12,13 +12,13 @@ A list of registered routes in AI DIAL Core. A route is used to proxy request th
 
 An object containing parameters for each [route](#routes).
 
-* `userRoles`: A list of user roles that can access this route. If the list is empty, the route is accessible by all users. 
+* `userRoles`: A list of user roles that can access this route. If the list is empty, the route is accessible by all users.
 * `response`: Pre-configured route's response. If the `response` is set then AI DIAL Core returns the response immediately. Available parameters:
     - `status` - http status code
     - `body` - http response body.
 * `rewritePath`: A boolean flag that indicates that the path to the upstream server will be replaced with the path of the original request, if this flag is set to `true`.
-* `paths`: A list of paths to be matched request's path. If any path is matched, the request will be processed by this route. **Note**. A path can be a plain string or a regular expression. 
-* `methods`: A list of HTTP methods supported by this route. 
+* `paths`: A list of paths to be matched request's path. If any path is matched, the request will be processed by this route. **Note**. A path can be a plain string or a regular expression.
+* `methods`: A list of HTTP methods supported by this route.
 * `maxRetryAttempts`: Maximum number of [retry](https://docs.dialx.ai/platform/core/load-balancer#fallbacks) attempts in case if upstream server returns unsuccessful response code. In this case load balancer will try to find another upstream from the list of available upstreams.
 * `order`: The value of this parameter determines the order within the global routes. The lower value means the higher priority. The value can't be negative integer. The default one is 2^31-1.
 * `upstreams`: A list of upstream servers. Refer to [routes.<route_name>.upstreams](#routesroute_nameupstreams) for more details.
@@ -28,7 +28,7 @@ An object containing parameters for each [route](#routes).
 A list of upstream servers with their parameters. Use to configure [load balancing](https://docs.dialx.ai/platform/core/load-balancer).
 
 * `endpoint`: One or more backend URLs to send requests to. Enables round-robin load balancing or fallback among multiple hosts.
-* `key`: API key, token, or credential passed to the upstream. 
+* `key`: API key, token, or credential passed to the upstream.
 * `weight`: Weight for upstream endpoint; positive number represents an endpoint capacity, zero or negative disables this endpoint from routing. Higher = more traffic share. Default value: 1.
 * `tier`: Specifies tier group for the endpoint. Only positive numbers allowed. All requests will be routed to the endpoints with the highest tier (the lowest tier value), other endpoints (with lower tier/higher tier value) may be used only if the highest tier endpoints are unavailable. Default value: 0 - highest tier. Refer to [load balancing](https://docs.dialx.ai/platform/core/load-balancer) to learn more.
 * `extraData`: Additional metadata containing any information that is passed to the upstream's endpoint. It can be a JSON or String.
@@ -37,29 +37,51 @@ A list of upstream servers with their parameters. Use to configure [load balanci
 
 ```json
 {
-"routes": {
-    "vector_store_query": {
-        "paths": ["/v1/vector_store(/[^/]+)*$"],
-        "rewritePath": true,
-        "methods": ["GET", "HEAD"],
-        "userRoles": ["role1"],
-        "upstreams": [
-            {
-                "endpoint": "http://localhost:9876"
-            },
-            {
-                "endpoint": "http://localhost:9877"
-            }
-        ]
-    },
-    "rate": {
-        "paths": ["/v1/rate"],
-        "rewritePath": true,
-        "methods": ["GET", "HEAD"],
-        "response": {
-            "status": 200,
-            "body": "OK"
-        }
-    }
-},
+  "routes": {
+      "vector_store_query": {
+          "paths": ["/v1/vector_store(/[^/]+)*$"],
+          "rewritePath": true,
+          "methods": ["GET", "HEAD"],
+          "userRoles": ["role1"],
+          "upstreams": [
+              {
+                  "endpoint": "http://localhost:9876"
+              },
+              {
+                  "endpoint": "http://localhost:9877"
+              }
+          ]
+      },
+      "rate": {
+          "paths": ["/v1/rate"],
+          "rewritePath": true,
+          "methods": ["GET", "HEAD"],
+          "response": {
+              "status": 200,
+              "body": "OK"
+          }
+      }
+  }
 }
+```
+
+### WebSocket proxying
+
+Routes can also proxy WebSocket connections. Configure the upstream endpoint with the `ws://` or `wss://` scheme and expose the desired path in DIAL Core. The incoming WebSocket handshake must use the `GET` method, so either leave the `methods` list empty or include `GET`.
+
+```json
+{
+  "routes": {
+    "echo": {
+      "paths": ["/v1/echo"],
+      "upstreams": [
+        {
+          "endpoint": "wss://echo.websocket.org"
+        }
+      ]
+    }
+  }
+}
+```
+
+This configuration exposes `wss://<dial-host>/v1/echo` and transparently forwards all frames to `wss://echo.websocket.org` and back to the caller.

--- a/docs/dynamic-settings/routes.md
+++ b/docs/dynamic-settings/routes.md
@@ -72,13 +72,21 @@ Routes can also proxy WebSocket connections. Configure the upstream endpoint wit
 ```json
 {
   "routes": {
-    "echo": {
+    "websocket-echo": {
       "paths": ["/v1/echo"],
+      "upstreams": [
+        {
+          "endpoint": "wss://echo.websocket.org"
+        }
+      ]
+    },
+    "websocket-realtime-openai": {
+      "paths": ["/openai/realtime"],
       "rewritePath": true,
       "upstreams": [
         {
-          "endpoint": "wss://echo.websocket.org",
-          "key": "optional-key"
+          "endpoint": "wss://${AZURE_FOUNDRY_PROJECT_NAME}.cognitiveservices.azure.com/openai/realtime",
+          "key": "${AZURE_FOUNDRY_API_KEY}"
         }
       ]
     }
@@ -86,6 +94,19 @@ Routes can also proxy WebSocket connections. Configure the upstream endpoint wit
 }
 ```
 
-This configuration exposes `wss://<dial-host>/v1/echo` and transparently forwards all frames to `wss://echo.websocket.org` and back to the caller.
+This configuration exposes the following WebSocket endpoints:
 
-The `key` field is passed in `api-key` header to the upstream endpoint.
+1. `ws://${DIAL_HOST}/v1/echo` - requests to the endpoint are transparently forwarded to `wss://echo.websocket.org` and back to the DIAL client.
+2. `ws://${DIAL_HOST}/openai/realtime` - the endpoint could be used to access Azure Realtime API.
+  The Realtime API could be set accessed using `openai` library in the following way:
+
+  ```python
+  client = AsyncAzureOpenAI(
+      websocket_base_url="ws://${DIAL_HOST}/openai",
+      api_key="${DIAL_API_KEY}",
+      api_version="2025-04-01-preview"
+  )
+
+  async with client.beta.realtime.connect(model="gpt-realtime") as conn:
+      ...
+  ```

--- a/docs/dynamic-settings/routes.md
+++ b/docs/dynamic-settings/routes.md
@@ -74,6 +74,7 @@ Routes can also proxy WebSocket connections. Configure the upstream endpoint wit
   "routes": {
     "echo": {
       "paths": ["/v1/echo"],
+      "rewritePath": true,
       "upstreams": [
         {
           "endpoint": "wss://echo.websocket.org"

--- a/docs/dynamic-settings/routes.md
+++ b/docs/dynamic-settings/routes.md
@@ -77,7 +77,8 @@ Routes can also proxy WebSocket connections. Configure the upstream endpoint wit
       "rewritePath": true,
       "upstreams": [
         {
-          "endpoint": "wss://echo.websocket.org"
+          "endpoint": "wss://echo.websocket.org",
+          "key": "optional-key"
         }
       ]
     }
@@ -86,3 +87,5 @@ Routes can also proxy WebSocket connections. Configure the upstream endpoint wit
 ```
 
 This configuration exposes `wss://<dial-host>/v1/echo` and transparently forwards all frames to `wss://echo.websocket.org` and back to the caller.
+
+The `key` field is passed in `api-key` header to the upstream endpoint.

--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -27,6 +27,7 @@ import com.epam.aidial.core.credentials.util.TimeProvider;
 import com.epam.aidial.core.credentials.validation.AuthSettingsValidatorFactory;
 import com.epam.aidial.core.credentials.validation.AuthorizationServerMetadataValidator;
 import com.epam.aidial.core.credentials.validation.ProtectedResourceMetadataValidator;
+import com.epam.aidial.core.server.WebSocketProxy;
 import com.epam.aidial.core.server.config.ConfigStore;
 import com.epam.aidial.core.server.config.FileConfigStore;
 import com.epam.aidial.core.server.config.PathNormalizerSpanProcessor;
@@ -234,7 +235,10 @@ public class AiDial {
                     toolSetService, applicationSchemaService, authorizationHeaderProvider, resourceAuthSettingsService, resourceCredentialsService,
                     taskExecutor, version());
 
-            server = vertx.createHttpServer(new HttpServerOptions(settings("server"))).requestHandler(proxy);
+            WebSocketProxy webSocketProxy = new WebSocketProxy(proxy);
+            proxy.setWebSocketProxy(webSocketProxy);
+            server = vertx.createHttpServer(new HttpServerOptions(settings("server")))
+                    .requestHandler(proxy);
             open(server, HttpServer::listen);
             log.info("Proxy started on {}", server.actualPort());
         } catch (Throwable e) {

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -134,6 +134,12 @@ public class Proxy implements Handler<HttpServerRequest> {
     private final AsyncTaskExecutor taskExecutor;
     private final String version;
 
+    private WebSocketProxy webSocketProxy;
+
+    void setWebSocketProxy(WebSocketProxy webSocketProxy) {
+        this.webSocketProxy = webSocketProxy;
+    }
+
     @Override
     public void handle(HttpServerRequest request) {
         try {
@@ -229,8 +235,28 @@ public class Proxy implements Handler<HttpServerRequest> {
         String traceFlags = spanContext.getTraceFlags().asHex();
 
         request.pause();
-        Future<AuthorizationResult> authorizationResultFuture = authorizeRequest(request);
-        authorizationResultFuture.compose(result -> processAuthorizationResult(result.extractedClaims, config, request, result.apiKeyData, traceId, spanId, traceFlags))
+        Future<AuthorizationResult> authorizationResultFuture = authorize(request);
+        String upgradeHeader = request.getHeader(HttpHeaders.UPGRADE);
+        boolean isWebSocketUpgrade = upgradeHeader != null && "websocket".equalsIgnoreCase(upgradeHeader);
+
+        if (isWebSocketUpgrade) {
+            Future<?> future = authorizationResultFuture.compose(result -> {
+                if (webSocketProxy == null) {
+                    return Future.failedFuture(new IllegalStateException("WebSocket proxy is not configured"));
+                }
+                return webSocketProxy.handle(request, config, result, traceId, spanId, traceFlags);
+            });
+            future
+                    .onFailure(error -> {
+                        if (!(error instanceof WebSocketProxy.HandledException)) {
+                            handleError(error, request);
+                        }
+                    })
+                    .onComplete(ignore -> request.resume());
+            return;
+        }
+
+        authorizationResultFuture.compose(result -> processAuthorizationResult(result, config, request, traceId, spanId, traceFlags))
                 .onFailure(error -> handleError(error, request))
                 .onComplete(ignore -> request.resume());
     }
@@ -261,7 +287,7 @@ public class Proxy implements Handler<HttpServerRequest> {
      * @param request HTTP request
      * @return the future of {@link AuthorizationResult}
      */
-    private Future<AuthorizationResult> authorizeRequest(HttpServerRequest request) {
+    Future<AuthorizationResult> authorize(HttpServerRequest request) {
         String apiKey = request.headers().get(HEADER_API_KEY);
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
         log.debug("Authorization header: {}", authorization);
@@ -329,20 +355,25 @@ public class Proxy implements Handler<HttpServerRequest> {
         }
     }
 
-    private record AuthorizationResult(ApiKeyData apiKeyData, ExtractedClaims extractedClaims) {
+    record AuthorizationResult(ApiKeyData apiKeyData, ExtractedClaims extractedClaims) {
 
     }
 
-    @SneakyThrows
-    private Future<?> processAuthorizationResult(ExtractedClaims extractedClaims, Config config,
-                                                 HttpServerRequest request, ApiKeyData apiKeyData,
-                                                 String traceId, String spanId, String traceFlags) {
-        // Clear context when the response is actually closed, not when controller completes
+    ProxyContext createContext(Config config, HttpServerRequest request, AuthorizationResult result,
+                               String traceId, String spanId, String traceFlags) {
         request.response().closeHandler(v -> ContextManager.clearContext());
+        ProxyContext context = new ProxyContext(this, config, request, result.apiKeyData(), result.extractedClaims(), traceId, spanId, traceFlags);
+        ContextManager.setProxyContext(context);
+        return context;
+    }
+
+    @SneakyThrows
+    private Future<?> processAuthorizationResult(AuthorizationResult result, Config config,
+                                                 HttpServerRequest request, String traceId, String spanId, String traceFlags) {
+        // Clear context when the response is actually closed, not when controller completes
         Future<?> future;
         try {
-            ProxyContext context = new ProxyContext(this, config, request, apiKeyData, extractedClaims, traceId, spanId, traceFlags);
-            ContextManager.setProxyContext(context);
+            ProxyContext context = createContext(config, request, result, traceId, spanId, traceFlags);
             ControllerTemplate controllerTemplate = ControllerSelector.select(request);
             Controller controller = controllerTemplate.build(this, context);
             future = controller.handle();

--- a/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
@@ -114,7 +114,7 @@ public class WebSocketProxy {
 
     private boolean isWebSocketUpgrade(HttpServerRequest request) {
         String upgradeHeader = request.getHeader(HttpHeaders.UPGRADE);
-        return upgradeHeader != null && "websocket".equalsIgnoreCase(upgradeHeader);
+        return "websocket".equalsIgnoreCase(upgradeHeader);
     }
 
     private Future<Void> handleRateLimit(RateLimitResult result, ProxyContext context) {

--- a/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
@@ -234,25 +234,46 @@ public class WebSocketProxy {
 
     private void forwardFrames(WebSocketBase source, WebSocketBase target) {
         source.frameHandler(frame -> {
-            if (target.writeQueueFull()) {
-                source.pause();
-                target.drainHandler(v -> {
-                    target.drainHandler(null);
-                    source.resume();
-                });
+            if (target.isClosed()) {
+                closeQuietly(source);
+                return;
             }
 
-            WebSocketFrameType type = frame.type();
-            switch (type) {
-                case TEXT -> target.writeFrame(WebSocketFrame.textFrame(frame.textData(), frame.isFinal()));
-                case BINARY -> target.writeFrame(WebSocketFrame.binaryFrame(frame.binaryData().copy(), frame.isFinal()));
-                case CONTINUATION -> target.writeFrame(WebSocketFrame.continuationFrame(frame.binaryData().copy(), frame.isFinal()));
-                case PING -> target.writePing(frame.binaryData().copy());
-                case PONG -> target.writePong(frame.binaryData().copy());
-                case CLOSE -> target.close(frame.closeStatusCode(), frame.closeReason());
-                default -> target.writeFrame(frame);
+            try {
+                if (target.writeQueueFull()) {
+                    source.pause();
+                    target.drainHandler(v -> {
+                        target.drainHandler(null);
+                        source.resume();
+                    });
+                }
+
+                WebSocketFrameType type = frame.type();
+                switch (type) {
+                    case TEXT -> target.writeFrame(WebSocketFrame.textFrame(frame.textData(), frame.isFinal()));
+                    case BINARY -> target.writeFrame(WebSocketFrame.binaryFrame(frame.binaryData().copy(), frame.isFinal()));
+                    case CONTINUATION -> target.writeFrame(WebSocketFrame.continuationFrame(frame.binaryData().copy(), frame.isFinal()));
+                    case PING -> target.writePing(frame.binaryData().copy());
+                    case PONG -> target.writePong(frame.binaryData().copy());
+                    case CLOSE -> target.close(frame.closeStatusCode(), frame.closeReason());
+                    default -> target.writeFrame(frame);
+                }
+            } catch (IllegalStateException e) {
+                log.debug("WebSocket target closed while forwarding frame: {}", e.getMessage());
+                closeQuietly(source);
             }
         });
+    }
+
+    private void closeQuietly(WebSocketBase socket) {
+        if (socket == null || socket.isClosed()) {
+            return;
+        }
+        try {
+            socket.close();
+        } catch (IllegalStateException e) {
+            log.debug("WebSocket already closed: {}", e.getMessage());
+        }
     }
 
     private Future<Void> setupProxyApiKeyIfNeeded(ProxyContext context) {

--- a/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
@@ -184,20 +184,10 @@ public class WebSocketProxy {
         ProxyUtil.copyHeaders(context.getRequest().headers(), headers);
         if (upstream.getKey() != null) {
             headers.set(Proxy.HEADER_API_KEY, upstream.getKey());
-        } else if (context.getProxyApiKeyData() != null) {
-            headers.set(Proxy.HEADER_API_KEY, context.getProxyApiKeyData().getPerRequestKey());
+        } else {
+            ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
+            headers.set(Proxy.HEADER_API_KEY, proxyApiKeyData.getPerRequestKey());
         }
-
-        if (context.getUserDisplayName() != null) {
-            headers.set(Proxy.HEADER_JOB_TITLE, context.getUserDisplayName());
-        }
-        headers.set(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(upstreamRoute.getAttemptCount()));
-
-        String extraData = upstream.getExtraData();
-        if (extraData != null) {
-            headers.set(Proxy.HEADER_UPSTREAM_EXTRA_DATA, extraData);
-        }
-        headers.set(Proxy.HEADER_UPSTREAM_ENDPOINT, upstream.getEndpoint());
 
         options.setHeaders(headers);
         return options;

--- a/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/WebSocketProxy.java
@@ -1,0 +1,369 @@
+package com.epam.aidial.core.server;
+
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.Route;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.limiter.RateLimitResult;
+import com.epam.aidial.core.server.upstream.UpstreamRoute;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketBase;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.http.WebSocketFrame;
+import io.vertx.core.http.WebSocketFrameType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+@Slf4j
+@RequiredArgsConstructor
+public class WebSocketProxy {
+
+    private static final short CLOSE_CODE_POLICY_VIOLATION = 1008;
+    private static final short CLOSE_CODE_TRY_AGAIN = 1013;
+    private static final short CLOSE_CODE_INTERNAL_ERROR = 1011;
+    private static final int MAX_CLOSE_REASON_LENGTH = 120;
+
+    private final Proxy proxy;
+
+    public Future<Void> handle(HttpServerRequest request, Config config, Proxy.AuthorizationResult result,
+                               String traceId, String spanId, String traceFlags) {
+        ProxyContext context = proxy.createContext(config, request, result, traceId, spanId, traceFlags);
+
+        if (!isWebSocketUpgrade(request)) {
+            return Future.failedFuture(new IllegalStateException("Request is not a WebSocket upgrade"));
+        }
+
+        if (request.version() != HttpVersion.HTTP_1_1) {
+            return failHttp(context, HttpStatus.HTTP_VERSION_NOT_SUPPORTED, "HTTP/1.1 is required for WebSocket connections");
+        }
+
+        if (request.method() != HttpMethod.GET) {
+            return failHttp(context, HttpStatus.METHOD_NOT_ALLOWED, "WebSocket upgrade must use GET");
+        }
+
+        Route route = selectRoute(config.getRoutes().values(), request);
+        if (route == null) {
+            log.warn("WebSocket route is not found for path {}", request.uri());
+            return failHttp(context, HttpStatus.BAD_GATEWAY, "No route");
+        }
+
+        context.setRoute(route);
+
+        if (!route.hasAccess(context.getUserRoles())) {
+            log.warn("Forbidden WebSocket route {}", route.getName());
+            return failHttp(context, HttpStatus.FORBIDDEN, "Forbidden route");
+        }
+
+        if (route.getResponse() != null) {
+            log.warn("WebSocket route {} has static response configured - unsupported", route.getName());
+            return failHttp(context, HttpStatus.BAD_GATEWAY, "WebSocket route does not support pre-defined responses");
+        }
+
+        context.setTraceOperation("Open WebSocket route %s".formatted(route.getName()));
+
+        UpstreamRoute upstreamRoute;
+        try {
+            upstreamRoute = proxy.getUpstreamRouteProvider().get(route);
+        } catch (Exception e) {
+            log.warn("Failed to obtain upstream route for {}", route.getName(), e);
+            return failHttp(context, HttpStatus.BAD_GATEWAY, "No upstream");
+        }
+        context.setUpstreamRoute(upstreamRoute);
+
+        try {
+            upstreamRoute.next();
+        } catch (HttpException e) {
+            log.warn("Upstream is unavailable: {}", e.getMessage());
+            return failHttp(context, e.getStatus(), e.getMessage());
+        }
+
+        return proxy.getRateLimiter().limit(context, route)
+                .compose(limitResult -> handleRateLimit(limitResult, context))
+                .compose(v -> setupProxyApiKeyIfNeeded(context))
+                .compose(v -> request.toWebSocket())
+                .compose(clientSocket -> proxyToUpstream(clientSocket, context))
+                .onFailure(error -> {
+                    if (!(error instanceof HandledException)) {
+                        log.warn("WebSocket proxy failed", error);
+                        finalizeContext(context);
+                    }
+                })
+                .mapEmpty();
+    }
+
+    private boolean isWebSocketUpgrade(HttpServerRequest request) {
+        String upgradeHeader = request.getHeader(HttpHeaders.UPGRADE);
+        return upgradeHeader != null && "websocket".equalsIgnoreCase(upgradeHeader);
+    }
+
+    private Future<Void> handleRateLimit(RateLimitResult result, ProxyContext context) {
+        if (result.status() == HttpStatus.OK) {
+            return Future.succeededFuture();
+        }
+        log.warn("WebSocket rate limit hit for route {}: {}", context.getRoute().getName(), result.errorMessage());
+        return failHttp(context, result.status(), result.displayErrorMessage());
+    }
+
+    private Future<Void> proxyToUpstream(ServerWebSocket clientSocket, ProxyContext context) {
+        Promise<Void> promise = Promise.promise();
+        AtomicBoolean closed = new AtomicBoolean();
+        AtomicReference<WebSocket> upstreamRef = new AtomicReference<>();
+
+        clientSocket.closeHandler(v -> handleClientClosure(closed, upstreamRef.get(), context, promise));
+        clientSocket.exceptionHandler(error -> {
+            log.debug("Client WebSocket error: {}", error.getMessage(), error);
+            handleClientClosure(closed, upstreamRef.get(), context, promise);
+        });
+
+        attemptConnect(clientSocket, context, upstreamRef, closed, promise);
+        return promise.future();
+    }
+
+    private void attemptConnect(ServerWebSocket clientSocket, ProxyContext context,
+                                AtomicReference<WebSocket> upstreamRef, AtomicBoolean closed,
+                                Promise<Void> promise) {
+        UpstreamRoute upstreamRoute = context.getUpstreamRoute();
+        Upstream upstream = upstreamRoute.get();
+        if (upstream == null) {
+            close(clientSocket, HttpStatus.BAD_GATEWAY, "No upstream");
+            promise.tryFail(new HandledException());
+            return;
+        }
+
+        WebSocketConnectOptions options = buildConnectOptions(context, upstream, upstreamRoute);
+        proxy.getClient().webSocket(options).onComplete(ar -> {
+            if (ar.succeeded()) {
+                if (closed.get()) {
+                    ar.result().close();
+                    promise.tryFail(new HandledException());
+                    return;
+                }
+                handleConnectedWebSocket(clientSocket, ar.result(), context, upstreamRef, closed);
+                promise.tryComplete();
+            } else {
+                log.warn("Failed to connect WebSocket to upstream: {}", ar.cause().getMessage());
+                upstreamRoute.fail(HttpStatus.BAD_GATEWAY);
+                try {
+                    upstreamRoute.next();
+                    attemptConnect(clientSocket, context, upstreamRef, closed, promise);
+                } catch (HttpException e) {
+                    close(clientSocket, e.getStatus(), e.getMessage());
+                    promise.tryFail(new HandledException());
+                }
+            }
+        });
+    }
+
+    private WebSocketConnectOptions buildConnectOptions(ProxyContext context, Upstream upstream, UpstreamRoute upstreamRoute) {
+        WebSocketConnectOptions options = new WebSocketConnectOptions()
+                .setAbsoluteURI(resolveEndpointUri(context, upstream))
+                .setTimeout(proxy.getClientOptions().getConnectTimeout());
+
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        ProxyUtil.copyHeaders(context.getRequest().headers(), headers);
+        if (upstream.getKey() != null) {
+            headers.set(Proxy.HEADER_API_KEY, upstream.getKey());
+        } else if (context.getProxyApiKeyData() != null) {
+            headers.set(Proxy.HEADER_API_KEY, context.getProxyApiKeyData().getPerRequestKey());
+        }
+
+        if (context.getUserDisplayName() != null) {
+            headers.set(Proxy.HEADER_JOB_TITLE, context.getUserDisplayName());
+        }
+        headers.set(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(upstreamRoute.getAttemptCount()));
+
+        String extraData = upstream.getExtraData();
+        if (extraData != null) {
+            headers.set(Proxy.HEADER_UPSTREAM_EXTRA_DATA, extraData);
+        }
+        headers.set(Proxy.HEADER_UPSTREAM_ENDPOINT, upstream.getEndpoint());
+
+        options.setHeaders(headers);
+        return options;
+    }
+
+    private void handleConnectedWebSocket(ServerWebSocket clientSocket, WebSocket upstreamSocket,
+                                          ProxyContext context, AtomicReference<WebSocket> upstreamRef,
+                                          AtomicBoolean closed) {
+        log.info("WebSocket connected to upstream {}", upstreamSocket.remoteAddress());
+
+        upstreamRef.set(upstreamSocket);
+
+        context.getUpstreamRoute().succeed();
+        proxy.getRateLimiter().increase(context, context.getRoute())
+                .onFailure(error -> log.warn("Failed to increase rate limit", error));
+
+        upstreamSocket.closeHandler(v -> {
+            if (closed.compareAndSet(false, true)) {
+                clientSocket.close();
+                finalizeContext(context);
+            }
+        });
+        upstreamSocket.exceptionHandler(error -> {
+            log.debug("Upstream WebSocket exception: {}", error.getMessage(), error);
+            if (closed.compareAndSet(false, true)) {
+                clientSocket.close();
+                finalizeContext(context);
+            }
+        });
+
+        forwardFrames(clientSocket, upstreamSocket);
+        forwardFrames(upstreamSocket, clientSocket);
+    }
+
+    private void forwardFrames(WebSocketBase source, WebSocketBase target) {
+        source.frameHandler(frame -> {
+            if (target.writeQueueFull()) {
+                source.pause();
+                target.drainHandler(v -> {
+                    target.drainHandler(null);
+                    source.resume();
+                });
+            }
+
+            WebSocketFrameType type = frame.type();
+            switch (type) {
+                case TEXT -> target.writeFrame(WebSocketFrame.textFrame(frame.textData(), frame.isFinal()));
+                case BINARY -> target.writeFrame(WebSocketFrame.binaryFrame(frame.binaryData().copy(), frame.isFinal()));
+                case CONTINUATION -> target.writeFrame(WebSocketFrame.continuationFrame(frame.binaryData().copy(), frame.isFinal()));
+                case PING -> target.writePing(frame.binaryData().copy());
+                case PONG -> target.writePong(frame.binaryData().copy());
+                case CLOSE -> target.close(frame.closeStatusCode(), frame.closeReason());
+                default -> target.writeFrame(frame);
+            }
+        });
+    }
+
+    private Future<Void> setupProxyApiKeyIfNeeded(ProxyContext context) {
+        Upstream upstream = context.getUpstreamRoute().get();
+        if (upstream != null && upstream.getKey() != null) {
+            return Future.succeededFuture();
+        }
+
+        ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
+        if (proxyApiKeyData == null) {
+            proxyApiKeyData = new ApiKeyData();
+            context.setProxyApiKeyData(proxyApiKeyData);
+            ApiKeyData.initFromContext(proxyApiKeyData, context);
+        }
+
+        ApiKeyData finalProxyApiKeyData = proxyApiKeyData;
+        return proxy.getTaskExecutor().submit(() -> {
+            proxy.getApiKeyStore().assignPerRequestApiKey(finalProxyApiKeyData);
+            return null;
+        }).mapEmpty();
+    }
+
+    private String resolveEndpointUri(ProxyContext context, Upstream upstream) {
+        try {
+            URIBuilder builder = new URIBuilder(upstream.getEndpoint());
+            if (context.getRoute().isRewritePath()) {
+                builder.setPath(context.getRequest().path());
+                String query = context.getRequest().query();
+                if (query != null) {
+                    builder.setParameters(URLEncodedUtils.parse(query, StandardCharsets.UTF_8));
+                }
+            }
+            return builder.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build upstream URI", e);
+        }
+    }
+
+    private Route selectRoute(Collection<Route> routes, HttpServerRequest request) {
+        String path = request.path();
+        HttpMethod method = request.method();
+
+        for (Route route : routes) {
+            Set<String> methods = route.getMethods();
+            if (!methods.isEmpty() && (method == null || !methods.contains(method.name()))) {
+                continue;
+            }
+
+            List<Pattern> paths = route.getPaths();
+            if (paths.isEmpty()) {
+                return route;
+            }
+
+            for (Pattern pattern : paths) {
+                if (pattern.matcher(path).matches()) {
+                    return route;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Future<Void> failHttp(ProxyContext context, HttpStatus status, String message) {
+        return context.respond(status, message)
+                .onComplete(ar -> finalizeContext(context))
+                .compose(v -> Future.<Void>failedFuture(new HandledException()));
+    }
+
+    private void handleClientClosure(AtomicBoolean closed, WebSocket upstream, ProxyContext context, Promise<Void> promise) {
+        if (closed.compareAndSet(false, true)) {
+            if (upstream != null) {
+                upstream.close();
+            }
+            finalizeContext(context);
+            promise.tryFail(new HandledException());
+        }
+    }
+
+    private void close(ServerWebSocket clientSocket, HttpStatus status, String reason) {
+        if (clientSocket == null || clientSocket.isClosed()) {
+            return;
+        }
+        short code = mapStatusToCloseCode(status);
+        String message = reason == null ? status.toString() : reason;
+        if (message.length() > MAX_CLOSE_REASON_LENGTH) {
+            message = message.substring(0, MAX_CLOSE_REASON_LENGTH);
+        }
+        clientSocket.close(code, message);
+    }
+
+    private short mapStatusToCloseCode(HttpStatus status) {
+        return switch (status) {
+            case TOO_MANY_REQUESTS -> CLOSE_CODE_TRY_AGAIN;
+            case FORBIDDEN, UNAUTHORIZED -> CLOSE_CODE_POLICY_VIOLATION;
+            default -> CLOSE_CODE_INTERNAL_ERROR;
+        };
+    }
+
+    private void finalizeContext(ProxyContext context) {
+        ContextManager.clearContext();
+        ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
+        if (proxyApiKeyData != null) {
+            proxy.getApiKeyStore().invalidatePerRequestApiKey(proxyApiKeyData)
+                    .onFailure(error -> log.error("Failed to invalidate per-request API key", error));
+        }
+    }
+
+    static class HandledException extends RuntimeException {
+        HandledException() {
+            super("Handled WebSocket proxy exception", null, false, false);
+        }
+    }
+}


### PR DESCRIPTION
An example configuration in DIAL Core config:

```json
{
  "routes": {
    "websocket-echo": {
      "paths": ["/v1/echo"],
      "upstreams": [
        {
          "endpoint": "wss://echo.websocket.org"
        }
      ]
    },
    "websocket-realtime-openai": {
      "paths": ["/openai/realtime"],
      "rewritePath": true,
      "upstreams": [
        {
          "endpoint": "wss://${AZURE_FOUNDRY_PROJECT_NAME}.cognitiveservices.azure.com/openai/realtime",
          "key": "${AZURE_FOUNDRY_API_KEY}"
        }
      ]
    }
  }
}
```