### PR TITLE
fix: [Toolsets] Regenerate PKCE challenge/verifier when codeChallengMethod changes on toolset update

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -74,9 +74,24 @@ public class ResourceAuthSettingsService {
                 resourceAuthSettings.setClientSecret(existingResourceAuthSettings.getClientSecret());
             }
 
-            // do not re-write auto-generated codeChallenge/codeVerifier fields
+            resolveCodeChallengeSettings(resourceAuthSettings, existingResourceAuthSettings);
+        }
+    }
+
+    /**
+     * Preserves existing auto-generated codeChallenge/codeVerifier when codeChallengeMethod is unchanged (or omitted),
+     * otherwise regenerates the pair under the new method.
+     */
+    private void resolveCodeChallengeSettings(ResourceAuthSettings resourceAuthSettings,
+                                              ResourceAuthSettings existingResourceAuthSettings) {
+        String newCodeChallengeMethod = resourceAuthSettings.getCodeChallengeMethod();
+        String existingCodeChallengeMethod = existingResourceAuthSettings.getCodeChallengeMethod();
+        if (newCodeChallengeMethod == null || newCodeChallengeMethod.equals(existingCodeChallengeMethod)) {
+            resourceAuthSettings.setCodeChallengeMethod(existingCodeChallengeMethod);
             resourceAuthSettings.setCodeChallenge(existingResourceAuthSettings.getCodeChallenge());
             resourceAuthSettings.setCodeVerifier(existingResourceAuthSettings.getCodeVerifier());
+        } else {
+            setCodeChallengeProperties(resourceAuthSettings, newCodeChallengeMethod);
         }
     }
 

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
@@ -15,6 +15,9 @@ import com.epam.aidial.core.credentials.service.token.TokenRefreshStrategyFactor
 import com.epam.aidial.core.credentials.validation.ApiKeyAuthSettingsValidator;
 import com.epam.aidial.core.credentials.validation.AuthSettingsValidatorFactory;
 import com.epam.aidial.core.credentials.validation.OauthAuthSettingsValidator;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallenge;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
+import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -244,6 +247,84 @@ class ResourceAuthSettingsServiceTest {
     }
 
     @Test
+    void testProcessResourceAuthSettings_OauthUpdate_CodeChallengeMethodUnchanged_PreservesPkce() {
+        // Given
+        ToolSet updatedToolSet = createOauthToolSetWithPkce("clientId", "clientSecret",
+                CodeChallengeMethod.S256.getValue(), "origChallenge", "origVerifier");
+        ToolSet existingToolSet = createOauthToolSetWithPkce("clientId", "clientSecret",
+                CodeChallengeMethod.S256.getValue(), "origChallenge", "origVerifier");
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        // When
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        // Then
+        verify(oauthAuthSettingsValidator, times(1)).validate(
+                any(ResourceAuthSettings.class), eq(ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES));
+        verifyNoInteractions(resourceRegistrationService);
+
+        ResourceAuthSettings result = updatedToolSet.getAuthSettings();
+        assertEquals(CodeChallengeMethod.S256.getValue(), result.getCodeChallengeMethod());
+        assertEquals("origChallenge", result.getCodeChallenge());
+        assertEquals("origVerifier", result.getCodeVerifier());
+    }
+
+    @Test
+    void testProcessResourceAuthSettings_OauthUpdate_CodeChallengeMethodNull_PreservesPkce() {
+        // Given
+        ToolSet updatedToolSet = createOauthToolSetWithPkce("clientId", "clientSecret",
+                null, null, null);
+        ToolSet existingToolSet = createOauthToolSetWithPkce("clientId", "clientSecret",
+                CodeChallengeMethod.S256.getValue(), "origChallenge", "origVerifier");
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        // When
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        // Then
+        verify(oauthAuthSettingsValidator, times(1)).validate(
+                any(ResourceAuthSettings.class), eq(ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES));
+        verifyNoInteractions(resourceRegistrationService);
+
+        ResourceAuthSettings result = updatedToolSet.getAuthSettings();
+        assertEquals(CodeChallengeMethod.S256.getValue(), result.getCodeChallengeMethod());
+        assertEquals("origChallenge", result.getCodeChallenge());
+        assertEquals("origVerifier", result.getCodeVerifier());
+    }
+
+    @Test
+    void testProcessResourceAuthSettings_OauthUpdate_CodeChallengeMethodChanged_RegeneratesPkce() {
+        // Given
+        CodeVerifier originalVerifier = new CodeVerifier();
+        String originalChallenge = CodeChallenge.compute(CodeChallengeMethod.S256, originalVerifier).getValue();
+        ToolSet updatedToolSet = createOauthToolSetWithPkce("clientId", "clientSecret",
+                CodeChallengeMethod.PLAIN.getValue(), originalChallenge, originalVerifier.getValue());
+        ToolSet existingToolSet = createOauthToolSetWithPkce("clientId", "clientSecret",
+                CodeChallengeMethod.S256.getValue(), originalChallenge, originalVerifier.getValue());
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        // When
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        // Then
+        verify(oauthAuthSettingsValidator, times(1)).validate(
+                any(ResourceAuthSettings.class), eq(ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES));
+        verifyNoInteractions(resourceRegistrationService);
+
+        ResourceAuthSettings result = updatedToolSet.getAuthSettings();
+        assertEquals(CodeChallengeMethod.PLAIN.getValue(), result.getCodeChallengeMethod());
+        Assertions.assertNotNull(result.getCodeVerifier());
+        Assertions.assertNotNull(result.getCodeChallenge());
+        Assertions.assertNotEquals(originalVerifier.getValue(), result.getCodeVerifier());
+        Assertions.assertNotEquals(originalChallenge, result.getCodeChallenge());
+        // PLAIN method: challenge equals verifier
+        assertEquals(result.getCodeVerifier(), result.getCodeChallenge());
+    }
+
+    @Test
     void testProcessResourceAuthSettings_UpdatedApiKeyToolSet() {
         // Given
         ToolSet updatedToolSet = createApiKeyToolSet("newApiKeyHeader");
@@ -410,6 +491,21 @@ class ResourceAuthSettingsServiceTest {
         authSettings.setAuthenticationType(AuthenticationType.OAUTH);
         authSettings.setClientId(clientId);
         authSettings.setClientSecret(clientSecret);
+        authSettings.setCodeVerifier(codeVerifier);
+        return createToolSet(authSettings);
+    }
+
+    private static ToolSet createOauthToolSetWithPkce(String clientId,
+                                                      String clientSecret,
+                                                      String codeChallengeMethod,
+                                                      String codeChallenge,
+                                                      String codeVerifier) {
+        ResourceAuthSettings authSettings = new ResourceAuthSettings();
+        authSettings.setAuthenticationType(AuthenticationType.OAUTH);
+        authSettings.setClientId(clientId);
+        authSettings.setClientSecret(clientSecret);
+        authSettings.setCodeChallengeMethod(codeChallengeMethod);
+        authSettings.setCodeChallenge(codeChallenge);
         authSettings.setCodeVerifier(codeVerifier);
         return createToolSet(authSettings);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1392,6 +1393,99 @@ public class ToolSetApiTest extends ResourceBaseTest {
             assertEquals("https://static.auth.example.com/token", authSettings.get("token_endpoint").asText());
             // codeChallengeMethod should be filled from discovery
             assertEquals("S256", authSettings.get("code_challenge_method").asText());
+        }
+    }
+
+    @Test
+    void testUpdateOauthToolSetRegeneratesPkceWhenCodeChallengeMethodChanges() throws JsonProcessingException {
+        String createRequestBody = """
+                {
+                    "endpoint": "http://localhost:9876/mcp",
+                    "transport": "HTTP",
+                    "allowedTools": [],
+                    "auth_settings": {
+                        "authentication_type": "OAUTH",
+                        "client_id": "my-client-id",
+                        "client_secret": "my-client-secret",
+                        "redirect_uri": "http://localhost:3000/auth/signin",
+                        "authorization_endpoint": "https://auth.example.com/authorize",
+                        "token_endpoint": "https://auth.example.com/token"
+                    }
+                }
+                """;
+
+        String authServerMetadata = """
+                {
+                    "issuer": "http://localhost:9876",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token",
+                    "code_challenge_methods_supported": ["S256", "plain"]
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+            server.map(HttpMethod.GET, "/.well-known/oauth-authorization-server",
+                    200, authServerMetadata, "Content-Type", "application/json");
+
+            // Create with S256 (picked from discovery as preferred)
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-pkce@",
+                    null, createRequestBody, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-pkce@",
+                    null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            JsonNode authSettings = ProxyUtil.MAPPER.readTree(response.body()).get("auth_settings");
+            assertEquals("S256", authSettings.get("code_challenge_method").asText());
+            String initialChallenge = authSettings.get("code_challenge").asText();
+            assertNotNull(initialChallenge);
+            assertFalse(initialChallenge.isEmpty());
+
+            // Update the same toolset, switching code_challenge_method to plain
+            String updateRequestBody = """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "client_id": "my-client-id",
+                            "redirect_uri": "http://localhost:3000/auth/signin",
+                            "authorization_endpoint": "https://auth.example.com/authorize",
+                            "token_endpoint": "https://auth.example.com/token",
+                            "code_challenge_method": "plain"
+                        }
+                    }
+                    """;
+            response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-pkce@",
+                    null, updateRequestBody, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-pkce@",
+                    null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            authSettings = ProxyUtil.MAPPER.readTree(response.body()).get("auth_settings");
+            assertEquals("plain", authSettings.get("code_challenge_method").asText());
+            String updatedChallenge = authSettings.get("code_challenge").asText();
+            assertNotNull(updatedChallenge);
+            assertFalse(updatedChallenge.isEmpty());
+            assertNotEquals(initialChallenge, updatedChallenge);
+
+            // Re-update without changing method - challenge must be preserved
+            response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-pkce@",
+                    null, updateRequestBody, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-pkce@",
+                    null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            authSettings = ProxyUtil.MAPPER.readTree(response.body()).get("auth_settings");
+            assertEquals("plain", authSettings.get("code_challenge_method").asText());
+            assertEquals(updatedChallenge, authSettings.get("code_challenge").asText());
         }
     }
 


### PR DESCRIPTION
When an OAuth toolset was updated with a different codeChallengeMethod, the existing codeChallenge/codeVerifier were preserved, leaving them computed under the previous method and breaking the subsequent authorization flow. Detect the method change in ResourceAuthSettingsService and regenerate the PKCE pair under the new method; preserve the triple as-is when the method is unchanged (or omitted in the update payload).

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1403

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
