### PR TITLE
fix: Core returns 500 on an unknown toolset instead of 404 #1375

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
@@ -398,6 +398,8 @@ public class ToolSetProxyController implements Controller {
             log.warn("Forbidden toolset {}", toolSetId);
         } else if (error instanceof HttpException httpException) {
             respond(httpException);
+        } else if (error instanceof ResourceNotFoundException) {
+            respond(HttpStatus.NOT_FOUND, error.getMessage());
         } else {
             String errorMsg = "Error occurred on processing MCP request by toolset: %s".formatted(toolSetId);
             respond(HttpStatus.INTERNAL_SERVER_ERROR, errorMsg);

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -434,6 +434,19 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testProxyMcpPostCall_WhenToolsetNotFound() {
+        String mcpRequest = """
+                {
+                   "payload": "foo"
+                }
+                """;
+
+        Response resp = send(HttpMethod.POST, "/v1/toolset/unknown/mcp", null, mcpRequest);
+
+        assertEquals(404, resp.status());
+    }
+
+    @Test
     void testProxyMcp_TerminateSession() {
         String mcpRequest = """                
                 """;


### PR DESCRIPTION
fixes #1375 