### PR TITLE
fix: [Toolsets] Toolset with expired login token return 404 in response instead of 401

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/ResourceAuthSettings.java
+++ b/config/src/main/java/com/epam/aidial/core/config/ResourceAuthSettings.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.Accessors;
 
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @Accessors(chain = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -31,6 +32,7 @@ public class ResourceAuthSettings {
     private String clientId;
 
     @JsonAlias({"clientSecret", "client_secret"})
+    @ToString.Exclude
     private String clientSecret;
 
     @JsonAlias({"authorizationEndpoint", "authorization_endpoint"})
@@ -49,6 +51,7 @@ public class ResourceAuthSettings {
     private String codeChallengeMethod;
 
     @JsonAlias({"codeVerifier", "code_verifier"})
+    @ToString.Exclude
     private String codeVerifier;
 
     @JsonAlias({"apiKeyHeader", "api_key_header"})

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/ResourceCredentials.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/ResourceCredentials.java
@@ -5,6 +5,7 @@ import com.epam.aidial.core.config.CredentialsLevel;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
 @Data
@@ -16,8 +17,11 @@ public class ResourceCredentials {
     private CredentialsLevel credentialsLevel;
     private AuthenticationType authenticationType;
     private String apiKeyHeader;
+    @ToString.Exclude
     private String apiKey;
+    @ToString.Exclude
     private String accessToken;
+    @ToString.Exclude
     private String refreshToken;
     private long createdAt;
     private long updatedAt;

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -241,7 +241,9 @@ public class ResourceCredentialsService {
         });
 
         if (refreshFailure.get() != null) {
-            throw new ResourceNotFoundException("Failed to refresh token for resource %s".formatted(resourceId));
+            // The toolset still exists; only its OAuth state is gone. 401 tells the client to re-auth
+            // rather than implying the resource itself is missing.
+            throw new HttpException(HttpStatus.UNAUTHORIZED, "Failed to refresh token for resource %s".formatted(resourceId));
         }
 
         return reference.get();

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
@@ -20,7 +20,6 @@ import com.epam.aidial.core.credentials.service.token.TokenRefreshStrategyFactor
 import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.credentials.util.TimeProvider;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
-import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
@@ -467,10 +466,12 @@ class ResourceCredentialsServiceTest {
             return new ResourceItemMetadata();
         }).when(resourceService).computeResourceBytes(eq(userResourceDescriptor), any());
 
-        // When & Then - should throw because refresh failed; GLOBAL fallback is skipped
-        assertThrows(ResourceNotFoundException.class, () -> {
+        // When & Then - should throw 401 because refresh failed; GLOBAL fallback is skipped.
+        // 401 (not 404) tells the client the toolset exists but its OAuth state needs refreshing.
+        HttpException ex = assertThrows(HttpException.class, () -> {
             service.getRefreshedResourceCredentials(credentialsLocator, authSettings, "userSub");
         });
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
 
         // Verify token service was called with the expired refresh token
         Mockito.verify(tokenService).getToken("testResourceId", authSettings, "expiredRefreshToken");

--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -65,6 +65,7 @@ import com.epam.aidial.core.server.service.codeinterpreter.CodeInterpreterServic
 import com.epam.aidial.core.server.token.TokenStatsTracker;
 import com.epam.aidial.core.server.tracing.DialTracingFactory;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
+import com.epam.aidial.core.server.util.AuthSettingsResolver;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
 import com.epam.aidial.core.storage.blobstore.BlobStorage;
@@ -206,6 +207,8 @@ public class AiDial {
             AuthorizationHeaderProvider authorizationHeaderProvider = new AuthorizationHeaderProvider(resourceCredentialsService);
             ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService = new ResourceAuthSettingsEncryptionService(
                     credentialEncryptionService);
+            AuthSettingsResolver authSettingsResolver = new AuthSettingsResolver(
+                    encryptionService, resourceAuthSettingsEncryptionService);
             ToolSetService toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService);
 
@@ -256,7 +259,7 @@ public class AiDial {
                     notificationService, applicationService, codeInterpreterService, heartbeatService, upstreamCacheService,
                     consentService, deploymentService, healthCheckController, wellKnownResourceMetadataService, resourceMetadataController,
                     toolSetService, applicationSchemaService, authorizationHeaderProvider, resourceAuthSettingsService, resourceCredentialsService,
-                    perRequestPermissionService, resourceAuthSettingsEncryptionService, clientChannelService, taskExecutor, version());
+                    perRequestPermissionService, resourceAuthSettingsEncryptionService, authSettingsResolver, clientChannelService, taskExecutor, version());
 
             server = vertx.createHttpServer(new HttpServerOptions(settings("server"))).requestHandler(proxy);
             open(server, HttpServer::listen);

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -40,6 +40,7 @@ import com.epam.aidial.core.server.service.clientchannel.ClientChannelService;
 import com.epam.aidial.core.server.service.codeinterpreter.CodeInterpreterService;
 import com.epam.aidial.core.server.token.TokenStatsTracker;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
+import com.epam.aidial.core.server.util.AuthSettingsResolver;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
 import com.epam.aidial.core.storage.blobstore.BlobStorage;
@@ -148,6 +149,7 @@ public class Proxy implements Handler<HttpServerRequest> {
     private final ResourceCredentialsService resourceCredentialsService;
     private final PerRequestPermissionService perRequestPermissionService;
     private final ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService;
+    private final AuthSettingsResolver authSettingsResolver;
     private final ClientChannelService clientChannelService;
     private final AsyncTaskExecutor taskExecutor;
     private final String version;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetMcpProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetMcpProxyController.java
@@ -9,6 +9,7 @@ import com.epam.aidial.core.credentials.service.AuthorizationHeaderProvider;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.util.AuthSettingsResolver;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
@@ -23,6 +24,7 @@ public class ToolSetMcpProxyController extends McpProxyController {
     private final CredentialsLocator credentialsLocator;
     private final AuthorizationHeaderProvider authorizationHeaderProvider;
     private final ResourceCredentialsService resourceCredentialsService;
+    private final AuthSettingsResolver authSettingsResolver;
 
 
     private ToolSet toolSet;
@@ -32,6 +34,7 @@ public class ToolSetMcpProxyController extends McpProxyController {
         this.authorizationHeaderProvider = proxy.getAuthorizationHeaderProvider();
         this.credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(UrlUtil.encodePath(toolSetId), context, ResourceTypes.TOOL_SET);
         this.resourceCredentialsService = proxy.getResourceCredentialsService();
+        this.authSettingsResolver = proxy.getAuthSettingsResolver();
     }
 
     @Override
@@ -45,7 +48,7 @@ public class ToolSetMcpProxyController extends McpProxyController {
     @Override
     protected void injectProxyRequestHeaders(HttpClientRequest proxyRequest, MultiMap excludeHeaders) {
         ResourceCredentials resourceCredentials = resourceCredentialsService.getRefreshedResourceCredentials(
-                credentialsLocator, toolSet.getAuthSettings(), context.getInitiatorId()
+                credentialsLocator, authSettingsResolver.resolve(toolSet, context), context.getInitiatorId()
         );
 
         if (resourceCredentials != null) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetMcpProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetMcpProxyController.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.AuthorizationHeader;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
@@ -47,8 +48,9 @@ public class ToolSetMcpProxyController extends McpProxyController {
 
     @Override
     protected void injectProxyRequestHeaders(HttpClientRequest proxyRequest, MultiMap excludeHeaders) {
+        ResourceAuthSettings authSettings = authSettingsResolver.resolve(toolSet, context);
         ResourceCredentials resourceCredentials = resourceCredentialsService.getRefreshedResourceCredentials(
-                credentialsLocator, authSettingsResolver.resolve(toolSet, context), context.getInitiatorId()
+                credentialsLocator, authSettings, context.getInitiatorId()
         );
 
         if (resourceCredentials != null) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -22,6 +22,7 @@ import com.epam.aidial.core.server.sse.SseEventListener;
 import com.epam.aidial.core.server.sse.SseParser;
 import com.epam.aidial.core.server.upstream.UpstreamRoute;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
+import com.epam.aidial.core.server.util.AuthSettingsResolver;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
@@ -73,6 +74,7 @@ public class ToolSetToolsController implements Controller {
     private final AccessService accessService;
     private final ResourceCredentialsService resourceCredentialsService;
     private final ApplicationSchemaService applicationSchemaService;
+    private final AuthSettingsResolver authSettingsResolver;
 
     public ToolSetToolsController(Proxy proxy, ProxyContext context, String toolSetId, boolean filterAllowed) {
         this.proxy = proxy;
@@ -88,6 +90,7 @@ public class ToolSetToolsController implements Controller {
         this.accessService = proxy.getAccessService();
         this.resourceCredentialsService = proxy.getResourceCredentialsService();
         this.applicationSchemaService = proxy.getApplicationSchemaService();
+        this.authSettingsResolver = proxy.getAuthSettingsResolver();
         this.credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(
                 UrlUtil.encodePath(toolSetId), context, ResourceTypes.TOOL_SET);
     }
@@ -345,7 +348,7 @@ public class ToolSetToolsController implements Controller {
     private void injectToolsetCredentials(HttpClientRequest proxyRequest, Deployment deployment) {
         if (deployment instanceof ToolSet toolSet) {
             ResourceCredentials resourceCredentials = resourceCredentialsService.getRefreshedResourceCredentials(
-                    credentialsLocator, toolSet.getAuthSettings(), context.getInitiatorId()
+                    credentialsLocator, authSettingsResolver.resolve(toolSet, context), context.getInitiatorId()
             );
             if (resourceCredentials != null) {
                 addAuthorizationHeader(proxyRequest, resourceCredentials);

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.credentials.data.credentials.AuthorizationHeader;
@@ -347,8 +348,9 @@ public class ToolSetToolsController implements Controller {
 
     private void injectToolsetCredentials(HttpClientRequest proxyRequest, Deployment deployment) {
         if (deployment instanceof ToolSet toolSet) {
+            ResourceAuthSettings authSettings = authSettingsResolver.resolve(toolSet, context);
             ResourceCredentials resourceCredentials = resourceCredentialsService.getRefreshedResourceCredentials(
-                    credentialsLocator, authSettingsResolver.resolve(toolSet, context), context.getInitiatorId()
+                    credentialsLocator, authSettings, context.getInitiatorId()
             );
             if (resourceCredentials != null) {
                 addAuthorizationHeader(proxyRequest, resourceCredentials);

--- a/server/src/main/java/com/epam/aidial/core/server/util/AuthSettingsResolver.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/AuthSettingsResolver.java
@@ -1,0 +1,33 @@
+package com.epam.aidial.core.server.util;
+
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
+import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthSettingsResolver {
+
+    private final EncryptionService encryptionService;
+    private final ResourceAuthSettingsEncryptionService authSettingsEncryptionService;
+
+    // For resource-stored toolsets returns a transient decrypted COPY of authSettings
+    // so the deployment held in ProxyContext stays ciphertext. Config-defined toolsets
+    // are already plaintext and returned as-is.
+    public ResourceAuthSettings resolve(ToolSet toolSet, ProxyContext context) {
+        ResourceAuthSettings stored = toolSet.getAuthSettings();
+        if (context.getConfig().isDeploymentExists(toolSet.getName())) {
+            return stored;
+        }
+        // toolSet.getName() is already percent-encoded; don't re-encode or AAD won't match.
+        ResourceDescriptor descriptor = ResourceDescriptorFactory.fromAnyUrl(toolSet.getName(), encryptionService);
+        BucketInfo bucketInfo = new BucketInfo(descriptor.getBucketName(), descriptor.getBucketLocation());
+        ResourceAuthSettings copy = stored.toBuilder().build();
+        authSettingsEncryptionService.decrypt(descriptor.getUrl(), bucketInfo, copy);
+        return copy;
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1667,6 +1667,108 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testStoredOauthToolsetSendsPlaintextClientSecretOnRefresh() {
+        // Resource-stored toolsets persist authSettings.clientSecret encrypted at rest. The MCP
+        // proxy controller used to forward toolset.getAuthSettings() to the credential refresh
+        // path WITHOUT decrypting first, so the auth server received Base64-wrapped ciphertext
+        // as client_secret and rejected with invalid_client. Reproduces and guards the fix.
+        String signInTokenResponse = """
+                {
+                    "access_token": "expired-access-token",
+                    "refresh_token": "valid-refresh-token",
+                    "expires_in": 0
+                }
+                """;
+        String refreshedTokenResponse = """
+                {
+                    "access_token": "refreshed-access-token",
+                    "refresh_token": "valid-refresh-token",
+                    "expires_in": 3600
+                }
+                """;
+        String plaintextClientSecret = "plaintext-client-secret";
+        java.util.concurrent.atomic.AtomicReference<String> refreshBody = new java.util.concurrent.atomic.AtomicReference<>();
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            // Mirror real OAuth servers (e.g. Notion): reject refresh requests whose client_secret
+            // doesn't match the registered value with 401 invalid_client.
+            server.map(HttpMethod.POST, "/token", request -> {
+                String body = request.getBody().readUtf8();
+                if (body.contains("grant_type=refresh_token")) {
+                    refreshBody.set(body);
+                    if (!body.contains("client_secret=" + plaintextClientSecret)) {
+                        return new MockResponse()
+                                .setResponseCode(401)
+                                .setBody("{\"error\":\"invalid_client\",\"error_description\":\"Invalid client_secret\"}")
+                                .setHeader("Content-Type", "application/json");
+                    }
+                    return new MockResponse()
+                            .setBody(refreshedTokenResponse)
+                            .setHeader("Content-Type", "application/json");
+                }
+                return new MockResponse()
+                        .setBody(signInTokenResponse)
+                        .setHeader("Content-Type", "application/json");
+            });
+            server.map(HttpMethod.POST, "/mcp", request ->
+                    new MockResponse()
+                            .setBody(MCP_TOOL_CALL_RESPONSE)
+                            .setHeader("Content-Type", "application/json"));
+
+            Response response = send(HttpMethod.PUT,
+                    "/v1/toolsets/4X25dj1mja51jykqxsXnCH/notion-toolset@", null, """
+                            {
+                                "endpoint": "http://localhost:9876/mcp",
+                                "transport": "HTTP",
+                                "allowedTools": [],
+                                "auth_settings": {
+                                    "authentication_type": "OAUTH",
+                                    "client_id": "stored-client-id",
+                                    "client_secret": "%s",
+                                    "redirect_uri": "http://admin/callback",
+                                    "authorization_endpoint": "http://localhost:9876/authorize",
+                                    "token_endpoint": "http://localhost:9876/token"
+                                }
+                            }
+                            """.formatted(plaintextClientSecret), "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "toolsets/4X25dj1mja51jykqxsXnCH/notion-toolset@",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            ApiKeyData apiKey = createAppKey("admin", Map.of(
+                    "toolsets/4X25dj1mja51jykqxsXnCH/notion-toolset@",
+                    new AutoSharedData(Set.of(ResourceAccessType.READ))));
+            apiKey.setExecutionPath(List.of("applications/4X25dj1mja51jykqxsXnCH/my-app"));
+            apiKeyStore.assignPerRequestApiKey(apiKey);
+
+            Response mcpResponse = send(HttpMethod.POST,
+                    "/v1/toolset/toolsets/4X25dj1mja51jykqxsXnCH/notion-toolset@/mcp", null,
+                    MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+            assertEquals(200, mcpResponse.status(),
+                    "MCP call should succeed when stored client_secret is decrypted before refresh, got: " + mcpResponse.status());
+
+            String capturedRefreshBody = refreshBody.get();
+            assertNotNull(capturedRefreshBody, "Token refresh should have been triggered (expires_in=0 on sign-in)");
+            assertTrue(capturedRefreshBody.contains("client_secret=" + plaintextClientSecret),
+                    "Refresh request must send plaintext client_secret, got: " + capturedRefreshBody);
+
+            response = send(HttpMethod.GET,
+                    "/openai/toolsets/toolsets/4X25dj1mja51jykqxsXnCH/notion-toolset@", null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""),
+                    "Toolset should remain SIGNED_IN after a successful refresh, got: " + response.body());
+        }
+    }
+
+    @Test
     void testStaticOauthToolsetSecretPreservedAfterListing() {
         String tokenResponse = """
                 {
@@ -2044,8 +2146,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
             ApiKeyData apiKey = createAdminAppKey();
             apiKeyStore.assignPerRequestApiKey(apiKey);
 
-            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+            Response mcpResponse = send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
                     MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+            assertEquals(401, mcpResponse.status(),
+                    "Expected 401 (re-auth needed) when refresh fails permanently, got: " + mcpResponse.status());
 
             // Verify credentials were removed (auth status back to SIGNED_OUT)
             response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
@@ -2118,8 +2222,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
             ApiKeyData apiKey = createAdminAppKey();
             apiKeyStore.assignPerRequestApiKey(apiKey);
 
-            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+            Response mcpResponse = send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
                     MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+            assertEquals(401, mcpResponse.status(),
+                    "Expected 401 (re-auth needed) when refresh fails permanently, got: " + mcpResponse.status());
 
             // Verify credentials were removed (auth status back to SIGNED_OUT)
             response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
@@ -2180,8 +2286,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
             ApiKeyData apiKey = createAdminAppKey();
             apiKeyStore.assignPerRequestApiKey(apiKey);
 
-            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+            Response mcpResponse = send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
                     MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+            assertEquals(401, mcpResponse.status(),
+                    "Expected 401 (re-auth needed) when refresh fails permanently, got: " + mcpResponse.status());
 
             response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
             assertEquals(200, response.status());
@@ -2241,8 +2349,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
             ApiKeyData apiKey = createAdminAppKey();
             apiKeyStore.assignPerRequestApiKey(apiKey);
 
-            send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
+            Response mcpResponse = send(HttpMethod.POST, "/v1/toolset/oauth-toolset/mcp", null,
                     MCP_TOOL_CALL_REQUEST, "Content-Type", "application/json", "api-key", apiKey.getPerRequestKey());
+            assertEquals(401, mcpResponse.status(),
+                    "Expected 401 (re-auth needed) when refresh fails permanently, got: " + mcpResponse.status());
 
             response = send(HttpMethod.GET, "/openai/toolsets/oauth-toolset", null, null, "authorization", "admin");
             assertEquals(200, response.status());

--- a/server/src/test/java/com/epam/aidial/core/server/util/AuthSettingsResolverTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/AuthSettingsResolverTest.java
@@ -1,0 +1,137 @@
+package com.epam.aidial.core.server.util;
+
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
+import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.security.EncryptionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthSettingsResolverTest {
+
+    @Mock
+    private EncryptionService encryptionService;
+    @Mock
+    private ResourceAuthSettingsEncryptionService authSettingsEncryptionService;
+    @Mock
+    private ProxyContext context;
+    @Mock
+    private Config config;
+
+    @InjectMocks
+    private AuthSettingsResolver resolver;
+
+    @Test
+    void resolve_configDefinedToolset_returnsOriginalReferenceWithoutDecryption() {
+        ToolSet toolSet = toolSet("config-toolset", "plaintext-secret");
+        ResourceAuthSettings stored = toolSet.getAuthSettings();
+        when(context.getConfig()).thenReturn(config);
+        when(config.isDeploymentExists("config-toolset")).thenReturn(true);
+
+        ResourceAuthSettings resolved = resolver.resolve(toolSet, context);
+
+        assertSame(stored, resolved, "Config-defined toolset must yield the original authSettings reference");
+        verifyNoInteractions(encryptionService, authSettingsEncryptionService);
+    }
+
+    @Test
+    void resolve_resourceStoredToolset_returnsDecryptedCopy() {
+        String url = "toolsets/encrypted-bucket/my-toolset";
+        ToolSet toolSet = toolSet(url, "ciphertext-secret");
+        ResourceAuthSettings encrypted = toolSet.getAuthSettings();
+        when(context.getConfig()).thenReturn(config);
+        when(config.isDeploymentExists(url)).thenReturn(false);
+        when(encryptionService.decrypt("encrypted-bucket")).thenReturn("Users/owner/");
+        doAnswer(invocation -> {
+            ResourceAuthSettings target = invocation.getArgument(2);
+            target.setClientSecret("plaintext-secret");
+            return null;
+        }).when(authSettingsEncryptionService).decrypt(
+                eq("toolsets/encrypted-bucket/my-toolset"),
+                eq(new BucketInfo("encrypted-bucket", "Users/owner/")),
+                org.mockito.ArgumentMatchers.any());
+
+        ResourceAuthSettings resolved = resolver.resolve(toolSet, context);
+
+        assertNotSame(encrypted, resolved, "Resource-stored toolset must yield a decrypted copy, not the original");
+        assertEquals("plaintext-secret", resolved.getClientSecret());
+    }
+
+    @Test
+    void resolve_resourceStoredToolset_doesNotMutateOriginalAuthSettings() {
+        String url = "toolsets/encrypted-bucket/my-toolset";
+        ToolSet toolSet = toolSet(url, "ciphertext-secret");
+        ResourceAuthSettings encrypted = toolSet.getAuthSettings();
+        when(context.getConfig()).thenReturn(config);
+        when(config.isDeploymentExists(url)).thenReturn(false);
+        when(encryptionService.decrypt("encrypted-bucket")).thenReturn("Users/owner/");
+        doAnswer(invocation -> {
+            ResourceAuthSettings target = invocation.getArgument(2);
+            target.setClientSecret("plaintext-secret");
+            return null;
+        }).when(authSettingsEncryptionService).decrypt(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any());
+
+        resolver.resolve(toolSet, context);
+
+        // The toolset held in ProxyContext must keep its ciphertext for the rest of the request,
+        // so a heap dump or accidental log of the deployment never exposes the plaintext secret.
+        assertEquals("ciphertext-secret", encrypted.getClientSecret());
+        assertSame(encrypted, toolSet.getAuthSettings());
+    }
+
+    @Test
+    void resolve_resourceStoredToolsetWithEncodedName_doesNotDoubleEncode() {
+        // toolSet.getName() is set to ResourceDescriptor.getUrl() at PUT time, so it is already
+        // percent-encoded. The decrypt call must use the SAME URL string the encrypt call used
+        // (it is the AAD); otherwise AES-GCM rejects the decryption. Re-encoding here would
+        // turn "my%20toolset" into "my%2520toolset" and break decryption silently for any
+        // toolset whose name contains percent-encoded characters.
+        String url = "toolsets/encrypted-bucket/my%20toolset";
+        ToolSet toolSet = toolSet(url, "ciphertext-secret");
+        when(context.getConfig()).thenReturn(config);
+        when(config.isDeploymentExists(url)).thenReturn(false);
+        when(encryptionService.decrypt("encrypted-bucket")).thenReturn("Users/owner/");
+        doAnswer(invocation -> {
+            ResourceAuthSettings target = invocation.getArgument(2);
+            target.setClientSecret("plaintext-secret");
+            return null;
+        }).when(authSettingsEncryptionService).decrypt(
+                eq("toolsets/encrypted-bucket/my%20toolset"),
+                eq(new BucketInfo("encrypted-bucket", "Users/owner/")),
+                org.mockito.ArgumentMatchers.any());
+
+        ResourceAuthSettings resolved = resolver.resolve(toolSet, context);
+
+        assertEquals("plaintext-secret", resolved.getClientSecret());
+    }
+
+    private static ToolSet toolSet(String name, String clientSecret) {
+        ToolSet toolSet = new ToolSet();
+        toolSet.setName(name);
+        toolSet.setAuthSettings(ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.OAUTH)
+                .clientId("client-id")
+                .clientSecret(clientSecret)
+                .build());
+        return toolSet;
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1504
- fixes Decrypt clientSecret on OAuth token refresh

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
