### PR TITLE
fix: Remove OAuth toolset credentials on 400/401 from token refresh flow

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -83,7 +83,7 @@ public class ResourceAuthorizationClient {
             String body = response.body();
 
             if (status != 200 && status != 201) {
-                log.debug("Error executing request {}: status {}, response {}, headers: {}",
+                log.info("Error executing request {}: status {}, response {}, headers: {}",
                         request.uri(), response.statusCode(), response.body(), response.headers());
                 if (status == 401) {
                     throw new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code",
@@ -134,7 +134,7 @@ public class ResourceAuthorizationClient {
             String description = node.containsKey("error_description")
                     ? String.valueOf(node.get("error_description"))
                     : "no description";
-            log.debug("OAuth error in 200 response from {}: error={}, description={}", uri, error, description);
+            log.info("OAuth error in 200 response from {}: error={}, description={}", uri, error, description);
             throw new HttpException(HttpStatus.BAD_REQUEST, "Authorization server returned error: %s (%s)".formatted(error, description),
                     Map.of(), body);
         }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -83,8 +83,8 @@ public class ResourceAuthorizationClient {
             String body = response.body();
 
             if (status != 200 && status != 201) {
-                log.info("Error executing request {}: status {}, response {}, headers: {}",
-                        request.uri(), response.statusCode(), response.body(), response.headers());
+                log.info("Error executing request {}: status {}, response {}",
+                        request.uri(), response.statusCode(), response.body());
                 if (status == 401) {
                     throw new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code",
                             httpHeadersHandler.convertHttpHeadersToMap(response.headers()), body);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -83,7 +83,7 @@ public class ResourceAuthorizationClient {
             String body = response.body();
 
             if (status != 200 && status != 201) {
-                log.info("Error executing request {}: status {}, response {}",
+                log.warn("Error executing request {}: status {}, response {}",
                         request.uri(), response.statusCode(), response.body());
                 if (status == 401) {
                     throw new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code",

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -19,9 +19,9 @@ import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.credentials.util.TimeProvider;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
@@ -48,7 +47,7 @@ public class ResourceCredentialsService {
                                        ResourceAuthSettings resourceAuthSettings,
                                        ResourceSignInRequest resourceSignInRequest,
                                        String userId) {
-        log.debug("Adding resource credentials for resourceId={}, bucket={}, credentialsLevel={}",
+        log.info("Adding resource credentials for resourceId={}, bucket={}, credentialsLevel={}",
                 credentialsDescriptor.getResourceId(), credentialsDescriptor.getBucketName(), resourceSignInRequest.getCredentialsLevel());
         ResourceCredentialsFactory factory = resourceCredentialsFactoryProvider.getFactory(resourceSignInRequest.getAuthenticationType());
         ResourceCredentials resourceCredentials = factory.createCredentials(resourceSignInRequest.getUrl(), resourceAuthSettings, resourceSignInRequest);
@@ -59,13 +58,13 @@ public class ResourceCredentialsService {
 
         byte[] encryptedBody = encrypt(credentialsDescriptor, resourceCredentials);
         resourceService.putResourceBytes(credentialsDescriptor.toResourceDescriptor(), encryptedBody, EtagHeader.ANY);
-        log.debug("Resource credentials for resourceId={}, bucket={} stored successfully",
+        log.info("Resource credentials for resourceId={}, bucket={} stored successfully",
                 credentialsDescriptor.getResourceId(), credentialsDescriptor.getBucketName());
     }
 
     public boolean copyResourceCredentials(CredentialsDescriptor from, CredentialsDescriptor to,
                                            CredentialsLevel credentialsLevel, boolean overwrite) {
-        log.debug("Copying resource credentials for resourceId={} from bucket={} to bucket={}",
+        log.info("Copying resource credentials for resourceId={} from bucket={} to bucket={}",
                 from.getResourceId(), from.getBucketName(), to.getBucketName());
 
         ResourceCredentials resourceCredentials = getResourceCredentials(from);
@@ -85,7 +84,7 @@ public class ResourceCredentialsService {
         byte[] encryptedBody = encrypt(to, resourceCredentials);
         EtagHeader etag = overwrite ? EtagHeader.ANY : EtagHeader.NEW_ONLY;
         resourceService.putResourceBytes(to.toResourceDescriptor(), encryptedBody, etag);
-        log.debug("Resource credentials for resourceId={} copied successfully from bucket={} to bucket={}",
+        log.info("Resource credentials for resourceId={} copied successfully from bucket={} to bucket={}",
                 from.getResourceId(), from.getBucketName(), to.getBucketName());
         return true;
     }
@@ -98,7 +97,7 @@ public class ResourceCredentialsService {
                     .filter(Objects::nonNull)
                     .toList();
         } catch (EncryptionException encryptionException) {
-            log.debug("Encryption error. No valid Resource Credentials found.");
+            log.warn("Encryption error. No valid Resource Credentials found.");
             return new ArrayList<>();
         }
     }
@@ -122,7 +121,7 @@ public class ResourceCredentialsService {
     public boolean deleteResourceCredentials(CredentialsLocator credentialsLocator,
                                              ResourceSignOutRequest resourceSignOutRequest,
                                              String userSub) {
-        log.debug("Deleting resource credentials for resourceId={}.", credentialsLocator.getResourceId());
+        log.info("Deleting resource credentials for resourceId={}.", credentialsLocator.getResourceId());
         CredentialsLevel signOutRequestCredentialsLevel = resourceSignOutRequest.getCredentialsLevel();
         CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(signOutRequestCredentialsLevel);
         MutableObject<Boolean> result = new MutableObject<>(false);
@@ -138,13 +137,13 @@ public class ResourceCredentialsService {
             return null;
         });
 
-        log.debug("Deleting resource credentials for resourceId={}, bucket={} finished. Result: {}",
+        log.info("Deleting resource credentials for resourceId={}, bucket={} finished. Result: {}",
                 credentialsDescriptor.getResourceId(), credentialsDescriptor.getBucketName(), result.get());
         return result.get();
     }
 
     public void deleteResourceCredentials(CredentialsLocator credentialsLocator) {
-        log.debug("Deleting all resource credentials for resourceId={}.", credentialsLocator.getResourceId());
+        log.info("Deleting all resource credentials for resourceId={}.", credentialsLocator.getResourceId());
 
         credentialsLocator.getUniqueCredentialsDescriptors().forEach(credentialsDescriptor -> {
             resourceService.deleteResource(credentialsDescriptor.toResourceDescriptor(), EtagHeader.ANY);
@@ -152,7 +151,7 @@ public class ResourceCredentialsService {
                     credentialsLocator.getResourceId(), credentialsDescriptor.getBucketName());
         });
 
-        log.debug("Deleting all resource credentials for resourceId={} finished", credentialsLocator.getResourceId());
+        log.info("Deleting all resource credentials for resourceId={} finished", credentialsLocator.getResourceId());
     }
 
     private void validateDeleteOperation(ResourceCredentials existingCredentials,
@@ -226,7 +225,7 @@ public class ResourceCredentialsService {
                 try {
                     updateExpiredResourceCredentials(resourceCredentials, resourceId, authSettings);
                 } catch (HttpException e) {
-                    if (isInvalidGrant(e)) {
+                    if (isPermanentRefreshFailure(e)) {
                         log.warn("Failed to refresh token for resourceId={}, bucket={}. Removing credentials", resourceId, bucketName, e);
                         refreshFailure.setValue(e);
                         return null;
@@ -250,19 +249,18 @@ public class ResourceCredentialsService {
         return reference.get();
     }
 
-    private static boolean isInvalidGrant(HttpException e) {
-        String body = e.getBody();
-        if (body == null || body.isBlank()) {
-            return false;
-        }
-        Map<String, Object> parsed = JsonMapperUtil.convertToObject(body, new TypeReference<>() {});
-        return parsed != null && "invalid_grant".equals(parsed.get("error"));
+    // 4xx on a token endpoint indicates a client-side problem — refresh token revoked/expired,
+    // client auth rejected, or malformed request. Safe to drop stored credentials so the user
+    // is prompted to sign in again. Transient issues (5xx, network) are rethrown and leave creds in place.
+    private static boolean isPermanentRefreshFailure(HttpException e) {
+        HttpStatus status = e.getStatus();
+        return status == HttpStatus.BAD_REQUEST || status == HttpStatus.UNAUTHORIZED;
     }
 
     private void updateExpiredResourceCredentials(ResourceCredentials resourceCredentials,
                                                   String resourceId,
                                                   ResourceAuthSettings authSettings) {
-        log.debug("Start updating expired token for Resource: {}", resourceId);
+        log.info("Start updating expired token for Resource: {}", resourceId);
         TokenResponse newAccessTokenResponse = tokenService.getToken(resourceId,
                 authSettings, resourceCredentials.getRefreshToken());
 

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1890,6 +1890,202 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testOauthTokenRefresh_Unauthorized_RemovesCredentials() {
+        // Token endpoint: returns expired token on sign-in
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "revoked-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+
+        // Notion-style 401 from /token with non-spec invalid_token error body
+        String invalidTokenResponse = """
+                {
+                    "error": "invalid_token",
+                    "error_description": "Missing or invalid access token"
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            // Token endpoint
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    // Refresh fails with 401 (Notion behavior on expired refresh token)
+                    return new MockResponse()
+                            .setResponseCode(401)
+                            .setBody(invalidTokenResponse)
+                            .setHeader("Content-Type", "application/json");
+                }
+                // sign-in succeeds
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            // MCP endpoint (will receive request without auth after credential failure)
+            server.map(HttpMethod.POST, "/", request ->
+                    new MockResponse()
+                            .setBody(MCP_TOOL_CALL_RESPONSE)
+                            .setHeader("Content-Type", "application/json"));
+
+            // Sign in with OAuth
+            Response response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "oauth-toolset",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            // Verify auth status is SIGNED_IN after sign-in
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""),
+                    "Expected SIGNED_IN after sign-in but got: " + response.body());
+
+            // MCP call triggers refresh → 401 → credentials removed
+            ApiKeyData apiKey = createAdminAppKey();
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+
+            // Verify credentials were removed (auth status back to SIGNED_OUT)
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""),
+                    "Expected SIGNED_OUT after 401 refresh failure but got: " + response.body());
+        }
+    }
+
+    @Test
+    void testOauthTokenRefresh_BadRequest_RemovesCredentials() {
+        // Token endpoint: returns expired token on sign-in
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "revoked-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+
+        // Generic 400 without invalid_grant (e.g., provider-specific error code)
+        String genericBadRequestResponse = """
+                {
+                    "error": "unauthorized_client",
+                    "error_description": "Client is not authorized to use refresh token grant"
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    return new MockResponse()
+                            .setResponseCode(400)
+                            .setBody(genericBadRequestResponse)
+                            .setHeader("Content-Type", "application/json");
+                }
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            server.map(HttpMethod.POST, "/", request ->
+                    new MockResponse()
+                            .setBody(MCP_TOOL_CALL_RESPONSE)
+                            .setHeader("Content-Type", "application/json"));
+
+            Response response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "oauth-toolset",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            ApiKeyData apiKey = createAdminAppKey();
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""),
+                    "Expected SIGNED_OUT after 400 refresh failure but got: " + response.body());
+        }
+    }
+
+    @Test
+    void testOauthTokenRefresh_TwoHundredWithErrorBody_RemovesCredentials() {
+        // Token endpoint: returns expired token on sign-in
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "revoked-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+
+        // Non-spec: some OAuth servers return HTTP 200 with an error payload instead of 4xx
+        String twoHundredErrorResponse = """
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Token has been expired or revoked."
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    return new MockResponse()
+                            .setResponseCode(200)
+                            .setBody(twoHundredErrorResponse)
+                            .setHeader("Content-Type", "application/json");
+                }
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            server.map(HttpMethod.POST, "/", request ->
+                    new MockResponse()
+                            .setBody(MCP_TOOL_CALL_RESPONSE)
+                            .setHeader("Content-Type", "application/json"));
+
+            Response response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "oauth-toolset",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            ApiKeyData apiKey = createAdminAppKey();
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""),
+                    "Expected SIGNED_OUT after 200-with-error-body refresh but got: " + response.body());
+        }
+    }
+
+    @Test
     void testOauthTokenRefresh_ServerError_KeepsCredentials() {
         // Token endpoint: returns expired token on sign-in
         String signInTokenResponse = """


### PR DESCRIPTION
The refresh flow previously only removed stored credentials when the authorization server returned a spec-compliant `{"error":"invalid_grant"}` body. Providers that respond with a different OAuth error code (e.g., Notion MCP returning 401 + `invalid_token`) left credentials on disk, so the UI kept showing SIGNED_IN while every request failed 401 in a loop.

Now any HTTP 400 or 401 from the token endpoint removes the stored credentials so the user is prompted to sign in again. Transient failures (5xx, network errors) still rethrow and keep credentials intact.

Also elevates lifecycle logs (sign-in, sign-out, delete, refresh start/end) from DEBUG to INFO so production operators can see toolset-auth activity without enabling DEBUG.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1385 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
