### PR TITLE
fix: Static OAuth endpoints are overwritten by metadata discovery results

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
@@ -50,7 +50,7 @@ public class StaticResourceRegistrationStrategy implements ResourceRegistrationS
      * @param resourceAuthSettings The static authentication settings provided for the resource.
      * @return A {@link ClientRegistration} containing the complete registration details.
      * @throws IllegalArgumentException If any of the required endpoints (authorizationEndpoint,
-     *                                  tokenEndpoint, codeChallengeMethod) cannot be resolved.
+     *                                  tokenEndpoint) cannot be resolved.
      */
     @Override
     public ClientRegistration register(String resourceId, String resourceEndpoint, ResourceAuthSettings resourceAuthSettings) {
@@ -78,12 +78,12 @@ public class StaticResourceRegistrationStrategy implements ResourceRegistrationS
             }
 
             if (authServerMetadata != null) {
-                authorizationEndpoint = Optional.ofNullable(authServerMetadata.getAuthorizationEndpoint())
-                        .orElse(authorizationEndpoint);
-                tokenEndpoint = Optional.ofNullable(authServerMetadata.getTokenEndpoint())
-                        .orElse(tokenEndpoint);
-                codeChallengeMethod = getCodeChallengeMethod(authServerMetadata)
-                        .orElse(codeChallengeMethod);
+                authorizationEndpoint = Optional.ofNullable(authorizationEndpoint)
+                        .orElse(authServerMetadata.getAuthorizationEndpoint());
+                tokenEndpoint = Optional.ofNullable(tokenEndpoint)
+                        .orElse(authServerMetadata.getTokenEndpoint());
+                codeChallengeMethod = Optional.ofNullable(codeChallengeMethod)
+                        .orElse(getCodeChallengeMethod(authServerMetadata).orElse(null));
             }
         }
 

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -119,6 +120,70 @@ class StaticResourceRegistrationStrategyTest {
         assertEquals(List.of("scope1"), result.getScopesSupported());
         verify(protectedResourceMetadataService).getProtectedResourceMetadata(
                 resourceId, resourceEndpoint);
+        verify(authorizationServerMetadataService).getAuthorizationServerMetadata(
+                resourceId, resourceEndpoint, protectedResourceMetadata, false);
+    }
+
+    @Test
+    void testStaticEndpointsNotOverwrittenByDiscovery() {
+        // Given
+        String resourceId = "staticResource";
+        String resourceEndpoint = "https://test.endpoint.com";
+        String clientId = "staticClientId";
+        String clientSecret = "staticClientSecret";
+        String redirectUri = "https://static.redirect.uri";
+
+        // Static endpoints provided by the user
+        String staticAuthorizationEndpoint = "https://static.auth.endpoint";
+        String staticTokenEndpoint = "https://static.token.endpoint";
+        List<String> scopesSupported = List.of("scope1", "scope2");
+
+        // Discovery returns different endpoints and a codeChallengeMethod
+        String discoveredAuthorizationEndpoint = "https://discovered.auth.endpoint";
+        String discoveredTokenEndpoint = "https://discovered.token.endpoint";
+        String discoveredCodeChallengeMethod = "S256";
+
+        // codeChallengeMethod is null (simulates UI-created toolset), triggering discovery
+        ResourceAuthSettings resourceAuthSettings = ResourceAuthSettings.builder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .redirectUri(redirectUri)
+                .authorizationEndpoint(staticAuthorizationEndpoint)
+                .tokenEndpoint(staticTokenEndpoint)
+                .scopesSupported(scopesSupported)
+                .build();
+
+        assertNull(resourceAuthSettings.getCodeChallengeMethod());
+
+        AuthorizationServerProtectedResourceMetadata protectedResourceMetadata = mock(AuthorizationServerProtectedResourceMetadata.class);
+        when(protectedResourceMetadataService.getProtectedResourceMetadata(resourceId, resourceEndpoint))
+                .thenReturn(protectedResourceMetadata);
+
+        AuthorizationServerMetadata authorizationServerMetadata = mock(AuthorizationServerMetadata.class);
+        when(authorizationServerMetadata.getAuthorizationEndpoint()).thenReturn(discoveredAuthorizationEndpoint);
+        when(authorizationServerMetadata.getTokenEndpoint()).thenReturn(discoveredTokenEndpoint);
+        when(authorizationServerMetadata.getCodeChallengeMethodsSupported()).thenReturn(List.of(discoveredCodeChallengeMethod));
+
+        when(authorizationServerMetadataService.getAuthorizationServerMetadata(
+                resourceId, resourceEndpoint, protectedResourceMetadata, false))
+                .thenReturn(authorizationServerMetadata);
+
+        // When
+        ClientRegistration result = resourceRegistrationStrategy.register(resourceId, resourceEndpoint, resourceAuthSettings);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(clientId, result.getClientId());
+        assertEquals(clientSecret, result.getClientSecret());
+        assertEquals(redirectUri, result.getRedirectUri());
+        // Static endpoints must be preserved (not overwritten by discovery)
+        assertEquals(staticAuthorizationEndpoint, result.getAuthorizationEndpoint());
+        assertEquals(staticTokenEndpoint, result.getTokenEndpoint());
+        // codeChallengeMethod should be filled from discovery
+        assertEquals(discoveredCodeChallengeMethod, result.getCodeChallengeMethod());
+        assertEquals(scopesSupported, result.getScopesSupported());
+        // Verify discovery was called (because codeChallengeMethod was null)
+        verify(protectedResourceMetadataService).getProtectedResourceMetadata(resourceId, resourceEndpoint);
         verify(authorizationServerMetadataService).getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, false);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1090,6 +1090,74 @@ public class ToolSetApiTest extends ResourceBaseTest {
         verify(response, 400, "Wrong authentication_type. Expected type: API_KEY, provided: OAUTH");
     }
 
+    @Test
+    void testCreateToolSetWithOauthStaticEndpointsPreservedAfterDiscovery() throws JsonProcessingException {
+        String requestBody = """
+                {
+                    "endpoint": "http://localhost:9876/mcp",
+                    "transport": "HTTP",
+                    "allowedTools": [],
+                    "auth_settings": {
+                        "authentication_type": "OAUTH",
+                        "client_id": "my-client-id",
+                        "client_secret": "my-client-secret",
+                        "redirect_uri": "http://localhost:3000/auth/signin",
+                        "authorization_endpoint": "https://static.auth.example.com/authorize",
+                        "token_endpoint": "https://static.auth.example.com/token"
+                    }
+                }
+                """;
+
+        String protectedResourceMetadata = """
+                {
+                    "resource": "http://localhost:9876/mcp",
+                    "authorization_servers": ["http://localhost:9876"],
+                    "scopes_supported": ["read", "write"]
+                }
+                """;
+
+        String authServerMetadata = """
+                {
+                    "issuer": "http://localhost:9876",
+                    "authorization_endpoint": "https://discovered.auth.example.com/authorize",
+                    "token_endpoint": "https://discovered.auth.example.com/token",
+                    "code_challenge_methods_supported": ["S256"]
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            // MCP endpoint returns 401 without WWW-Authenticate to trigger well-known discovery
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+
+            // Protected resource metadata discovery
+            server.map(HttpMethod.GET, "/.well-known/oauth-protected-resource/mcp",
+                    200, protectedResourceMetadata, "Content-Type", "application/json");
+
+            // Authorization server metadata discovery (on the auth server from authorization_servers)
+            server.map(HttpMethod.GET, "/.well-known/oauth-authorization-server",
+                    200, authServerMetadata, "Content-Type", "application/json");
+
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-oauth-static@",
+                    null, requestBody, "authorization", "admin");
+
+            assertEquals(200, response.status());
+
+            // GET the created toolset to verify auth_settings
+            response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-oauth-static@",
+                    null, null, "authorization", "admin");
+
+            assertEquals(200, response.status());
+            JsonNode toolset = ProxyUtil.MAPPER.readTree(response.body());
+            JsonNode authSettings = toolset.get("auth_settings");
+
+            // Static endpoints must be preserved (not overwritten by discovered ones)
+            assertEquals("https://static.auth.example.com/authorize", authSettings.get("authorization_endpoint").asText());
+            assertEquals("https://static.auth.example.com/token", authSettings.get("token_endpoint").asText());
+            // codeChallengeMethod should be filled from discovery
+            assertEquals("S256", authSettings.get("code_challenge_method").asText());
+        }
+    }
+
     private String replaceValueInJsonArray(
             String originalJson,
             String arrayFieldName,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1413

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
