### PR TITLE
fix: [ToolSets] Skip ToolSet authentication metadata discovery when scopes are statically configured

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
@@ -73,7 +73,9 @@ public class StaticResourceRegistrationStrategy implements ResourceRegistrationS
             AuthorizationServerMetadata authServerMetadata = authorizationServerMetadataService.getAuthorizationServerMetadata(
                     resourceId, resourceEndpoint, protectedResourceMetadata, false);
 
-            supportedScopes = collectSupportedScopes(protectedResourceMetadata, authServerMetadata);
+            if (supportedScopes == null || supportedScopes.isEmpty()) {
+                supportedScopes = collectSupportedScopes(protectedResourceMetadata, authServerMetadata);
+            }
 
             if (authServerMetadata != null) {
                 authorizationEndpoint = Optional.ofNullable(authServerMetadata.getAuthorizationEndpoint())

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
@@ -10,11 +10,11 @@ import com.epam.aidial.core.credentials.service.ResourceAuthorizationClient;
 import com.epam.aidial.core.credentials.service.metadata.AuthorizationServerMetadataService;
 import com.epam.aidial.core.credentials.service.metadata.ProtectedResourceMetadataService;
 import org.apache.hc.core5.http.ContentType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class DynamicResourceRegistrationStrategyTest {
 
     @Mock
@@ -43,11 +44,6 @@ class DynamicResourceRegistrationStrategyTest {
     @InjectMocks
     private DynamicResourceRegistrationStrategy resourceRegistrationStrategy;
 
-    @BeforeEach
-    void setup() {
-        MockitoAnnotations.openMocks(this);
-    }
-
     @Test
     void testCreateDynamicResourceRegistration_Success() {
         // Given
@@ -59,7 +55,6 @@ class DynamicResourceRegistrationStrategyTest {
         when(resourceAuthSettings.getRedirectUri()).thenReturn(resourceRedirectUri);
 
         AuthorizationServerProtectedResourceMetadata protectedResourceMetadata = mock(AuthorizationServerProtectedResourceMetadata.class);
-        when(protectedResourceMetadata.getAuthorizationServers()).thenReturn(List.of("https://auth.server"));
         when(protectedResourceMetadata.getScopesSupported()).thenReturn(List.of("scope1", "scope2"));
 
         when(protectedResourceMetadataService.getProtectedResourceMetadata(resourceId, resourceEndpoint)).thenReturn(protectedResourceMetadata);
@@ -67,7 +62,6 @@ class DynamicResourceRegistrationStrategyTest {
         AuthorizationServerMetadata authorizationServerMetadata = mock(AuthorizationServerMetadata.class);
         when(authorizationServerMetadata.getRegistrationEndpoint()).thenReturn("https://auth.server/registration");
         when(authorizationServerMetadata.getCodeChallengeMethodsSupported()).thenReturn(List.of("S256"));
-        when(authorizationServerMetadata.getScopesSupported()).thenReturn(List.of("scope3", "scope4"));
 
         when(authorizationServerMetadataService.getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, true))

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
@@ -6,22 +6,22 @@ import com.epam.aidial.core.credentials.data.registration.AuthorizationServerPro
 import com.epam.aidial.core.credentials.data.registration.ClientRegistration;
 import com.epam.aidial.core.credentials.service.metadata.AuthorizationServerMetadataService;
 import com.epam.aidial.core.credentials.service.metadata.ProtectedResourceMetadataService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class StaticResourceRegistrationStrategyTest {
 
     @Mock
@@ -33,32 +33,73 @@ class StaticResourceRegistrationStrategyTest {
     @InjectMocks
     private StaticResourceRegistrationStrategy resourceRegistrationStrategy;
 
-    @BeforeEach
-    void setup() {
-        MockitoAnnotations.openMocks(this);
-    }
-
     @Test
-    void testCreateStaticResourceRegistration_Success() {
+    void testCreateStaticResourceRegistrationWithUserProvidedData() {
         // Given
         String resourceId = "staticResource";
         String resourceEndpoint = "https://test.endpoint.com";
-        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
-        resourceAuthSettings.setClientId("staticClientId");
-        resourceAuthSettings.setClientSecret("staticClientSecret");
-        resourceAuthSettings.setRedirectUri("https://static.redirect.uri");
+        String clientId = "staticClientId";
+        String clientSecret = "staticClientSecret";
+        String redirectUri = "https://static.redirect.uri";
+        String authorizationEndpoint = "https://static.auth.endpoint";
+        String tokenEndpoint = "https://static.token.endpoint";
+        String codeChallengeMethod = "S256";
+        List<String> scopesSupported = List.of("scope1", "scope2");
+
+        ResourceAuthSettings resourceAuthSettings = ResourceAuthSettings.builder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .redirectUri(redirectUri)
+                .authorizationEndpoint(authorizationEndpoint)
+                .tokenEndpoint(tokenEndpoint)
+                .codeChallengeMethod(codeChallengeMethod)
+                .scopesSupported(scopesSupported)
+                .build();
+
+        // When
+        ClientRegistration result = resourceRegistrationStrategy.register(resourceId, resourceEndpoint, resourceAuthSettings);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(clientId, result.getClientId());
+        assertEquals(clientSecret, result.getClientSecret());
+        assertEquals(redirectUri, result.getRedirectUri());
+        assertEquals(authorizationEndpoint, result.getAuthorizationEndpoint());
+        assertEquals(tokenEndpoint, result.getTokenEndpoint());
+        assertEquals(codeChallengeMethod, result.getCodeChallengeMethod());
+        assertEquals(scopesSupported, result.getScopesSupported());
+        verifyNoInteractions(protectedResourceMetadataService);
+        verifyNoInteractions(authorizationServerMetadataService);
+    }
+
+    @Test
+    void testCreateStaticResourceRegistrationWithDiscoveredData() {
+        // Given
+        String resourceId = "staticResource";
+        String resourceEndpoint = "https://test.endpoint.com";
+        String clientId = "staticClientId";
+        String clientSecret = "staticClientSecret";
+        String redirectUri = "https://static.redirect.uri";
+
+        String authorizationEndpoint = "https://static.auth.endpoint";
+        String tokenEndpoint = "https://static.token.endpoint";
+        String codeChallengeMethod = "S256";
+
+        ResourceAuthSettings resourceAuthSettings = ResourceAuthSettings.builder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .redirectUri(redirectUri)
+                .build();
 
         AuthorizationServerProtectedResourceMetadata protectedResourceMetadata = mock(AuthorizationServerProtectedResourceMetadata.class);
-        when(protectedResourceMetadata.getAuthorizationServers()).thenReturn(List.of("https://auth.server"));
-        when(protectedResourceMetadata.getScopesSupported()).thenReturn(List.of());
+        when(protectedResourceMetadata.getScopesSupported()).thenReturn(List.of("scope1"));
 
         when(protectedResourceMetadataService.getProtectedResourceMetadata(resourceId, resourceEndpoint)).thenReturn(protectedResourceMetadata);
 
         AuthorizationServerMetadata authorizationServerMetadata = mock(AuthorizationServerMetadata.class);
-        when(authorizationServerMetadata.getAuthorizationEndpoint()).thenReturn("https://static.auth.endpoint");
-        when(authorizationServerMetadata.getTokenEndpoint()).thenReturn("https://static.token.endpoint");
-        when(authorizationServerMetadata.getCodeChallengeMethodsSupported()).thenReturn(List.of("S256", "plain"));
-        when(authorizationServerMetadata.getScopesSupported()).thenReturn(List.of("scope2", "scope3"));
+        when(authorizationServerMetadata.getAuthorizationEndpoint()).thenReturn(authorizationEndpoint);
+        when(authorizationServerMetadata.getTokenEndpoint()).thenReturn(tokenEndpoint);
+        when(authorizationServerMetadata.getCodeChallengeMethodsSupported()).thenReturn(List.of(codeChallengeMethod));
 
         when(authorizationServerMetadataService.getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, false))
@@ -69,16 +110,16 @@ class StaticResourceRegistrationStrategyTest {
 
         // Then
         assertNotNull(result);
-        assertEquals("staticClientId", result.getClientId());
-        assertEquals("staticClientSecret", result.getClientSecret());
-        assertEquals("https://static.redirect.uri", result.getRedirectUri());
-        assertEquals("S256", result.getCodeChallengeMethod());
-        List<String> actualScopesSupported = result.getScopesSupported();
-        Collections.sort(actualScopesSupported);
-        assertEquals(List.of("scope2", "scope3"), actualScopesSupported);
-        verify(authorizationServerMetadataService, times(1)).getAuthorizationServerMetadata(
+        assertEquals(clientId, result.getClientId());
+        assertEquals(clientSecret, result.getClientSecret());
+        assertEquals(redirectUri, result.getRedirectUri());
+        assertEquals(authorizationEndpoint, result.getAuthorizationEndpoint());
+        assertEquals(tokenEndpoint, result.getTokenEndpoint());
+        assertEquals(codeChallengeMethod, result.getCodeChallengeMethod());
+        assertEquals(List.of("scope1"), result.getScopesSupported());
+        verify(protectedResourceMetadataService).getProtectedResourceMetadata(
+                resourceId, resourceEndpoint);
+        verify(authorizationServerMetadataService).getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, false);
     }
-
-    // TODO: add more tests
 }


### PR DESCRIPTION


### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1255

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
