### PR TITLE
fix: [Toolsets] USER-level sign-in/sign-out fails for API key

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/ProxyContext.java
+++ b/server/src/main/java/com/epam/aidial/core/server/ProxyContext.java
@@ -202,6 +202,16 @@ public class ProxyContext {
         return key == null ? null : key.getProject();
     }
 
+    /**
+     * Returns an identifier of the request initiator: the JWT user id when present,
+     * otherwise the API key project name. Mirrors the fallback used by
+     * {@link com.epam.aidial.core.server.util.BucketBuilder#buildInitiatorBucket(ProxyContext)}
+     * so features that track per-principal state work for both auth types.
+     */
+    public String getInitiatorId() {
+        return userId != null ? userId : getProject();
+    }
+
     public boolean isSecuredApiKey() {
         return key != null && key.isSecured();
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
@@ -84,7 +84,7 @@ public class ResourceCredentialsController {
                             CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceUrl, context, ResourceTypes.TOOL_SET);
                             CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(resourceSignInRequest.getCredentialsLevel());
                             resourceCredentialsService.addResourceCredentials(credentialsDescriptor, resourceAuthSettings,
-                                    resourceSignInRequest, context.getUserId());
+                                    resourceSignInRequest, context.getInitiatorId());
                             return true;
                         }
                         throw new ResourceNotFoundException("Resource is not found: " + resourceId);
@@ -124,7 +124,7 @@ public class ResourceCredentialsController {
                     return resourceCredentialsService.deleteResourceCredentials(
                             credentialsLocator,
                             resourceSignOutRequest,
-                            context.getUserId());
+                            context.getInitiatorId());
                 }))
                 .onSuccess(removed -> context.respond(HttpStatus.OK, removed))
                 .onFailure(error ->

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetProxyController.java
@@ -270,7 +270,7 @@ public class ToolSetProxyController implements Controller {
         try {
             if (deployment instanceof ToolSet toolSet) {
                 ResourceCredentials resourceCredentials = resourceCredentialsService.getRefreshedResourceCredentials(
-                        credentialsLocator, toolSet.getAuthSettings(), context.getUserId()
+                        credentialsLocator, toolSet.getAuthSettings(), context.getInitiatorId()
                 );
 
                 if (resourceCredentials != null) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -345,7 +345,7 @@ public class ToolSetToolsController implements Controller {
     private void injectToolsetCredentials(HttpClientRequest proxyRequest, Deployment deployment) {
         if (deployment instanceof ToolSet toolSet) {
             ResourceCredentials resourceCredentials = resourceCredentialsService.getRefreshedResourceCredentials(
-                    credentialsLocator, toolSet.getAuthSettings(), context.getUserId()
+                    credentialsLocator, toolSet.getAuthSettings(), context.getInitiatorId()
             );
             if (resourceCredentials != null) {
                 addAuthorizationHeader(proxyRequest, resourceCredentials);

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -173,7 +173,7 @@ public class ToolSetService {
 
     public void setResourceAuthStatuses(ProxyContext context, ToolSet toolSet, String encodedToolSetId) {
         CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedToolSetId, context, ResourceTypes.TOOL_SET);
-        resourceAuthSettingsService.setResourceAuthStatuses(credentialsLocator, toolSet.getAuthSettings(), context.getUserId());
+        resourceAuthSettingsService.setResourceAuthStatuses(credentialsLocator, toolSet.getAuthSettings(), context.getInitiatorId());
     }
 
     private boolean copyCredentials(ProxyContext context, ResourceDescriptor source, ResourceDescriptor destination,

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1252,6 +1252,52 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testUserLevelSignInAndSignOutWithApiKeyAuthenticatedCaller() {
+        // Regression for #1470: USER-level sign-in/sign-out must work when the caller is authenticated
+        // by an API key (not JWT). Previously context.getUserId() was null for API-key callers,
+        // which stored null into ResourceCredentials.userId and later NPE'd on refresh/sign-out/status.
+        String bucket = "3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST"; // proxyKey1's bucket (project EPM-RTC-GPT)
+
+        // create toolset owned by the API key
+        Response response = send(HttpMethod.PUT, "/v1/toolsets/" + bucket + "/toolset%201@", null,
+                TOOLSET_CREATE_REQEUST_BODY, "api-key", "proxyKey1");
+        verifyNotExact(response, 200, "\"url\":\"toolsets/" + bucket + "/toolset%201@\"");
+
+        // USER-level sign-in authenticated by the API key (pre-fix: stored userId=null)
+        response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                {
+                    "url": "toolsets/%s/toolset 1@",
+                    "credentialsLevel": "USER",
+                    "authenticationType": "API_KEY",
+                    "api_key": "Bearer api_key"
+                }
+                """.formatted(bucket), "api-key", "proxyKey1");
+        verify(response, 200, "true");
+
+        // GET the toolset via the same API key - user_level_auth_status should be SIGNED_IN.
+        // Pre-fix: ResourceAuthSettingsService.setUserAuthStatus NPE'd on userId.equals(...) when userId was null.
+        response = send(HttpMethod.GET, "/v1/toolsets/" + bucket + "/toolset%201@", null, null,
+                "api-key", "proxyKey1");
+        verifyNotExact(response, 200, "\"user_level_auth_status\":\"SIGNED_IN\"");
+
+        // USER-level sign-out authenticated by the same API key.
+        // Pre-fix: validateDeleteOperation NPE'd on Objects.requireNonNull(existingCredentialsUserId).
+        response = send(HttpMethod.POST, "/v1/ops/toolset/signout", null, """
+                {
+                    "url": "toolsets/%s/toolset 1@",
+                    "credentialsLevel": "USER",
+                    "authenticationType": "API_KEY"
+                }
+                """.formatted(bucket), "api-key", "proxyKey1");
+        verify(response, 200, "true");
+
+        // Verify the toolset reports SIGNED_OUT after sign-out.
+        response = send(HttpMethod.GET, "/v1/toolsets/" + bucket + "/toolset%201@", null, null,
+                "api-key", "proxyKey1");
+        verifyNotExact(response, 200, "\"user_level_auth_status\":\"SIGNED_OUT\"");
+    }
+
+    @Test
     void testSignOutFromApiCreatedToolsetWithIncorrectAuthType() {
         // create ToolSet with admin JWT
         Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset%201@", null,  TOOLSET_CREATE_REQEUST_BODY,

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -120,6 +120,7 @@ class ResourceCredentialsControllerTest {
         when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
         when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Users/userSub/");
         when(context.getUserId()).thenReturn("userSub");
+        when(context.getInitiatorId()).thenReturn("userSub");
         when(context.getConfig()).thenReturn(mock(Config.class));
         when(context.getProxy()).thenReturn(proxy);
 
@@ -130,7 +131,7 @@ class ResourceCredentialsControllerTest {
         controller.signIn();
 
         // Then
-        verify(resourceCredentialsService).addResourceCredentials(any(), any(), any(), any());
+        verify(resourceCredentialsService).addResourceCredentials(any(), any(), any(), eq("userSub"));
         verify(context).respond(expectedResponseStatus, true);
     }
 
@@ -230,6 +231,7 @@ class ResourceCredentialsControllerTest {
         when(context.getProxy()).thenReturn(proxy);
         when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Users/userSub/");
         when(context.getUserId()).thenReturn("userSub");
+        when(context.getInitiatorId()).thenReturn("userSub");
         when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
         when(context.getConfig()).thenReturn(mock(Config.class));
 
@@ -242,6 +244,7 @@ class ResourceCredentialsControllerTest {
         controller.signOut();
 
         // Then
+        verify(resourceCredentialsService).deleteResourceCredentials(any(), any(), eq("userSub"));
         verify(context).respond(expectedResponseStatus, expectedResponse);
     }
 
@@ -287,6 +290,58 @@ class ResourceCredentialsControllerTest {
     }
 
     @Test
+    void testSignIn_UserLevelWithApiKeyAuthentication() {
+        // Given - request is authenticated by API Key (no JWT), so userId is null and project name is the initiator.
+        String resourceName = "toolset-1";
+        mockRequest(resourceName, CredentialsLevel.USER, AuthenticationType.OAUTH);
+
+        when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
+        when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Keys/api-key-project/");
+        when(context.getUserId()).thenReturn(null);
+        when(context.getProject()).thenReturn("api-key-project");
+        when(context.getInitiatorId()).thenReturn("api-key-project");
+        when(context.getConfig()).thenReturn(mock(Config.class));
+        when(context.getProxy()).thenReturn(proxy);
+
+        mockToolset();
+        setPermissions(resourceName, "Keys/api-key-project/", ResourceAccessType.ALL);
+
+        // When
+        controller.signIn();
+
+        // Then - project name is persisted as the owner so subsequent lookups do not NPE.
+        verify(resourceCredentialsService).addResourceCredentials(any(), any(), any(), eq("api-key-project"));
+        verify(context).respond(HttpStatus.OK, true);
+    }
+
+    @Test
+    void testSignOut_UserLevelWithApiKeyAuthentication() {
+        // Given - API Key authenticated sign-out must pass the project name as the owner to avoid NPE.
+        String resourceName = "toolset-1";
+        mockRequest(resourceName, CredentialsLevel.USER, AuthenticationType.OAUTH);
+
+        when(context.getProxy()).thenReturn(proxy);
+        when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Keys/api-key-project/");
+        when(context.getUserId()).thenReturn(null);
+        when(context.getProject()).thenReturn("api-key-project");
+        when(context.getInitiatorId()).thenReturn("api-key-project");
+        when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
+        when(context.getConfig()).thenReturn(mock(Config.class));
+
+        mockToolset();
+        setPermissions(resourceName, "Keys/api-key-project/", ResourceAccessType.ALL);
+
+        when(resourceCredentialsService.deleteResourceCredentials(any(), any(), any())).thenReturn(true);
+
+        // When
+        controller.signOut();
+
+        // Then
+        verify(resourceCredentialsService).deleteResourceCredentials(any(), any(), eq("api-key-project"));
+        verify(context).respond(HttpStatus.OK, true);
+    }
+
+    @Test
     void testSignIn_WrongAuthenticationType() {
         // Given
         mockRequest("toolset 1", CredentialsLevel.USER, AuthenticationType.API_KEY);
@@ -315,12 +370,20 @@ class ResourceCredentialsControllerTest {
     }
 
     private ResourceDescriptor createResourceDescriptor(String resourceName) {
+        return createResourceDescriptor(resourceName, "Users/userSub/");
+    }
+
+    private ResourceDescriptor createResourceDescriptor(String resourceName, String bucketLocation) {
         return new ResourceDescriptor(ResourceTypes.TOOL_SET, resourceName, List.of(),
-                "encrypted-user-bucket", "Users/userSub/", false);
+                "encrypted-user-bucket", bucketLocation, false);
     }
 
     private void setPermissions(String resourceName, Set<ResourceAccessType> userPermissions) {
-        ResourceDescriptor resourceDescriptor = createResourceDescriptor(resourceName);
+        setPermissions(resourceName, "Users/userSub/", userPermissions);
+    }
+
+    private void setPermissions(String resourceName, String bucketLocation, Set<ResourceAccessType> userPermissions) {
+        ResourceDescriptor resourceDescriptor = createResourceDescriptor(resourceName, bucketLocation);
         Map<ResourceDescriptor, Set<ResourceAccessType>> permissions = Map.of(resourceDescriptor, userPermissions);
         when(accessService.lookupPermissions(any(), eq(context))).thenReturn(permissions);
     }


### PR DESCRIPTION
Route toolset credential flows (sign-in, sign-out, refresh, auth-status) through a new ProxyContext#getInitiatorId() that falls back to the API key project name when JWT userId is absent. Previously API-key callers stored null as the owner on USER credentials, which NPE'd on later refresh, status, and sign-out operations.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1470 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
