### PR TITLE
fix: [Toolsets] Decode gzip-encoded OAuth discovery responses #1493

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -9,6 +9,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.http.ContentType;
 
+import java.io.ByteArrayInputStream;
 import java.net.ConnectException;
 import java.net.ProxySelector;
 import java.net.URI;
@@ -20,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
 
 @Slf4j
@@ -77,14 +79,14 @@ public class ResourceAuthorizationClient {
     @SneakyThrows
     private <R> R execute(HttpRequest request, Class<R> responseType) {
         try {
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
 
             int status = response.statusCode();
-            String body = response.body();
+            String body = decodeBody(response);
 
             if (status != 200 && status != 201) {
                 log.warn("Error executing request {}: status {}, response {}",
-                        request.uri(), response.statusCode(), response.body());
+                        request.uri(), response.statusCode(), body);
                 if (status == 401) {
                     throw new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code",
                             httpHeadersHandler.convertHttpHeadersToMap(response.headers()), body);
@@ -114,6 +116,23 @@ public class ResourceAuthorizationClient {
             ex = ex.getCause();
         }
         return false;
+    }
+
+    // Some OAuth servers (e.g., CDN-fronted) return Content-Encoding: gzip even when the client
+    // did not request it. Java's built-in HttpClient does not auto-decompress, so we do it here.
+    @SneakyThrows
+    private static String decodeBody(HttpResponse<byte[]> response) {
+        byte[] body = response.body();
+        if (body == null || body.length == 0) {
+            return "";
+        }
+        String encoding = response.headers().firstValue("Content-Encoding").orElse("");
+        if ("gzip".equalsIgnoreCase(encoding)) {
+            try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(body))) {
+                return new String(gzip.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        }
+        return new String(body, StandardCharsets.UTF_8);
     }
 
     private java.time.Duration createRequestConfig() {

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -7,6 +7,7 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Strings;
 import org.apache.hc.core5.http.ContentType;
 
 import java.io.ByteArrayInputStream;
@@ -20,6 +21,8 @@ import java.nio.channels.UnresolvedAddressException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
@@ -120,19 +123,31 @@ public class ResourceAuthorizationClient {
 
     // Some OAuth servers (e.g., CDN-fronted) return Content-Encoding: gzip even when the client
     // did not request it. Java's built-in HttpClient does not auto-decompress, so we do it here.
+    // Per RFC 9110 §8.4, any coding we do not understand MUST be treated as undeliverable, and
+    // §8.4.1.3 requires "x-gzip" be considered equivalent to "gzip".
     @SneakyThrows
     private static String decodeBody(HttpResponse<byte[]> response) {
         byte[] body = response.body();
         if (body == null || body.length == 0) {
             return "";
         }
-        String encoding = response.headers().firstValue("Content-Encoding").orElse("");
-        if ("gzip".equalsIgnoreCase(encoding)) {
+        List<String> codings = response.headers().allValues("Content-Encoding").stream()
+                .flatMap(value -> Arrays.stream(value.split(",")))
+                .map(String::trim)
+                .filter(coding -> !coding.isEmpty())
+                .toList();
+        if (codings.isEmpty() || (codings.size() == 1 && Strings.CI.equals(codings.getFirst(), "identity"))) {
+            return new String(body, StandardCharsets.UTF_8);
+        }
+        if (codings.size() == 1 && (Strings.CI.equals(codings.getFirst(), "gzip")
+                || Strings.CI.equals(codings.getFirst(), "x-gzip"))) {
             try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(body))) {
                 return new String(gzip.readAllBytes(), StandardCharsets.UTF_8);
             }
         }
-        return new String(body, StandardCharsets.UTF_8);
+        throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR,
+                "Unsupported Content-Encoding '%s' from authorization server".formatted(String.join(", ", codings)),
+                Map.of(), "");
     }
 
     private java.time.Duration createRequestConfig() {

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -18,6 +18,7 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.channels.UnresolvedAddressException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ResourceAuthorizationClientTest {
+
+    private static final HttpHeaders EMPTY_HEADERS = HttpHeaders.of(Map.of(), (k, v) -> true);
 
     @Mock
     private HttpClient httpClientMock;
@@ -51,11 +54,12 @@ class ResourceAuthorizationClientTest {
         // Given
         String url = "https://example.com/resource";
         String jsonResponse = "{\"key\":\"value\"}";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         TestResponse expectedResponse = new TestResponse("value");
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(200);
-        when(httpResponseMock.body()).thenReturn(jsonResponse);
+        when(httpResponseMock.body()).thenReturn(jsonResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
 
         // When
         TestResponse actualResponse = resourceAuthorizationClient.executeGet(url, TestResponse.class);
@@ -69,7 +73,7 @@ class ResourceAuthorizationClientTest {
     void testExecuteGet_NotFoundStatus() throws Exception {
         // Given
         String url = "https://example.com/resource";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         HttpHeaders httpHeadersMock = mock(HttpHeaders.class);
         when(httpHeadersMock.map()).thenReturn(new HashMap<>());
@@ -89,7 +93,7 @@ class ResourceAuthorizationClientTest {
     void testExecuteGet_UnauthorizedStatus() throws Exception {
         // Given
         String url = "https://example.com/resource";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(401);
         HttpHeaders httpHeadersMock = mock(HttpHeaders.class);
@@ -112,10 +116,11 @@ class ResourceAuthorizationClientTest {
         TestRequest requestPayload = new TestRequest("testValue");
 
         String jsonResponse = "{\"key\":\"responseValue\"}";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(201);
-        when(httpResponseMock.body()).thenReturn(jsonResponse);
+        when(httpResponseMock.body()).thenReturn(jsonResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
 
         // When
         TestResponse actualResponse = resourceAuthorizationClient.executePost(
@@ -132,7 +137,7 @@ class ResourceAuthorizationClientTest {
         String url = "https://example.com/resource";
         TestRequest requestPayload = new TestRequest("testValue");
 
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(404);
 
@@ -157,7 +162,7 @@ class ResourceAuthorizationClientTest {
         String url = "https://example.com/resource";
         TestRequest requestPayload = new TestRequest("testValue");
 
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(401);
 
@@ -231,10 +236,11 @@ class ResourceAuthorizationClientTest {
         // Given
         String url = "https://example.com/token";
         String errorResponse = "{\"error\":\"invalid_grant\",\"error_description\":\"The authorization code has expired\"}";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(200);
-        when(httpResponseMock.body()).thenReturn(errorResponse);
+        when(httpResponseMock.body()).thenReturn(errorResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
 
         // When
         HttpException exception = assertThrows(HttpException.class,
@@ -252,10 +258,11 @@ class ResourceAuthorizationClientTest {
         String url = "https://example.com/token";
         TestRequest requestPayload = new TestRequest("testValue");
         String errorResponse = "{\"error\":\"invalid_client\",\"error_description\":\"Invalid redirect_uri\"}";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(200);
-        when(httpResponseMock.body()).thenReturn(errorResponse);
+        when(httpResponseMock.body()).thenReturn(errorResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
 
         // When
         HttpException exception = assertThrows(HttpException.class,
@@ -274,10 +281,11 @@ class ResourceAuthorizationClientTest {
         String url = "https://example.com/token";
         TestRequest requestPayload = new TestRequest("testValue");
         String errorResponse = "{\"error\":\"server_error\"}";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(200);
-        when(httpResponseMock.body()).thenReturn(errorResponse);
+        when(httpResponseMock.body()).thenReturn(errorResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
 
         // When
         HttpException exception = assertThrows(HttpException.class,
@@ -294,10 +302,11 @@ class ResourceAuthorizationClientTest {
     void testExecuteGet_ValidResponseNotTreatedAsOauthError() throws Exception {
         String url = "https://example.com/resource";
         String jsonResponse = "{\"key\":\"value\"}";
-        HttpResponse<String> httpResponseMock = mock(HttpResponse.class);
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
         when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
         when(httpResponseMock.statusCode()).thenReturn(200);
-        when(httpResponseMock.body()).thenReturn(jsonResponse);
+        when(httpResponseMock.body()).thenReturn(jsonResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
 
         // When
         TestResponse actualResponse = resourceAuthorizationClient.executeGet(url, TestResponse.class);

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.io.ByteArrayOutputStream;
 import java.net.ConnectException;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -22,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -314,6 +316,82 @@ class ResourceAuthorizationClientTest {
         // Then
         assertNotNull(actualResponse);
         assertEquals("value", actualResponse.getKey());
+    }
+
+    @Test
+    void testExecuteGet_DecodesXgzipAsGzip() throws Exception {
+        String url = "https://example.com/resource";
+        String jsonResponse = "{\"key\":\"value\"}";
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(gzip(jsonResponse));
+        when(httpResponseMock.headers()).thenReturn(
+                HttpHeaders.of(Map.of("Content-Encoding", List.of("x-gzip")), (k, v) -> true));
+
+        TestResponse actualResponse = resourceAuthorizationClient.executeGet(url, TestResponse.class);
+
+        assertNotNull(actualResponse);
+        assertEquals("value", actualResponse.getKey());
+    }
+
+    @Test
+    void testExecuteGet_FailsOnStackedCodings() throws Exception {
+        String url = "https://example.com/resource";
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn("ignored".getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(
+                HttpHeaders.of(Map.of("Content-Encoding", List.of("gzip, deflate")), (k, v) -> true));
+
+        HttpException exception = assertThrows(HttpException.class,
+                () -> resourceAuthorizationClient.executeGet(url, TestResponse.class));
+
+        assertTrue(exception.getMessage().contains("gzip"));
+        assertTrue(exception.getMessage().contains("deflate"));
+    }
+
+    @Test
+    void testExecuteGet_FailsWhenContentEncodingIsUnsupported() throws Exception {
+        String url = "https://example.com/resource";
+        String jsonResponse = "{\"key\":\"value\"}";
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(jsonResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(
+                HttpHeaders.of(Map.of("Content-Encoding", List.of("br")), (k, v) -> true));
+
+        HttpException exception = assertThrows(HttpException.class,
+                () -> resourceAuthorizationClient.executeGet(url, TestResponse.class));
+
+        assertTrue(exception.getMessage().contains("br"));
+    }
+
+    @Test
+    void testExecuteGet_TreatsBodyAsRawWhenContentEncodingIsIdentity() throws Exception {
+        String url = "https://example.com/resource";
+        String jsonResponse = "{\"key\":\"value\"}";
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn(jsonResponse.getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(
+                HttpHeaders.of(Map.of("Content-Encoding", List.of("identity")), (k, v) -> true));
+
+        TestResponse actualResponse = resourceAuthorizationClient.executeGet(url, TestResponse.class);
+
+        assertNotNull(actualResponse);
+        assertEquals("value", actualResponse.getKey());
+    }
+
+    private static byte[] gzip(String value) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+            gz.write(value.getBytes(StandardCharsets.UTF_8));
+        }
+        return baos.toByteArray();
     }
 
     @Data

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -12,13 +12,16 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.http.HttpMethod;
 import okhttp3.mockwebserver.MockResponse;
+import okio.Buffer;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1348,6 +1351,74 @@ public class ToolSetApiTest extends ResourceBaseTest {
             // codeChallengeMethod should be filled from discovery
             assertEquals("S256", authSettings.get("code_challenge_method").asText());
         }
+    }
+
+    @Test
+    void testCreateToolSetWithOauthWhenDiscoveryResponseIsGzipped() {
+        // Regression test for #1493: CDN-fronted OAuth discovery endpoints (e.g., Akamai) return
+        // Content-Encoding: gzip. ResourceAuthorizationClient must handle compressed responses.
+        String requestBody = """
+                {
+                    "endpoint": "http://localhost:9876/mcp",
+                    "transport": "HTTP",
+                    "allowedTools": [],
+                    "auth_settings": {
+                        "authentication_type": "OAUTH",
+                        "client_id": "my-client-id",
+                        "client_secret": "my-client-secret",
+                        "redirect_uri": "http://localhost:3000/auth/signin",
+                        "authorization_endpoint": "https://static.auth.example.com/authorize",
+                        "token_endpoint": "https://static.auth.example.com/token"
+                    }
+                }
+                """;
+
+        String protectedResourceMetadata = """
+                {
+                    "resource": "http://localhost:9876/mcp",
+                    "authorization_servers": ["http://localhost:9876"],
+                    "scopes_supported": ["read", "write"]
+                }
+                """;
+
+        String authServerMetadata = """
+                {
+                    "issuer": "http://localhost:9876",
+                    "authorization_endpoint": "https://discovered.auth.example.com/authorize",
+                    "token_endpoint": "https://discovered.auth.example.com/token",
+                    "code_challenge_methods_supported": ["S256"]
+                }
+                """;
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+            // Simulate a CDN (e.g., Akamai) that always gzips JSON responses regardless of
+            // the client's Accept-Encoding preference. The fix must decompress on receive.
+            server.map(HttpMethod.GET, "/.well-known/oauth-protected-resource/mcp",
+                    gzippedJsonResponse(protectedResourceMetadata));
+            server.map(HttpMethod.GET, "/.well-known/oauth-authorization-server",
+                    gzippedJsonResponse(authServerMetadata));
+
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-oauth-gzip@",
+                    null, requestBody, "authorization", "admin");
+
+            assertEquals(200, response.status(), "PUT should succeed when OAuth discovery response is gzipped");
+        }
+    }
+
+    private static MockResponse gzippedJsonResponse(String body) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+            gz.write(body.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        MockResponse response = new MockResponse();
+        response.setResponseCode(200);
+        response.setBody(new Buffer().write(baos.toByteArray()));
+        response.setHeader("Content-Type", "application/json");
+        response.setHeader("Content-Encoding", "gzip");
+        return response;
     }
 
     @Test


### PR DESCRIPTION
CDN-fronted OAuth servers (e.g., Akamai) may return Content-Encoding: gzip regardless of the client's Accept-Encoding. Java's built-in HttpClient does not auto-decompress, so ResourceAuthorizationClient now reads the response as bytes and decodes gzip bodies when the header is present.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1493

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
