### PR TITLE
fix: Optimize lock service #1274

### DIFF
--- a/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
@@ -3,11 +3,11 @@ package com.epam.aidial.core.storage.service;
 import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.mutable.MutableObject;
 import org.redisson.api.RScript;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 
 /**
  * Simple spin-lock implementation which works with Redis as cache. Supports volatile-* eviction policies.
@@ -60,7 +59,8 @@ public class LockService {
         long owner = ThreadLocalRandom.current().nextLong();
         log.debug("Thread {} acquires a lock to the resource {} with owner {}", Thread.currentThread().getName(), id, owner);
         // try to get a local lock the first
-        acquireLocalLock(id);
+        LocalLock localLock = acquireLocalLock(id);
+        localLock.lock();
 
         long ttl = tryLock(id, owner);
         long interval = WAIT_MIN;
@@ -71,11 +71,11 @@ public class LockService {
             ttl = tryLock(id, owner);
         }
 
-        return () -> unlock(id, owner);
+        return () -> unlock(id, owner, localLock);
     }
 
-    private void acquireLocalLock(String id) {
-        LocalLock localLock = locks.compute(id, (k, cur) -> {
+    private LocalLock acquireLocalLock(String id) {
+        return locks.compute(id, (k, cur) -> {
             if (cur == null) {
                 return new LocalLock();
             } else {
@@ -83,7 +83,6 @@ public class LockService {
             }
             return cur;
         });
-        localLock.lock();
     }
 
     public <T> T underBucketLock(String bucketLocation, Supplier<T> function) {
@@ -140,6 +139,15 @@ public class LockService {
                         """, RScript.ReturnType.INTEGER, List.of(id), String.valueOf(owner), String.valueOf(PERIOD));
     }
 
+    private void unlock(String id, long owner, LocalLock localLock) {
+        try {
+            unlock(id, owner);
+        } finally {
+            localLock.unlock();
+            releaseLocalLock(id);
+        }
+    }
+
     private void unlock(String id, long owner) {
         boolean ok = tryUnlock(id, owner);
         if (!ok) {
@@ -147,24 +155,15 @@ public class LockService {
         } else {
             log.debug("Thread {} releases a lock to the resource {} with owner {}", Thread.currentThread().getName(), id, owner);
         }
-        releaseLocalLock(id);
     }
 
     private void releaseLocalLock(String id) {
-        MutableObject<LocalLock> lockRef = new MutableObject<>();
         locks.compute(id, (k, cur) -> {
-            lockRef.setValue(cur);
             if (cur == null || --cur.threadCount == 0) {
                 return null;
             }
             return cur;
         });
-        LocalLock localLock = lockRef.get();
-        if (localLock != null) {
-            localLock.unlock();
-        } else {
-            log.warn("Local lock is not found for the key: {}", id);
-        }
     }
 
     private boolean tryUnlock(String id, long owner) {

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.storage.service;
 import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.redisson.api.RScript;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
@@ -10,9 +11,11 @@ import org.redisson.client.codec.StringCodec;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -29,19 +32,39 @@ public class LockService {
     @Getter
     private final String prefix;
     private final RScript script;
+    private final ConcurrentHashMap<String, LocalLock> locks;
+
+    private static class LocalLock {
+        // number of threads requested this lock
+        int threadCount = 1;
+
+        ReentrantLock lock = new ReentrantLock();
+
+        void lock() {
+            lock.lock();
+        }
+
+        void unlock() {
+            lock.unlock();
+        }
+    }
 
     public LockService(RedissonClient redis, @Nullable String prefix) {
         this.prefix = prefix;
         this.script = redis.getScript(StringCodec.INSTANCE);
+        this.locks = new ConcurrentHashMap<>();
     }
 
     public Lock lock(String key) {
         String id = id(key);
         long owner = ThreadLocalRandom.current().nextLong();
         log.debug("Thread {} acquires a lock to the resource {} with owner {}", Thread.currentThread().getName(), id, owner);
+        // try to get a local lock the first
+        acquireLocalLock(id);
+
         long ttl = tryLock(id, owner);
         long interval = WAIT_MIN;
-
+        // it seems the lock has been acquired by another instance of Core
         while (ttl > 0) {
             LockSupport.parkNanos(interval);
             interval = Math.min(2 * interval, Math.min(WAIT_MAX, ttl + 1));
@@ -49,6 +72,18 @@ public class LockService {
         }
 
         return () -> unlock(id, owner);
+    }
+
+    private void acquireLocalLock(String id) {
+        LocalLock localLock = locks.compute(id, (k, cur) -> {
+            if (cur == null) {
+                return new LocalLock();
+            } else {
+                cur.threadCount++;
+            }
+            return cur;
+        });
+        localLock.lock();
     }
 
     public <T> T underBucketLock(String bucketLocation, Supplier<T> function) {
@@ -111,6 +146,24 @@ public class LockService {
             log.warn("Lock service failed to unlock: {}", id);
         } else {
             log.debug("Thread {} releases a lock to the resource {} with owner {}", Thread.currentThread().getName(), id, owner);
+        }
+        releaseLocalLock(id);
+    }
+
+    private void releaseLocalLock(String id) {
+        MutableObject<LocalLock> lockRef = new MutableObject<>();
+        locks.compute(id, (k, cur) -> {
+            lockRef.setValue(cur);
+            if (cur == null || --cur.threadCount == 0) {
+                return null;
+            }
+            return cur;
+        });
+        LocalLock localLock = lockRef.get();
+        if (localLock != null) {
+            localLock.unlock();
+        } else {
+            log.warn("Local lock is not found for the key: {}", id);
         }
     }
 

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
@@ -7,7 +7,6 @@ import org.redisson.api.RScript;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -17,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Simple spin-lock implementation which works with Redis as cache. Supports volatile-* eviction policies.


### PR DESCRIPTION
We run a load test with 60 RPS for 10 min.

Before optimization:

```
========================================================================================================================
---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
> request count                                                                      |    36,000 |    36,000 |         -
> min response time (ms)                                                             |        18 |        18 |         -
> max response time (ms)                                                             |    30,845 |    30,845 |         -
> mean response time (ms)                                                            |        47 |        47 |         -
> response time std deviation (ms)                                                   |       333 |       333 |         -
> response time 50th percentile (ms)                                                 |        39 |        39 |         -
> response time 75th percentile (ms)                                                 |        42 |        42 |         -
> response time 95th percentile (ms)                                                 |        49 |        49 |         -
> response time 99th percentile (ms)                                                 |        70 |        70 |         -
> mean throughput (rps)                                                              |      59.9 |      59.9 |         -
---- Response Time Distribution ----------------------------------------------------------------------------------------
> OK: t < 50 ms                                                                                          34,291 (95.25%)
> OK: 50 ms <= t < 150 ms                                                                                 1,583   (4.4%)
> OK: t >= 150 ms                                                                                           126  (0.35%)
> KO                                                                                                          0     (0%)
========================================================================================================================
```

after optimization

```
========================================================================================================================
---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
> request count                                                                      |    36,000 |    36,000 |         -
> min response time (ms)                                                             |        18 |        18 |         -
> max response time (ms)                                                             |       576 |       576 |         -
> mean response time (ms)                                                            |        38 |        38 |         -
> response time std deviation (ms)                                                   |        19 |        19 |         -
> response time 50th percentile (ms)                                                 |        37 |        37 |         -
> response time 75th percentile (ms)                                                 |        43 |        43 |         -
> response time 95th percentile (ms)                                                 |        51 |        51 |         -
> response time 99th percentile (ms)                                                 |        85 |        85 |         -
> mean throughput (rps)                                                              |        60 |        60 |         -
---- Response Time Distribution ----------------------------------------------------------------------------------------
> OK: t < 50 ms                                                                                          34,045 (94.57%)
> OK: 50 ms <= t < 150 ms                                                                                 1,817  (5.05%)
> OK: t >= 150 ms                                                                                           138  (0.38%)
> KO                                                                                                          0     (0%)
========================================================================================================================
```