### PR TITLE
fix: [Toolset] Toolset sign-in succeeds when AS /token returns 200 with error payload

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -92,7 +92,7 @@ public class ResourceAuthorizationClient {
                 }
             }
 
-            checkOAuthError(body, request.uri());
+            checkOauthError(body, request.uri());
 
             return JsonMapperUtil.convertToObject(body, responseType);
         } catch (ConnectException e) {
@@ -122,7 +122,7 @@ public class ResourceAuthorizationClient {
      * Some OAuth Authorization Servers return HTTP 200 with an error payload
      * instead of a proper error status code. Detect and handle this case.
      */
-    private static void checkOAuthError(String body, URI uri) {
+    private static void checkOauthError(String body, URI uri) {
         if (body == null || body.isBlank()) {
             return;
         }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.credentials.service;
 import com.epam.aidial.core.credentials.service.metadata.HttpHeadersHandler;
 import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -91,6 +92,8 @@ public class ResourceAuthorizationClient {
                 }
             }
 
+            checkOAuthError(body, request.uri());
+
             return JsonMapperUtil.convertToObject(body, responseType);
         } catch (ConnectException e) {
             if (hasUnresolvedAddressException(e)) {
@@ -113,5 +116,24 @@ public class ResourceAuthorizationClient {
 
     private java.time.Duration createRequestConfig() {
         return java.time.Duration.ofSeconds(30);
+    }
+
+    /**
+     * Some OAuth Authorization Servers return HTTP 200 with an error payload
+     * instead of a proper error status code. Detect and handle this case.
+     */
+    private static void checkOAuthError(String body, URI uri) {
+        if (body == null || body.isBlank()) {
+            return;
+        }
+        var node = JsonMapperUtil.convertToObject(body, java.util.Map.class);
+        if (node != null && node.containsKey("error")) {
+            String error = String.valueOf(node.get("error"));
+            String description = node.containsKey("error_description")
+                    ? String.valueOf(node.get("error_description"))
+                    : "no description";
+            log.debug("OAuth error in 200 response from {}: error={}, description={}", uri, error, description);
+            throw new HttpException(HttpStatus.BAD_REQUEST, "Authorization server returned error: %s (%s)".formatted(error, description));
+        }
     }
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
@@ -5,7 +5,6 @@ import com.epam.aidial.core.credentials.data.credentials.RefreshTokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenResponse;
-
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
@@ -5,6 +5,7 @@ import com.epam.aidial.core.credentials.data.credentials.RefreshTokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenResponse;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,11 +29,7 @@ public class TokenService {
                 .redirectUri(resourceAuthSettings.getRedirectUri())
                 .build();
 
-        TokenResponse tokenResponse = resourceAuthorizationClient.executePost(
-                resourceAuthSettings.getTokenEndpoint(),
-                tokenRequest.buildFormData(),
-                "application/x-www-form-urlencoded",
-                TokenResponse.class);
+        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData());
         log.debug("Finished Resource {} token retrieval", resourceId);
         return tokenResponse;
     }
@@ -48,12 +45,15 @@ public class TokenService {
                 .refreshToken(refreshToken)
                 .build();
 
-        TokenResponse tokenResponse = resourceAuthorizationClient.executePost(
-                resourceAuthSettings.getTokenEndpoint(),
-                tokenRequest.buildFormData(),
-                "application/x-www-form-urlencoded",
-                TokenResponse.class);
+        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData());
         log.debug("Finished Resource {} refresh token retrieval", resourceId);
         return tokenResponse;
+    }
+
+    private TokenResponse doTokenCall(String tokenEndpoint, String tokenRequest) {
+        return resourceAuthorizationClient.executePost(
+                tokenEndpoint, tokenRequest,
+                "application/x-www-form-urlencoded",
+                TokenResponse.class);
     }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -241,7 +241,7 @@ class ResourceAuthorizationClientTest {
                 () -> resourceAuthorizationClient.executeGet(url, TestResponse.class));
 
         // Then
-        assertEquals(502, exception.getStatus().getCode());
+        assertEquals(400, exception.getStatus().getCode());
         assertTrue(exception.getMessage().contains("invalid_grant"));
         assertTrue(exception.getMessage().contains("The authorization code has expired"));
     }
@@ -263,7 +263,7 @@ class ResourceAuthorizationClientTest {
                         ContentType.APPLICATION_JSON.toString(), TestResponse.class));
 
         // Then
-        assertEquals(502, exception.getStatus().getCode());
+        assertEquals(400, exception.getStatus().getCode());
         assertTrue(exception.getMessage().contains("invalid_client"));
         assertTrue(exception.getMessage().contains("Invalid redirect_uri"));
     }
@@ -285,7 +285,7 @@ class ResourceAuthorizationClientTest {
                         ContentType.APPLICATION_JSON.toString(), TestResponse.class));
 
         // Then
-        assertEquals(502, exception.getStatus().getCode());
+        assertEquals(400, exception.getStatus().getCode());
         assertTrue(exception.getMessage().contains("server_error"));
         assertTrue(exception.getMessage().contains("no description"));
     }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -226,6 +226,87 @@ class ResourceAuthorizationClientTest {
         assertEquals("Cannot connect to https://example.com/resource", exception.getMessage());
     }
 
+    @Test
+    void testExecuteGet_OAuthErrorInSuccessResponse() throws Exception {
+        // Given
+        String url = "https://example.com/token";
+        String errorResponse = "{\"error\":\"invalid_grant\",\"error_description\":\"The authorization code has expired\"}";
+        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(errorResponse);
+
+        // When
+        HttpException exception = assertThrows(HttpException.class,
+                () -> resourceAuthorizationClient.executeGet(url, TestResponse.class));
+
+        // Then
+        assertEquals(502, exception.getStatus().getCode());
+        assertTrue(exception.getMessage().contains("invalid_grant"));
+        assertTrue(exception.getMessage().contains("The authorization code has expired"));
+    }
+
+    @Test
+    void testExecutePost_OAuthErrorInSuccessResponse() throws Exception {
+        // Given
+        String url = "https://example.com/token";
+        TestRequest requestPayload = new TestRequest("testValue");
+        String errorResponse = "{\"error\":\"invalid_client\",\"error_description\":\"Invalid redirect_uri\"}";
+        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(errorResponse);
+
+        // When
+        HttpException exception = assertThrows(HttpException.class,
+                () -> resourceAuthorizationClient.executePost(url, requestPayload,
+                        ContentType.APPLICATION_JSON.toString(), TestResponse.class));
+
+        // Then
+        assertEquals(502, exception.getStatus().getCode());
+        assertTrue(exception.getMessage().contains("invalid_client"));
+        assertTrue(exception.getMessage().contains("Invalid redirect_uri"));
+    }
+
+    @Test
+    void testExecutePost_OAuthErrorWithoutDescription() throws Exception {
+        // Given
+        String url = "https://example.com/token";
+        TestRequest requestPayload = new TestRequest("testValue");
+        String errorResponse = "{\"error\":\"server_error\"}";
+        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(errorResponse);
+
+        // When
+        HttpException exception = assertThrows(HttpException.class,
+                () -> resourceAuthorizationClient.executePost(url, requestPayload,
+                        ContentType.APPLICATION_JSON.toString(), TestResponse.class));
+
+        // Then
+        assertEquals(502, exception.getStatus().getCode());
+        assertTrue(exception.getMessage().contains("server_error"));
+        assertTrue(exception.getMessage().contains("no description"));
+    }
+
+    @Test
+    void testExecuteGet_ValidResponseNotTreatedAsOAuthError() throws Exception {
+        String url = "https://example.com/resource";
+        String jsonResponse = "{\"key\":\"value\"}";
+        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(jsonResponse);
+
+        // When
+        TestResponse actualResponse = resourceAuthorizationClient.executeGet(url, TestResponse.class);
+
+        // Then
+        assertNotNull(actualResponse);
+        assertEquals("value", actualResponse.getKey());
+    }
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -227,7 +227,7 @@ class ResourceAuthorizationClientTest {
     }
 
     @Test
-    void testExecuteGet_OAuthErrorInSuccessResponse() throws Exception {
+    void testExecuteGet_OauthErrorInSuccessResponse() throws Exception {
         // Given
         String url = "https://example.com/token";
         String errorResponse = "{\"error\":\"invalid_grant\",\"error_description\":\"The authorization code has expired\"}";
@@ -247,7 +247,7 @@ class ResourceAuthorizationClientTest {
     }
 
     @Test
-    void testExecutePost_OAuthErrorInSuccessResponse() throws Exception {
+    void testExecutePost_OauthErrorInSuccessResponse() throws Exception {
         // Given
         String url = "https://example.com/token";
         TestRequest requestPayload = new TestRequest("testValue");
@@ -269,7 +269,7 @@ class ResourceAuthorizationClientTest {
     }
 
     @Test
-    void testExecutePost_OAuthErrorWithoutDescription() throws Exception {
+    void testExecutePost_OauthErrorWithoutDescription() throws Exception {
         // Given
         String url = "https://example.com/token";
         TestRequest requestPayload = new TestRequest("testValue");
@@ -291,7 +291,7 @@ class ResourceAuthorizationClientTest {
     }
 
     @Test
-    void testExecuteGet_ValidResponseNotTreatedAsOAuthError() throws Exception {
+    void testExecuteGet_ValidResponseNotTreatedAsOauthError() throws Exception {
         String url = "https://example.com/resource";
         String jsonResponse = "{\"key\":\"value\"}";
         HttpResponse<String> httpResponseMock = mock(HttpResponse.class);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1354

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
