### PR TITLE
fix: [Toolsets] Expose OAuth discovery for application MCP path

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -82,6 +82,8 @@ public class Proxy implements Handler<HttpServerRequest> {
 
     public static final Pattern TOOLSET_PROXY_PATTERN = RouteTemplate.TOOL_SET_MCP_PROXY.getPattern();
     public static final Pattern TOOLSET_PROXY_METADATA_PATTERN = RouteTemplate.TOOL_SET_PROXY_METADATA.getPattern();
+    public static final Pattern APPLICATION_MCP_PROXY_PATTERN = RouteTemplate.APPLICATION_MCP_PROXY.getPattern();
+    public static final Pattern APPLICATION_MCP_PROXY_METADATA_PATTERN = RouteTemplate.APPLICATION_MCP_PROXY_METADATA.getPattern();
 
     // All new headers should start with X-DIAL- while existing may stay untouched
 
@@ -233,7 +235,7 @@ public class Proxy implements Handler<HttpServerRequest> {
             return;
         }
 
-        if (request.method() == HttpMethod.GET && TOOLSET_PROXY_METADATA_PATTERN.matcher(request.path()).matches()) {
+        if (request.method() == HttpMethod.GET && isMcpResourceMetadataPath(request.path())) {
             resourceMetadataController.handle(request);
             return;
         }
@@ -285,7 +287,7 @@ public class Proxy implements Handler<HttpServerRequest> {
         String clientIpAddress = ProxyUtil.getClientIpAddress(request, apiKeyValidation.getProxyCount());
         if (apiKey == null && authorization == null) {
             Map<String, String> headers = Map.of();
-            if ((request.method() == HttpMethod.GET || request.method() == HttpMethod.POST) && TOOLSET_PROXY_PATTERN.matcher(request.path()).matches()) {
+            if ((request.method() == HttpMethod.GET || request.method() == HttpMethod.POST) && isMcpResourcePath(request.path())) {
                 headers = resourceMetadataService.resolveResourceMetadataPath(request)
                         .map(path -> Map.of("WWW-Authenticate", "Bearer resource_metadata=\"" + path + "\""))
                         .orElse(Map.of());
@@ -390,5 +392,15 @@ public class Proxy implements Handler<HttpServerRequest> {
     private void respond(HttpServerRequest request, HttpStatus status, String body, Map<String, String> headers) {
         headers.forEach(request.response()::putHeader);
         respond(request, status, body);
+    }
+
+    private static boolean isMcpResourcePath(String path) {
+        return TOOLSET_PROXY_PATTERN.matcher(path).matches()
+                || APPLICATION_MCP_PROXY_PATTERN.matcher(path).matches();
+    }
+
+    private static boolean isMcpResourceMetadataPath(String path) {
+        return TOOLSET_PROXY_METADATA_PATTERN.matcher(path).matches()
+                || APPLICATION_MCP_PROXY_METADATA_PATTERN.matcher(path).matches();
     }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
@@ -195,6 +195,10 @@ public enum RouteTemplate {
             "^/\\.well-known/oauth-protected-resource/v1/toolset/(?<id>.+?)/mcp$",
             "/.well-known/oauth-protected-resource/v1/toolset/{id}/mcp"
     ),
+    APPLICATION_MCP_PROXY_METADATA(
+            "^/\\.well-known/oauth-protected-resource/v1/deployments/(?<id>.+?)/mcp$",
+            "/.well-known/oauth-protected-resource/v1/deployments/{id}/mcp"
+    ),
     PER_REQUEST_PERMISSION("^/v1/ops/resource/per-request-permissions/(grant|revoke|list)",
             "/v1/ops/resource/per-request-permissions/{operation}"),
 

--- a/server/src/test/java/com/epam/aidial/core/server/ProxyTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ProxyTest.java
@@ -217,6 +217,22 @@ public class ProxyTest {
         verify(response).putHeader("WWW-Authenticate", "Bearer resource_metadata=\"example.com\"");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"GET", "POST"})
+    public void testHandle_MissingApiKeyAndToken_PathMatchesApplicationMcpProxyPattern(String method) {
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.method()).thenReturn(HttpMethod.valueOf(method));
+        MultiMap headers = mock(MultiMap.class);
+        when(request.headers()).thenReturn(headers);
+        when(request.path()).thenReturn("/v1/deployments/test-app/mcp");
+        when(resourceMetadataService.resolveResourceMetadataPath(request)).thenReturn(Optional.of("example.com"));
+
+        proxy.handle(request);
+
+        verify(response).setStatusCode(UNAUTHORIZED.getCode());
+        verify(response).putHeader("WWW-Authenticate", "Bearer resource_metadata=\"example.com\"");
+    }
+
     @Test
     public void testHandle_BothApiKeyAndToken_ApiKeyNotFound() {
         when(request.version()).thenReturn(HttpVersion.HTTP_1_1);

--- a/server/src/test/java/com/epam/aidial/core/server/WellKnownResourceMetadataApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/WellKnownResourceMetadataApiTest.java
@@ -16,4 +16,16 @@ public class WellKnownResourceMetadataApiTest extends ResourceBaseTest {
                 }
                 """);
     }
+
+    @Test
+    public void testWellKnownResourceMetadataForApplicationMcp() {
+        Response response = send(HttpMethod.GET, "/.well-known/oauth-protected-resource/v1/deployments/test-app/mcp");
+
+        verifyJsonNotExact(response, 200, """
+                {
+                  "resource" : "https://localhost/v1/deployments/test-app/mcp",
+                  "authorization_servers" : [ "https://example.com" ]
+                }
+                """);
+    }
 }


### PR DESCRIPTION
The application MCP path /v1/deployments/{id}/mcp had no OAuth protected-resource metadata route and the auth layer did not emit the WWW-Authenticate header on 401, breaking RFC 9728 discovery for MCP clients (e.g., Claude.ai).

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1498

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
