### PR TITLE
feat: pass X-UPSTREAM-KEY header to the chat completion feature endpoints

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentFeatureController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentFeatureController.java
@@ -196,6 +196,7 @@ public class DeploymentFeatureController {
         if (deployment instanceof Model model && !model.getUpstreams().isEmpty()) {
             Upstream upstream = model.getUpstreams().getFirst();
             proxyRequest.putHeader(Proxy.HEADER_UPSTREAM_ENDPOINT, upstream.getEndpoint());
+            proxyRequest.putHeader(Proxy.HEADER_UPSTREAM_KEY, upstream.getKey());
         }
 
         Buffer requestBody = context.getRequestBody();

--- a/server/src/test/java/com/epam/aidial/core/server/FeaturesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/FeaturesApiTest.java
@@ -114,6 +114,7 @@ public class FeaturesApiTest extends ResourceBaseTest {
                 String path = request.getPath();
                 if (path.endsWith("model_config")) {
                     assertEquals("http://localhost:7001", request.getHeader(Proxy.HEADER_UPSTREAM_ENDPOINT));
+                    assertEquals("modelKey1", request.getHeader(Proxy.HEADER_UPSTREAM_KEY));
                 }
                 if (path.endsWith("rate_response")) {
                     return handleRateResponse(request, responseHeaders);


### PR DESCRIPTION
Follow-up of https://github.com/epam/ai-dial-core/pull/1347

Unblocks https://github.com/epam/ai-dial-adapter-dial/issues/39