### PR TITLE
fix: Set OAuth toolset 'LOGGED IN' status based on refresh token validity instead of access token (#1476)

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -19,6 +19,7 @@ import java.nio.channels.UnresolvedAddressException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 @Slf4j
@@ -85,10 +86,11 @@ public class ResourceAuthorizationClient {
                 log.debug("Error executing request {}: status {}, response {}, headers: {}",
                         request.uri(), response.statusCode(), response.body(), response.headers());
                 if (status == 401) {
-                    throw new HttpException(status, "Authorization server returns 401 error code",
-                            httpHeadersHandler.convertHttpHeadersToMap(response.headers()));
+                    throw new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code",
+                            httpHeadersHandler.convertHttpHeadersToMap(response.headers()), body);
                 } else {
-                    throw new HttpException(status, "Authorization server returns error code");
+                    throw new HttpException(HttpStatus.fromStatusCode(status, HttpStatus.INTERNAL_SERVER_ERROR),
+                            "Authorization server returns error code", Map.of(), body);
                 }
             }
 
@@ -133,7 +135,8 @@ public class ResourceAuthorizationClient {
                     ? String.valueOf(node.get("error_description"))
                     : "no description";
             log.debug("OAuth error in 200 response from {}: error={}, description={}", uri, error, description);
-            throw new HttpException(HttpStatus.BAD_REQUEST, "Authorization server returned error: %s (%s)".formatted(error, description));
+            throw new HttpException(HttpStatus.BAD_REQUEST, "Authorization server returned error: %s (%s)".formatted(error, description),
+                    Map.of(), body);
         }
     }
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -18,8 +18,10 @@ import com.epam.aidial.core.credentials.service.token.TokenRefreshStrategyFactor
 import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.credentials.util.TimeProvider;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
+import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
+import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +30,7 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
@@ -211,6 +214,7 @@ public class ResourceCredentialsService {
         log.debug("Updating resource credentials for resourceId={}, bucket={}", resourceId, bucketName);
 
         MutableObject<ResourceCredentials> reference = new MutableObject<>();
+        MutableObject<Exception> refreshFailure = new MutableObject<>();
         resourceService.computeResourceBytes(credentialsDescriptor.toResourceDescriptor(), existingCredentialsBytesEncrypted -> {
             if (existingCredentialsBytesEncrypted == null) {
                 throw new ResourceNotFoundException("Credentials for %s not found".formatted(credentialsDescriptor.getResourceId()));
@@ -219,7 +223,16 @@ public class ResourceCredentialsService {
             ResourceCredentials resourceCredentials = decrypt(credentialsDescriptor, existingCredentialsBytesEncrypted);
 
             if (tokenRefreshStrategyFactory.getTokenValidatorStrategy(authSettings.getAuthenticationType()).requiresTokenRefresh(resourceCredentials)) {
-                updateExpiredResourceCredentials(resourceCredentials, resourceId, authSettings);
+                try {
+                    updateExpiredResourceCredentials(resourceCredentials, resourceId, authSettings);
+                } catch (HttpException e) {
+                    if (isInvalidGrant(e)) {
+                        log.warn("Failed to refresh token for resourceId={}, bucket={}. Removing credentials", resourceId, bucketName, e);
+                        refreshFailure.setValue(e);
+                        return null;
+                    }
+                    throw e;
+                }
                 reference.setValue(resourceCredentials);
                 log.debug("Encrypting and storing refreshed credentials for resourceId={}, bucket={}", resourceId, bucketName);
                 return encrypt(credentialsDescriptor, resourceCredentials);
@@ -229,7 +242,21 @@ public class ResourceCredentialsService {
             reference.setValue(resourceCredentials);
             return existingCredentialsBytesEncrypted;
         });
+
+        if (refreshFailure.get() != null) {
+            throw new ResourceNotFoundException("Failed to refresh token for resource %s".formatted(resourceId));
+        }
+
         return reference.get();
+    }
+
+    private static boolean isInvalidGrant(HttpException e) {
+        String body = e.getBody();
+        if (body == null || body.isBlank()) {
+            return false;
+        }
+        Map<String, Object> parsed = JsonMapperUtil.convertToObject(body, new TypeReference<>() {});
+        return parsed != null && "invalid_grant".equals(parsed.get("error"));
     }
 
     private void updateExpiredResourceCredentials(ResourceCredentials resourceCredentials,

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/token/OauthTokenRefreshStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/token/OauthTokenRefreshStrategy.java
@@ -14,7 +14,8 @@ public class OauthTokenRefreshStrategy implements TokenRefreshStrategy {
     @Override
     public boolean hasUnexpiredToken(ResourceCredentials credentials) {
         return credentials.getAccessToken() != null
-                && isTokenUnexpired(credentials.getUpdatedAt(), credentials.getExpiresInSeconds());
+                && (isTokenUnexpired(credentials.getUpdatedAt(), credentials.getExpiresInSeconds())
+                    || credentials.getRefreshToken() != null);
     }
 
     @Override

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
@@ -21,6 +21,8 @@ import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.credentials.util.TimeProvider;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
@@ -407,6 +409,82 @@ class ResourceCredentialsServiceTest {
         Assertions.assertEquals("newAccessToken", result.getAccessToken());
         Assertions.assertEquals("newRefreshToken", result.getRefreshToken());
         Mockito.verify(tokenService).getToken("testResourceId", authSettings, "refreshTokenValue");
+    }
+
+    @Test
+    void testGetAndRefreshCredentials_RefreshFails_InvalidatesRefreshToken() {
+        // Given
+        CredentialsLocator credentialsLocator = Mockito.mock(CredentialsLocator.class);
+        CredentialsDescriptor userCredentialsDescriptor = Mockito.mock(CredentialsDescriptor.class);
+        CredentialsDescriptor globalCredentialsDescriptor = Mockito.mock(CredentialsDescriptor.class);
+        Map<CredentialsLevel, CredentialsDescriptor> descriptors = new EnumMap<>(CredentialsLevel.class);
+        descriptors.put(CredentialsLevel.USER, userCredentialsDescriptor);
+        descriptors.put(CredentialsLevel.GLOBAL, globalCredentialsDescriptor);
+        when(credentialsLocator.getCredentialsDescriptors()).thenReturn(descriptors);
+        ResourceAuthSettings authSettings = Mockito.mock(ResourceAuthSettings.class);
+        when(authSettings.getAuthenticationType()).thenReturn(AuthenticationType.OAUTH);
+
+        Mockito.when(userCredentialsDescriptor.getResourceId()).thenReturn("testResourceId");
+        Mockito.when(userCredentialsDescriptor.getBucketName()).thenReturn("testBucket");
+
+        byte[] encryptedBytes = "mockEncryptedData".getBytes(StandardCharsets.UTF_8);
+        byte[] decryptedBytes = """
+                {
+                    "resourceId": "testResourceId",
+                    "credentialsLevel": "USER",
+                    "userSub": "userSub",
+                    "authenticationType": "OAUTH",
+                    "accessToken": "expiredAccessToken",
+                    "refreshToken": "expiredRefreshToken",
+                    "updatedAt": "1",
+                    "expiresInSeconds": "100"
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        ResourceDescriptor userResourceDescriptor = Mockito.mock(ResourceDescriptor.class);
+        when(userCredentialsDescriptor.toResourceDescriptor()).thenReturn(userResourceDescriptor);
+        when(userCredentialsDescriptor.getFullPath()).thenReturn("path");
+
+        Mockito.when(credentialEncryptionService.decrypt(any(), eq(encryptedBytes), any())).thenReturn(decryptedBytes);
+        ResourceCredentials decryptedResourceCredentials = JsonMapperUtil.convertToObject(decryptedBytes, ResourceCredentials.class);
+        when(tokenRefreshStrategyFactory.getTokenValidatorStrategy(AuthenticationType.OAUTH))
+                .thenReturn(oauthTokenRefreshStrategy);
+        when(oauthTokenRefreshStrategy.requiresTokenRefresh(decryptedResourceCredentials)).thenReturn(true);
+
+        // Simulate refresh token expired - auth server returns 400 with invalid_grant
+        String errorBody = """
+                {"error": "invalid_grant", "error_description": "Token has been expired or revoked."}
+                """;
+        Mockito.when(tokenService.getToken("testResourceId", authSettings, "expiredRefreshToken"))
+                .thenThrow(new HttpException(HttpStatus.BAD_REQUEST, "Authorization server returns error code",
+                        Map.of(), errorBody));
+
+        Mockito.doAnswer(invocation -> {
+            Function<byte[], byte[]> callbackFunction = invocation.getArgument(1);
+            byte[] result = callbackFunction.apply(encryptedBytes);
+            // Lambda should return null to trigger credential deletion
+            Assertions.assertNull(result);
+            return new ResourceItemMetadata();
+        }).when(resourceService).computeResourceBytes(eq(userResourceDescriptor), any());
+
+        // Global credentials not found
+        ResourceDescriptor globalResourceDescriptor = Mockito.mock(ResourceDescriptor.class);
+        Mockito.when(globalCredentialsDescriptor.getResourceId()).thenReturn("testResourceId");
+        Mockito.when(globalCredentialsDescriptor.toResourceDescriptor()).thenReturn(globalResourceDescriptor);
+
+        Mockito.doAnswer(invocation -> {
+            Function<byte[], byte[]> callbackFunction = invocation.getArgument(1);
+            callbackFunction.apply(null);
+            return null;
+        }).when(resourceService).computeResourceBytes(eq(globalResourceDescriptor), any());
+
+        // When & Then - should throw because refresh failed
+        assertThrows(ResourceNotFoundException.class, () -> {
+            service.getRefreshedResourceCredentials(credentialsLocator, authSettings, "userSub");
+        });
+
+        // Verify token service was called with the expired refresh token
+        Mockito.verify(tokenService).getToken("testResourceId", authSettings, "expiredRefreshToken");
     }
 
     @Test

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/token/OauthTokenRefreshStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/token/OauthTokenRefreshStrategyTest.java
@@ -60,17 +60,33 @@ class OauthTokenRefreshStrategyTest {
                         .updatedAt(now)
                         .expiresInSeconds(null)
                         .build(), true),
+                // expired access token + refresh token present → SIGNED_IN (can refresh)
                 Arguments.of(ResourceCredentials.builder()
                         .authenticationType(AuthenticationType.OAUTH)
                         .accessToken("access")
                         .refreshToken("refresh")
                         .updatedAt(0)
                         .expiresInSeconds(10L)
-                        .build(), false),
+                        .build(), true),
                 Arguments.of(ResourceCredentials.builder()
                         .authenticationType(AuthenticationType.OAUTH)
                         .accessToken("access")
                         .refreshToken("refresh")
+                        .updatedAt(now)
+                        .expiresInSeconds(0L)
+                        .build(), true),
+                // expired access token + no refresh token → SIGNED_OUT
+                Arguments.of(ResourceCredentials.builder()
+                        .authenticationType(AuthenticationType.OAUTH)
+                        .accessToken("access")
+                        .refreshToken(null)
+                        .updatedAt(0)
+                        .expiresInSeconds(10L)
+                        .build(), false),
+                Arguments.of(ResourceCredentials.builder()
+                        .authenticationType(AuthenticationType.OAUTH)
+                        .accessToken("access")
+                        .refreshToken(null)
                         .updatedAt(now)
                         .expiresInSeconds(0L)
                         .build(), false)

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1446,6 +1446,215 @@ public class ToolSetApiTest extends ResourceBaseTest {
         }
     }
 
+    @Test
+    void testOauthTokenRefresh_Success() {
+        // Token endpoint: returns expired token on sign-in, fresh token on refresh
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+        String refreshTokenResponse = """
+                {
+                    "access_token": "refreshed-access-token",
+                    "refresh_token": "new-refresh-token",
+                    "expires_in": 3600
+                }
+                """;
+
+        String mcpResponse = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "content": [{ "type": "text", "text": "ok" }]
+                  }
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            // Token endpoint: differentiate sign-in vs refresh by grant_type
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    return new MockResponse()
+                            .setBody(refreshTokenResponse)
+                            .setHeader("Content-Type", "application/json");
+                }
+                // sign-in (authorization_code grant)
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            // MCP endpoint: verify the refreshed token is used
+            server.map(HttpMethod.POST, "/", request -> {
+                String auth = request.getHeader("Authorization");
+                assertEquals("Bearer refreshed-access-token", auth);
+                return new MockResponse()
+                        .setBody(mcpResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            // Sign in with OAuth (token expires immediately due to expires_in: 0)
+            Response response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "oauth-toolset",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            // MCP call should trigger token refresh and use the refreshed token
+            ApiKeyData apiKey = createAdminAppKey();
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            Response resp = send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+
+            assertEquals(200, resp.status());
+            assertEquals(mcpResponse, resp.body());
+        }
+    }
+
+    @Test
+    void testOauthTokenRefresh_InvalidGrant_RemovesCredentials() {
+        // Token endpoint: returns expired token on sign-in
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "revoked-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+
+        String invalidGrantResponse = """
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Token has been expired or revoked."
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            // Token endpoint
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    // Refresh fails with invalid_grant
+                    return new MockResponse()
+                            .setResponseCode(400)
+                            .setBody(invalidGrantResponse)
+                            .setHeader("Content-Type", "application/json");
+                }
+                // sign-in succeeds
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            // MCP endpoint (will receive request without auth after credential failure)
+            server.map(HttpMethod.POST, "/", request ->
+                    new MockResponse()
+                            .setBody(MCP_TOOL_CALL_RESPONSE)
+                            .setHeader("Content-Type", "application/json"));
+
+            // Sign in with OAuth
+            Response response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "oauth-toolset",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            // Verify auth status is SIGNED_IN after sign-in
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""),
+                    "Expected SIGNED_IN after sign-in but got: " + response.body());
+
+            // MCP call triggers refresh → invalid_grant → credentials removed
+            ApiKeyData apiKey = createAdminAppKey();
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+
+            // Verify credentials were removed (auth status back to SIGNED_OUT)
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""),
+                    "Expected SIGNED_OUT after invalid_grant but got: " + response.body());
+        }
+    }
+
+    @Test
+    void testOauthTokenRefresh_ServerError_KeepsCredentials() {
+        // Token endpoint: returns expired token on sign-in
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            // Token endpoint
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    // Refresh fails with server error (not invalid_grant)
+                    return new MockResponse()
+                            .setResponseCode(500)
+                            .setBody("Internal Server Error")
+                            .setHeader("Content-Type", "text/plain");
+                }
+                // sign-in succeeds
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            // MCP endpoint
+            server.map(HttpMethod.POST, "/", request ->
+                    new MockResponse()
+                            .setBody(MCP_TOOL_CALL_RESPONSE)
+                            .setHeader("Content-Type", "application/json"));
+
+            // Sign in with OAuth
+            Response response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "oauth-toolset",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            // MCP call triggers refresh → server error → credentials kept
+            ApiKeyData apiKey = createAdminAppKey();
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+
+            // Verify credentials are still present (auth status still SIGNED_IN)
+            response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""),
+                    "Expected SIGNED_IN after server error but got: " + response.body());
+        }
+    }
+
+
     private String replaceValueInJsonArray(
             String originalJson,
             String arrayFieldName,

--- a/storage/src/main/java/com/epam/aidial/core/storage/http/HttpException.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/http/HttpException.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 public class HttpException extends RuntimeException {
     private final HttpStatus status;
     private final Map<String, String> headers;
+    private final String body;
 
     public HttpException(int status, String message) {
         this(HttpStatus.fromStatusCode(status, HttpStatus.INTERNAL_SERVER_ERROR), message, Map.of());
@@ -24,16 +25,21 @@ public class HttpException extends RuntimeException {
     }
 
     public HttpException(HttpStatus status, String message, Map<String, String> headers) {
+        this(status, message, headers, null);
+    }
+
+    public HttpException(HttpStatus status, String message, Map<String, String> headers, String body) {
         super(message);
         this.status = status;
         this.headers = new TreeMap<>(String::compareToIgnoreCase);
         this.headers.putAll(Objects.requireNonNull(headers, "HTTP headers must not be null"));
+        this.body = body;
     }
-
 
     public HttpException(HttpStatus status, String message, Throwable cause) {
         super(message, cause);
         this.status = status;
         this.headers = Map.of();
+        this.body = null;
     }
 }


### PR DESCRIPTION
Cherry-pick of #1476 into `release-0.42`.

Note: `ToolSetApiTest` had a merge conflict because unrelated test additions are on `development` but not on `release-0.42`. Resolved by taking only the three `testOauthTokenRefresh_*` tests that PR #1476 actually adds. All helpers (`MCP_TOOL_CALL_REQUEST`, `createAdminAppKey`, `TestWebServer`, `apiKeyStore`) are already present on `release-0.42`.

### Original description
fixes #1385