### PR TITLE
fix: Token usage statistics are not updated correctly in some cases #1154

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseRouteController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseRouteController.java
@@ -92,29 +92,35 @@ public abstract class BaseRouteController implements Controller {
                 context.setResponseBody(Buffer.buffer(response.getBody()));
             }
             return proxy.getRateLimiter().limit(context, context.getRoute())
-                    .map(rateLimitResult -> {
+                    .compose(rateLimitResult -> {
+                        Future<?> future;
                         if (rateLimitResult.status() == HttpStatus.OK) {
-                            handleRateLimitSuccess();
+                            future = handleRateLimitSuccess();
                         } else {
                             handleRateLimitHit(rateLimitResult);
+                            future = Future.succeededFuture();
                         }
-                        return null;
+                        return future;
                     });
         });
     }
 
-    private void handleRateLimitSuccess() {
+    private Future<?> handleRateLimitSuccess() {
         if (context.getResponseBody() == null) {
             setupProxyApiKeyData();
-            context.getRequest().body()
-                    .onFailure(this::handleRequestBodyError)
-                    .onSuccess(body -> proxy.getTaskExecutor().submit(() -> {
-                        handleRequestBody(body);
-                        return null;
-                    }));
+            return proxy.getTokenStatsTracker().startSpan(context).map(ignore -> {
+                context.getRequest().body()
+                        .onFailure(this::handleRequestBodyError)
+                        .onSuccess(body -> proxy.getTaskExecutor().submit(() -> {
+                            handleRequestBody(body);
+                            return null;
+                        }));
+                return null;
+            });
         } else {
             context.getResponse().send(context.getResponseBody());
             proxy.getLogStore().save(context);
+            return Future.succeededFuture();
         }
     }
 
@@ -442,6 +448,7 @@ public abstract class BaseRouteController implements Controller {
     }
 
     private void finalizeRequest() {
+        proxy.getTokenStatsTracker().endSpan(context).onFailure(error -> log.error("Error occurred at completing span", error));
         ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
         if (proxyApiKeyData != null) {
             proxy.getApiKeyStore().invalidatePerRequestApiKey(proxyApiKeyData)

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
@@ -16,6 +16,7 @@ import com.epam.aidial.core.server.log.LogStore;
 import com.epam.aidial.core.server.security.ApiKeyStore;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
+import com.epam.aidial.core.server.token.TokenStatsTracker;
 import com.epam.aidial.core.server.upstream.UpstreamRoute;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
@@ -79,6 +80,8 @@ public class ToolSetProxyController implements Controller {
 
     private final ApiKeyStore apiKeyStore;
 
+    private final TokenStatsTracker tokenStatsTracker;
+
     private String mcpMethodName;
 
     public ToolSetProxyController(Proxy proxy, ProxyContext context, String toolSetId) {
@@ -91,6 +94,7 @@ public class ToolSetProxyController implements Controller {
         this.context = context;
         this.authorizationHeaderProvider = proxy.getAuthorizationHeaderProvider();
         this.apiKeyStore = proxy.getApiKeyStore();
+        this.tokenStatsTracker = proxy.getTokenStatsTracker();
         this.toolSetId = toolSetId;
         this.credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(UrlUtil.encodePath(toolSetId), context);
     }
@@ -104,13 +108,15 @@ public class ToolSetProxyController implements Controller {
             }
             throw new ResourceNotFoundException("Toolset is not found: " + toolSetId);
         }).compose(toolSet -> rateLimiter.limit(context, toolSet)
-                .map(rateLimitResult -> {
+                .compose(rateLimitResult -> {
+                    Future<?> future;
                     if (rateLimitResult.status() == HttpStatus.OK) {
-                        handleRateLimitSuccess(toolSet);
+                        future = handleRateLimitSuccess(toolSet);
                     } else {
                         handleRateLimitHit(rateLimitResult);
+                        future = Future.succeededFuture();
                     }
-                    return null;
+                    return future;
                 })).otherwise(error -> {
                     handleError(error);
                     return null;
@@ -316,17 +322,20 @@ public class ToolSetProxyController implements Controller {
         return modified;
     }
 
-    private void handleRateLimitSuccess(ToolSet toolSet) {
-        UpstreamRoute upstreamRoute = upstreamRouteProvider.get(toolSet, null);
-        if (!canRetry(upstreamRoute)) {
-            return;
-        }
-        context.setUpstreamRoute(upstreamRoute);
-        context.setDeployment(toolSet);
-        context.setTraceOperation("Send request to %s toolset".formatted(toolSet.getName()));
-        context.getRequest().body()
-                .onFailure(this::handleRequestBodyError)
-                .onSuccess(this::handleRequestBody);
+    private Future<?> handleRateLimitSuccess(ToolSet toolSet) {
+        return tokenStatsTracker.startSpan(context).map(ignore -> {
+            UpstreamRoute upstreamRoute = upstreamRouteProvider.get(toolSet, null);
+            if (!canRetry(upstreamRoute)) {
+                return null;
+            }
+            context.setUpstreamRoute(upstreamRoute);
+            context.setDeployment(toolSet);
+            context.setTraceOperation("Send request to %s toolset".formatted(toolSet.getName()));
+            context.getRequest().body()
+                    .onFailure(this::handleRequestBodyError)
+                    .onSuccess(this::handleRequestBody);
+            return null;
+        });
     }
 
     private void handleRateLimitHit(RateLimitResult result) {
@@ -423,6 +432,7 @@ public class ToolSetProxyController implements Controller {
     }
 
     protected void finalizeRequest() {
+        tokenStatsTracker.endSpan(context).onFailure(error -> log.error("Error occurred at completing span", error));
         ApiKeyData proxyApiKeyData = context.getProxyApiKeyData();
         if (proxyApiKeyData != null) {
             apiKeyStore.invalidatePerRequestApiKey(proxyApiKeyData)

--- a/server/src/main/java/com/epam/aidial/core/server/token/TokenStatsTracker.java
+++ b/server/src/main/java/com/epam/aidial/core/server/token/TokenStatsTracker.java
@@ -122,6 +122,10 @@ public class TokenStatsTracker {
             String parenSpanId = tokenStats.parentSpanId;
             while (parenSpanId != null) {
                 tokenStats = spans.get(parenSpanId);
+                if (tokenStats == null) {
+                    log.warn("Parent span {} was not added to the trace context.");
+                    break;
+                }
                 tokenStats.tokenUsage.increase(tokenUsage);
                 parenSpanId = tokenStats.parentSpanId;
             }


### PR DESCRIPTION
A parent span might not be added to the trace context for next use cases:

- Request to global/application routes
- Request to toolsets

Those deployments might have initiated calls to other applications or models causing NPE at the Core side.

We mitigate the issue by checking NPE in the stats tracker and add spans for the missed use cases.