### PR TITLE
fix: Configuration endpoint for Quick App 2.0 responses with 500 error if Quick App 2.0 was created in DIAL Admin #1461

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
@@ -277,7 +277,7 @@ public class ApplicationSchemaService {
             String schema = getCustomApplicationSchemaOrThrow(application, false);
             JsonNode schemaNode = ProxyUtil.MAPPER.readTree(schema);
 
-            String completionEndpoint = getEndpoint(schemaNode, APPLICATION_TYPE_COMPLETION_ENDPOINT, true);
+            String completionEndpoint = getEndpoint(schemaNode, APPLICATION_TYPE_COMPLETION_ENDPOINT, false);
             String responsesEndpoint = getEndpoint(schemaNode, APPLICATION_TYPE_RESPONSES_ENDPOINT, false);
             String configurationEndpoint = getEndpoint(schemaNode, APPLICATION_TYPE_CONFIGURATION_ENDPOINT, false);
             String rateEndpoint = getEndpoint(schemaNode, APPLICATION_TYPE_RATE_ENDPOINT, false);

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -407,7 +407,7 @@ public class ApplicationSchemaServiceTest {
     }
 
     @Test
-    public void modifyEndpointForCustomApplication_throws_whenEndpointsNotFound() {
+    public void modifyEndpointForCustomApplication_ChatEndpointIsOptional() {
         when(configStore.get()).thenReturn(config);
         String schemaWithoutEndpoint = """
                 {
@@ -428,8 +428,7 @@ public class ApplicationSchemaServiceTest {
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(config.getCustomApplicationSchema(any())).thenReturn(schemaWithoutEndpoint);
 
-        Assertions.assertThrows(ApplicationTypeSchemaProcessingException.class, () ->
-                service.modifyEndpointsForCustomApplication(application));
+        Assertions.assertNull(service.modifyEndpointsForCustomApplication(application).getEndpoint());
     }
 
     @Test


### PR DESCRIPTION
fixes #1461 