### PR TITLE
fix: [Toolsets] Return null instead of throwing ResourceNotFoundException when no credentials stored

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -178,18 +178,14 @@ public class ResourceCredentialsService {
             return null;
         }
 
-        try {
-            ResourceCredentials userCredentials = getAndRefreshCredentials(
-                    credentialsLocator.getCredentialsDescriptors().get(CredentialsLevel.USER),
-                    authSettings
-            );
-            if (userCredentials != null
-                    && userCredentials.getCredentialsLevel().equals(CredentialsLevel.USER)
-                    && userCredentials.getUserId().equals(userSub)) {
-                return userCredentials;
-            }
-        } catch (ResourceNotFoundException e) {
-            log.debug(e.getMessage(), e); // if User credentials are not found - let's look for Global one
+        ResourceCredentials userCredentials = getAndRefreshCredentials(
+                credentialsLocator.getCredentialsDescriptors().get(CredentialsLevel.USER),
+                authSettings
+        );
+        if (userCredentials != null
+                && userCredentials.getCredentialsLevel().equals(CredentialsLevel.USER)
+                && userCredentials.getUserId().equals(userSub)) {
+            return userCredentials;
         }
 
         ResourceCredentials globalCredentials = getAndRefreshCredentials(
@@ -201,7 +197,7 @@ public class ResourceCredentialsService {
             return globalCredentials;
         }
 
-        throw new ResourceNotFoundException("Credentials (Global or Personal) for Resource %s not found".formatted(credentialsLocator.getResourceId()));
+        return null;
     }
 
     private ResourceCredentials getAndRefreshCredentials(CredentialsDescriptor credentialsDescriptor,
@@ -213,7 +209,8 @@ public class ResourceCredentialsService {
         MutableObject<ResourceCredentials> reference = new MutableObject<>();
         resourceService.computeResourceBytes(credentialsDescriptor.toResourceDescriptor(), existingCredentialsBytesEncrypted -> {
             if (existingCredentialsBytesEncrypted == null) {
-                throw new ResourceNotFoundException("Credentials for %s not found".formatted(credentialsDescriptor.getResourceId()));
+                log.debug("No credentials found for resourceId={}, bucket={}", resourceId, bucketName);
+                return null;
             }
 
             ResourceCredentials resourceCredentials = decrypt(credentialsDescriptor, existingCredentialsBytesEncrypted);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -171,6 +171,7 @@ public class ResourceCredentialsService {
         }
     }
 
+    @Nullable
     public ResourceCredentials getRefreshedResourceCredentials(CredentialsLocator credentialsLocator,
                                                                ResourceAuthSettings authSettings,
                                                                String userSub) {

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/AuthorizationHeaderProviderTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/AuthorizationHeaderProviderTest.java
@@ -6,7 +6,6 @@ import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.data.credentials.AuthorizationHeader;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
-import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,7 +20,6 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -116,12 +114,15 @@ class AuthorizationHeaderProviderTest {
         ResourceAuthSettings authSettings = Mockito.mock(ResourceAuthSettings.class);
 
         when(resourceCredentialsService.getRefreshedResourceCredentials(any(), any(), any()))
-                .thenThrow(new ResourceNotFoundException());
+                .thenReturn(null);
 
-        // When & Then
-        assertThrows(ResourceNotFoundException.class, () -> {
-            authorizationHeaderProvider.createAuthorizationHeader(credentialsLocator, authSettings, "userSub");
-        });
+        // When
+        AuthorizationHeader header = authorizationHeaderProvider.createAuthorizationHeader(
+                credentialsLocator, authSettings, "userSub"
+        );
+
+        // Then
+        assertNull(header);
     }
 
     @Test

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
@@ -467,18 +467,7 @@ class ResourceCredentialsServiceTest {
             return new ResourceItemMetadata();
         }).when(resourceService).computeResourceBytes(eq(userResourceDescriptor), any());
 
-        // Global credentials not found
-        ResourceDescriptor globalResourceDescriptor = Mockito.mock(ResourceDescriptor.class);
-        Mockito.when(globalCredentialsDescriptor.getResourceId()).thenReturn("testResourceId");
-        Mockito.when(globalCredentialsDescriptor.toResourceDescriptor()).thenReturn(globalResourceDescriptor);
-
-        Mockito.doAnswer(invocation -> {
-            Function<byte[], byte[]> callbackFunction = invocation.getArgument(1);
-            callbackFunction.apply(null);
-            return null;
-        }).when(resourceService).computeResourceBytes(eq(globalResourceDescriptor), any());
-
-        // When & Then - should throw because refresh failed
+        // When & Then - should throw because refresh failed; GLOBAL fallback is skipped
         assertThrows(ResourceNotFoundException.class, () -> {
             service.getRefreshedResourceCredentials(credentialsLocator, authSettings, "userSub");
         });

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
@@ -20,7 +20,6 @@ import com.epam.aidial.core.credentials.service.token.TokenRefreshStrategyFactor
 import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.credentials.util.TimeProvider;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
-import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
@@ -434,9 +433,8 @@ class ResourceCredentialsServiceTest {
         }).when(resourceService).computeResourceBytes(any(), any());
 
         // When & Then
-        Assertions.assertThrows(ResourceNotFoundException.class, () -> {
-            service.getRefreshedResourceCredentials(credentialsLocator, authSettings, "userSub");
-        });
+        ResourceCredentials result = service.getRefreshedResourceCredentials(credentialsLocator, authSettings, "userSub");
+        Assertions.assertNull(result);
     }
 
     private CredentialsDescriptor createCredentialsDescriptor() {


### PR DESCRIPTION
getRefreshedResourceCredentials() was throwing ResourceNotFoundException when no credentials existed, causing false ERROR logs in ToolSetProxyController. Now returns null which all callers already handle correctly.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1478 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
