### PR TITLE
fix: Consent service should take a root deployment to verify user consent

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
@@ -7,10 +7,12 @@ import com.epam.aidial.core.server.data.consent.ReviewConsentResponse;
 import com.epam.aidial.core.server.util.BucketBuilder;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
+import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayDeque;
 import java.util.HashSet;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+@Slf4j
 public class ConsentService {
 
     private static final ReviewConsentResponse ACCEPTED_CONSENT_RESPONSE = new ReviewConsentResponse(null, true);
@@ -75,23 +78,50 @@ public class ConsentService {
         if (!isConsentRequired(deployment)) {
             return;
         }
-        String deploymentId = deployment.getName();
-        Consent consent = readConsent(context, deploymentId);
+        String currentDeploymentId = deployment.getName();
+        List<String> executionPath = context.getApiKeyData().getExecutionPath();
+        Deployment rootDeployment = getRootDeployment(context, deployment);
+        if (rootDeployment == null) {
+            log.debug("Root deployment is not found for the deployment {} in the execution path: {}", currentDeploymentId, executionPath);
+            return;
+        }
+        String rootDeploymentId = rootDeployment.getName();
+        Consent consent = readConsent(context, rootDeploymentId);
         if (consent == null) {
             // missing consent
-            fail(deploymentId);
+            fail(rootDeploymentId);
         }
-        List<String> executionPath = context.getApiKeyData().getExecutionPath();
         if (executionPath != null) {
             for (String dep : executionPath) {
                 if (!consent.getDeployments().containsKey(dep)) {
-                    fail(deploymentId);
+                    fail(currentDeploymentId);
                 }
             }
         }
-        Consent.Deployment consentDeployment = consent.getDeployments().get(deploymentId);
+        Consent.Deployment consentDeployment = consent.getDeployments().get(currentDeploymentId);
         if (consentDeployment == null || !consentDeployment.isConsentRequired()) {
-            fail(deploymentId);
+            fail(currentDeploymentId);
+        }
+    }
+
+    private Deployment getRootDeployment(ProxyContext context, Deployment current) {
+        if (context.getApiKeyData().getPerRequestKey() == null) {
+            return current;
+        }
+        List<String> executionPath = context.getApiKeyData().getExecutionPath();
+        if (executionPath == null || executionPath.isEmpty()) {
+            throw new IllegalStateException("Execution path is empty for per-request API key");
+        }
+        String rootDeploymentId = executionPath.getFirst();
+        try {
+            return deploymentService.findDeployment(context, rootDeploymentId);
+        } catch (ResourceNotFoundException e) {
+            if (e.getMessage().startsWith("Unknown deployment")) {
+                // the root deployment might be a route
+                // we don't have user consent for routes
+                return null;
+            }
+            throw e;
         }
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
@@ -42,13 +42,13 @@ public class ConsentService {
         Consent newConsent = new Consent();
         boolean noneConsentRequired = true;
         while (!queue.isEmpty()) {
-            deploymentId = queue.poll();
-            Deployment deployment = deploymentService.findDeployment(context, deploymentId);
+            String currentDeploymentId = queue.poll();
+            Deployment deployment = deploymentService.findDeployment(context, currentDeploymentId);
             boolean consentRequired = isConsentRequired(deployment);
             if (consentRequired) {
                 noneConsentRequired = false;
             }
-            Consent.Deployment current = newConsent.getDeployments().computeIfAbsent(deploymentId, key -> new Consent.Deployment());
+            Consent.Deployment current = newConsent.getDeployments().computeIfAbsent(currentDeploymentId, key -> new Consent.Deployment());
             current.setConsentRequired(consentRequired);
             for (String dependency : deployment.getDependencies()) {
                 if (seen.add(dependency)) {
@@ -114,7 +114,7 @@ public class ConsentService {
         }
         String rootDeploymentId = executionPath.getFirst();
         try {
-            return deploymentService.findDeployment(context, rootDeploymentId);
+            return deploymentService.findDeploymentBypassingAuthorization(context, rootDeploymentId);
         } catch (ResourceNotFoundException e) {
             if (e.getMessage().startsWith("Unknown deployment")) {
                 // the root deployment might be a route

--- a/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
@@ -80,12 +80,7 @@ public class ConsentService {
         }
         String currentDeploymentId = deployment.getName();
         List<String> executionPath = context.getApiKeyData().getExecutionPath();
-        Deployment rootDeployment = getRootDeployment(context, deployment);
-        if (rootDeployment == null) {
-            log.debug("Root deployment is not found for the deployment {} in the execution path: {}", currentDeploymentId, executionPath);
-            return;
-        }
-        String rootDeploymentId = rootDeployment.getName();
+        String rootDeploymentId = getRootDeploymentId(context, deployment);
         Consent consent = readConsent(context, rootDeploymentId);
         if (consent == null) {
             // missing consent
@@ -104,25 +99,15 @@ public class ConsentService {
         }
     }
 
-    private Deployment getRootDeployment(ProxyContext context, Deployment current) {
+    private String getRootDeploymentId(ProxyContext context, Deployment current) {
         if (context.getApiKeyData().getPerRequestKey() == null) {
-            return current;
+            return current.getName();
         }
         List<String> executionPath = context.getApiKeyData().getExecutionPath();
         if (executionPath == null || executionPath.isEmpty()) {
             throw new IllegalStateException("Execution path is empty for per-request API key");
         }
-        String rootDeploymentId = executionPath.getFirst();
-        try {
-            return deploymentService.findDeploymentBypassingAuthorization(context, rootDeploymentId);
-        } catch (ResourceNotFoundException e) {
-            if (e.getMessage().startsWith("Unknown deployment")) {
-                // the root deployment might be a route
-                // we don't have user consent for routes
-                return null;
-            }
-            throw e;
-        }
+        return executionPath.getFirst();
     }
 
     private static void fail(String deploymentId) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
@@ -59,23 +59,15 @@ public class DeploymentService {
         this.applicationSchemaService = applicationSchemaService;
     }
 
-    Deployment findDeploymentBypassingAuthorization(ProxyContext context, String id) {
-        return findDeployment(context, id, false);
-    }
-
     public Deployment findDeployment(ProxyContext context, String id) {
-        return findDeployment(context, id, true);
-    }
-
-    private Deployment findDeployment(ProxyContext context, String id, boolean verifyAccess) {
         Deployment deployment = context.getConfig().selectDeployment(id);
         if (deployment != null) {
-            if (verifyAccess && !deployment.hasAccess(context.getUserRoles())) {
+            if (!deployment.hasAccess(context.getUserRoles())) {
                 throwForbiddenDeploymentError(id);
             }
             return deployment;
         }
-        ResourceDescriptor deploymentDescriptor = toResourceDescriptor(context, id, verifyAccess);
+        ResourceDescriptor deploymentDescriptor = toResourceDescriptor(context, id);
         ResourceType resourceType = deploymentDescriptor.getType();
         return switch (resourceType) {
             case APPLICATION -> applicationService.getApplication(deploymentDescriptor).getValue();
@@ -92,7 +84,7 @@ public class DeploymentService {
         return deployments;
     }
 
-    private ResourceDescriptor toResourceDescriptor(ProxyContext context, String resourceUrl, boolean verifyAccess) {
+    private ResourceDescriptor toResourceDescriptor(ProxyContext context, String resourceUrl) {
         String url;
         ResourceDescriptor resource;
 
@@ -107,7 +99,7 @@ public class DeploymentService {
             throw new ResourceNotFoundException("Invalid deployment url: " + url);
         }
 
-        if (verifyAccess && !accessService.hasReadAccess(resource, context)) {
+        if (!accessService.hasReadAccess(resource, context)) {
             throwForbiddenDeploymentError(resourceUrl);
         }
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
@@ -59,15 +59,23 @@ public class DeploymentService {
         this.applicationSchemaService = applicationSchemaService;
     }
 
+    Deployment findDeploymentBypassingAuthorization(ProxyContext context, String id) {
+        return findDeployment(context, id, false);
+    }
+
     public Deployment findDeployment(ProxyContext context, String id) {
+        return findDeployment(context, id, true);
+    }
+
+    private Deployment findDeployment(ProxyContext context, String id, boolean verifyAccess) {
         Deployment deployment = context.getConfig().selectDeployment(id);
         if (deployment != null) {
-            if (!deployment.hasAccess(context.getUserRoles())) {
+            if (verifyAccess && !deployment.hasAccess(context.getUserRoles())) {
                 throwForbiddenDeploymentError(id);
             }
             return deployment;
         }
-        ResourceDescriptor deploymentDescriptor = toResourceDescriptor(context, id);
+        ResourceDescriptor deploymentDescriptor = toResourceDescriptor(context, id, verifyAccess);
         ResourceType resourceType = deploymentDescriptor.getType();
         return switch (resourceType) {
             case APPLICATION -> applicationService.getApplication(deploymentDescriptor).getValue();
@@ -84,7 +92,7 @@ public class DeploymentService {
         return deployments;
     }
 
-    private ResourceDescriptor toResourceDescriptor(ProxyContext context, String resourceUrl) {
+    private ResourceDescriptor toResourceDescriptor(ProxyContext context, String resourceUrl, boolean verifyAccess) {
         String url;
         ResourceDescriptor resource;
 
@@ -99,7 +107,7 @@ public class DeploymentService {
             throw new ResourceNotFoundException("Invalid deployment url: " + url);
         }
 
-        if (!accessService.hasReadAccess(resource, context)) {
+        if (verifyAccess && !accessService.hasReadAccess(resource, context)) {
             throwForbiddenDeploymentError(resourceUrl);
         }
 

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -13,6 +13,7 @@ import okhttp3.mockwebserver.MockResponse;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -651,6 +652,33 @@ public class ToolSetApiTest extends ResourceBaseTest {
                 "authorization", "admin");
         verifyNotExact(response, 200, "\"url\":\"toolsets/4X25dj1mja51jykqxsXnCH/toolset@\"");
 
+        response = send(HttpMethod.PUT, "/v1/applications/4X25dj1mja51jykqxsXnCH/my-app", null, """
+                {
+                  "endpoint": "http://application1/v1/completions",
+                  "display_name": "My Custom Application",
+                  "display_version": "1.0",
+                  "icon_url": "http://application1/icon.svg",
+                  "description": "My Custom Application Description",
+                  "dependencies": ["toolsets/4X25dj1mja51jykqxsXnCH/toolset@"]
+                }
+                """,
+                "authorization", "admin");
+        verify(response, 200);
+
+        response = send(HttpMethod.GET, "/v1/consent/applications/4X25dj1mja51jykqxsXnCH/my-app", null, null, "authorization", "admin");
+        verify(response, 200);
+        ObjectNode node = (ObjectNode) ProxyUtil.MAPPER.readTree(response.body());
+        assertFalse(node.get("accepted").asBoolean());
+
+        node.remove("accepted");
+        response = send(HttpMethod.POST, "/v1/consent/applications/4X25dj1mja51jykqxsXnCH/my-app", null, node.toString(), "authorization", "admin");
+        verify(response, 200);
+
+        response = send(HttpMethod.GET, "/v1/consent/applications/4X25dj1mja51jykqxsXnCH/my-app", null, null, "authorization", "admin");
+        verify(response, 200);
+        node = (ObjectNode) ProxyUtil.MAPPER.readTree(response.body());
+        assertTrue(node.get("accepted").asBoolean());
+
         // signin into toolset
         response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
                 {
@@ -662,23 +690,6 @@ public class ToolSetApiTest extends ResourceBaseTest {
                 """, "authorization", "admin");
         verify(response, 200, "true");
 
-        // verify user consent is not provided
-        response = send(HttpMethod.GET, "/v1/consent/toolsets/4X25dj1mja51jykqxsXnCH/toolset@", null, null, "authorization", "admin");
-        verify(response, 200);
-        ObjectNode node = (ObjectNode) ProxyUtil.MAPPER.readTree(response.body());
-        assertFalse(node.get("accepted").asBoolean());
-
-        // provide consent to use toolset
-        node.remove("accepted");
-        response = send(HttpMethod.POST, "/v1/consent/toolsets/4X25dj1mja51jykqxsXnCH/toolset@", null, node.toString(), "authorization", "admin");
-        verify(response, 200);
-
-        // verify user consent is provided
-        response = send(HttpMethod.GET, "/v1/consent/toolsets/4X25dj1mja51jykqxsXnCH/toolset@", null, null, "authorization", "admin");
-        verify(response, 200);
-        node = (ObjectNode) ProxyUtil.MAPPER.readTree(response.body());
-        assertTrue(node.get("accepted").asBoolean());
-
         // use mcp with user's per request api key
         TestWebServer.Handler handler = request -> new MockResponse()
                 .setBody(MCP_TOOL_CALL_RESPONSE)
@@ -687,6 +698,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
             ApiKeyData adminAppKey = createAppKey("admin", Map.of(
                     "toolsets/4X25dj1mja51jykqxsXnCH/toolset@",
                     new AutoSharedData(Set.of(ResourceAccessType.READ))));
+            adminAppKey.setExecutionPath(List.of("applications/4X25dj1mja51jykqxsXnCH/my-app"));
             apiKeyStore.assignPerRequestApiKey(adminAppKey);
 
             Response resp = send(HttpMethod.POST, "/v1/toolset/toolsets/4X25dj1mja51jykqxsXnCH/toolset@/mcp", null,

--- a/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
@@ -8,7 +8,6 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.data.consent.Consent;
 import com.epam.aidial.core.server.data.consent.ReviewConsentResponse;
 import com.epam.aidial.core.server.util.ProxyUtil;
-import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
@@ -35,7 +34,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -342,7 +340,7 @@ public class ConsentServiceTest {
     }
 
     @Test
-    public void testVerifyUserConsent_WhenRootDeploymentIsNotFound() {
+    public void testVerifyUserConsent_WhenConsentIsNotFound() {
         Application application = new Application();
         application.setName("C");
         Features features = new Features();
@@ -354,29 +352,9 @@ public class ConsentServiceTest {
         apiKeyData.setExecutionPath(List.of("A", "B"));
         when(context.getApiKeyData()).thenReturn(apiKeyData);
 
-        when(deploymentService.findDeploymentBypassingAuthorization(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Application is not found"));
+        when(context.getUserSub()).thenReturn("sub");
 
-        assertThrows(ResourceNotFoundException.class, () -> service.verifyUserConsent(context, application));
-    }
-
-    @Test
-    public void testVerifyUserConsent_WhenRootDeploymentIsUnknown() {
-        Application application = new Application();
-        application.setName("C");
-        Features features = new Features();
-        features.setConsentRequired(true);
-        application.setFeatures(features);
-
-        ApiKeyData apiKeyData = new ApiKeyData();
-        apiKeyData.setPerRequestKey("key");
-        apiKeyData.setExecutionPath(List.of("A", "B"));
-        when(context.getApiKeyData()).thenReturn(apiKeyData);
-
-        when(deploymentService.findDeploymentBypassingAuthorization(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Unknown deployment"));
-
-        assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
-
-        verifyNoInteractions(resourceService);
+        assertThrows(PermissionDeniedException.class, () -> service.verifyUserConsent(context, application));
     }
 
     @Test
@@ -540,7 +518,6 @@ public class ConsentServiceTest {
 
         Application root = new Application();
         root.setName("A");
-        when(deploymentService.findDeploymentBypassingAuthorization(eq(context), eq("A"))).thenReturn(root);
 
         assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
     }

--- a/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
@@ -354,7 +354,7 @@ public class ConsentServiceTest {
         apiKeyData.setExecutionPath(List.of("A", "B"));
         when(context.getApiKeyData()).thenReturn(apiKeyData);
 
-        when(deploymentService.findDeployment(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Application is not found"));
+        when(deploymentService.findDeploymentBypassingAuthorization(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Application is not found"));
 
         assertThrows(ResourceNotFoundException.class, () -> service.verifyUserConsent(context, application));
     }
@@ -372,7 +372,7 @@ public class ConsentServiceTest {
         apiKeyData.setExecutionPath(List.of("A", "B"));
         when(context.getApiKeyData()).thenReturn(apiKeyData);
 
-        when(deploymentService.findDeployment(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Unknown deployment"));
+        when(deploymentService.findDeploymentBypassingAuthorization(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Unknown deployment"));
 
         assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
 
@@ -540,7 +540,7 @@ public class ConsentServiceTest {
 
         Application root = new Application();
         root.setName("A");
-        when(deploymentService.findDeployment(eq(context), eq("A"))).thenReturn(root);
+        when(deploymentService.findDeploymentBypassingAuthorization(eq(context), eq("A"))).thenReturn(root);
 
         assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
     }

--- a/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
@@ -8,6 +8,7 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.data.consent.Consent;
 import com.epam.aidial.core.server.data.consent.ReviewConsentResponse;
 import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
@@ -34,6 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -331,9 +333,50 @@ public class ConsentServiceTest {
         features.setConsentRequired(true);
         application.setFeatures(features);
 
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+
         when(context.getUserSub()).thenReturn("sub");
 
         assertThrows(PermissionDeniedException.class, () -> service.verifyUserConsent(context, application));
+    }
+
+    @Test
+    public void testVerifyUserConsent_WhenRootDeploymentIsNotFound() {
+        Application application = new Application();
+        application.setName("C");
+        Features features = new Features();
+        features.setConsentRequired(true);
+        application.setFeatures(features);
+
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setPerRequestKey("key");
+        apiKeyData.setExecutionPath(List.of("A", "B"));
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+
+        when(deploymentService.findDeployment(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Application is not found"));
+
+        assertThrows(ResourceNotFoundException.class, () -> service.verifyUserConsent(context, application));
+    }
+
+    @Test
+    public void testVerifyUserConsent_WhenRootDeploymentIsUnknown() {
+        Application application = new Application();
+        application.setName("C");
+        Features features = new Features();
+        features.setConsentRequired(true);
+        application.setFeatures(features);
+
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setPerRequestKey("key");
+        apiKeyData.setExecutionPath(List.of("A", "B"));
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+
+        when(deploymentService.findDeployment(eq(context), eq("A"))).thenThrow(new ResourceNotFoundException("Unknown deployment"));
+
+        assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
+
+        verifyNoInteractions(resourceService);
     }
 
     @Test
@@ -417,7 +460,7 @@ public class ConsentServiceTest {
     }
 
     @Test
-    public void testVerifyUserConsent_Success() {
+    public void testVerifyUserConsent_Success_RootIsCurrentDeployment() {
         Application application = new Application();
         application.setName("X");
         Features features = new Features();
@@ -452,6 +495,52 @@ public class ConsentServiceTest {
         ApiKeyData apiKeyData = new ApiKeyData();
         apiKeyData.setExecutionPath(List.of("A", "B"));
         when(context.getApiKeyData()).thenReturn(apiKeyData);
+
+        assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
+    }
+
+    @Test
+    public void testVerifyUserConsent_Success_RootIsInPath() {
+        Application application = new Application();
+        application.setName("X");
+        Features features = new Features();
+        features.setConsentRequired(true);
+        application.setFeatures(features);
+
+        when(context.getUserSub()).thenReturn("sub");
+
+        String jsonConsent = """
+               {
+                   "deployments" : {
+                      "A" : {
+                        "consentRequired" : false
+                      },
+                      "B" : {
+                        "consentRequired" : false
+                      },
+                      "C" : {
+                        "consentRequired" : false
+                      },
+                      "X" : {
+                        "consentRequired" : true
+                      },
+                      "Y" : {
+                        "consentRequired" : true
+                      }
+                   }
+               }
+                """;
+
+        when(resourceService.getResource(any(ResourceDescriptor.class))).thenReturn(jsonConsent);
+
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setPerRequestKey("key");
+        apiKeyData.setExecutionPath(List.of("A", "B"));
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+
+        Application root = new Application();
+        root.setName("A");
+        when(deploymentService.findDeployment(eq(context), eq("A"))).thenReturn(root);
 
         assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
     }


### PR DESCRIPTION
DIAL Core should take a root deployment to verify user consent. 

A root deployment is the first deployment in the chain of chat completion request.

User accepts consent for calling a root deployment.