### PR TITLE
fix: share limit bypass when sharing files with encoded URLs #1495

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/SharedByMeDto.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/SharedByMeDto.java
@@ -43,7 +43,7 @@ public class SharedByMeDto {
         this.writableResourcesToUsers = Objects.requireNonNullElseGet(writableResourcesToUsers, HashMap::new);
         this.shareableResourcesToUsers = Objects.requireNonNullElseGet(shareableResourcesToUsers, HashMap::new);
         this.userIdToDisplayName = Objects.requireNonNullElseGet(userIdToDisplayName, HashMap::new);
-        this.limits = limits;
+        this.limits = Objects.requireNonNullElseGet(limits, HashMap::new);
     }
 
     public Set<String> collectUsersForPermissions(String url, Set<ResourceAccessType> permissions) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/ShareService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ShareService.java
@@ -220,14 +220,14 @@ public class ShareService {
                     throw new IllegalArgumentException("Duplicated resource: %s".formatted(resource.getUrl()));
                 }
                 if (resource.getBucketName().equals(bucket)) {
-                    ownerResources.add(sharedResource);
+                    ownerResources.add(sharedResource.withUrl(resource.getUrl()));
                 }
                 String author = reshareableResourceUrls.containsKey(resource.getUrl())
                         ? reshareableResourceUrls.get(resource.getUrl()).getAuthor()
                         : context.getUserDisplayName();
                 normalizedResourceLinks.add(sharedResource.withUrl(resource.getUrl()).withAuthor(author));
-                updateLimits(context, resourceType, limit, ownerResources);
             }
+            updateLimits(context, resourceType, limit, ownerResources);
         }
 
         Invitation invitation = invitationService.createInvitation(bucket, bucketLocation, normalizedResourceLinks,

--- a/server/src/test/java/com/epam/aidial/core/server/ShareApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ShareApiTest.java
@@ -2521,4 +2521,88 @@ public class ShareApiTest extends ResourceBaseTest {
                 }
                 """);
     }
+
+    @Test
+    @DialConfigLocation("dial-config/share-limit-config.json")
+    void testShareFileLimitEnforced() {
+        // upload a file with a percent-encoded special character in the path
+        Response response = upload(HttpMethod.PUT, "/v1/files/%s/folder%%40name/test.txt".formatted(bucket), null, "test content");
+        Assertions.assertEquals(200, response.status());
+
+        // initialize share request using the percent-encoded URL
+        response = operationRequest("/v1/ops/resource/share/create", """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    {
+                      "url": "files/%s/folder%%40name/test.txt"
+                    }
+                  ]
+                }
+                """.formatted(bucket));
+        verify(response, 200);
+        InvitationLink invitationLink = ProxyUtil.convertToObject(response.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        // user2 accepts invitation - should succeed (0 < 1)
+        response = send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey2");
+        verify(response, 200);
+
+        // create another invitation for the same file
+        response = operationRequest("/v1/ops/resource/share/create", """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    {
+                      "url": "files/%s/folder%%40name/test.txt"
+                    }
+                  ]
+                }
+                """.formatted(bucket));
+        verify(response, 200);
+        invitationLink = ProxyUtil.convertToObject(response.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        // user3 accepts invitation - should fail (1 >= 1, limit exceeded)
+        response = send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey3");
+        verify(response, 400);
+    }
+
+    @Test
+    @DialConfigLocation("dial-config/share-limit-config.json")
+    void testShareFileLimitEnforcedForFolder() {
+        // upload files in a folder
+        Response response = upload(HttpMethod.PUT, "/v1/files/%s/shared-folder/file1.txt".formatted(bucket), null, "content1");
+        Assertions.assertEquals(200, response.status());
+
+        // create conversation referencing files
+        response = resourceRequest(HttpMethod.PUT, "/test-conversation", CONVERSATION_BODY_1);
+        verifyNotExact(response, 200, "\"url\":");
+
+        // share both conversation and folder
+        response = operationRequest("/v1/ops/resource/share/create", """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    {
+                      "url": "conversations/%s/test-conversation"
+                    },
+                    {
+                      "url": "metadata/files/%s/shared-folder/"
+                    }
+                  ]
+                }
+                """.formatted(bucket, bucket));
+        verify(response, 200);
+        InvitationLink invitationLink = ProxyUtil.convertToObject(response.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        // user2 accepts - should succeed (file limit: 0 < 1)
+        response = send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey2");
+        verify(response, 200);
+
+        // user3 accepts - should fail (file limit exceeded: 1 >= 1)
+        response = send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey3");
+        verify(response, 400);
+    }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/service/ShareServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ShareServiceTest.java
@@ -10,8 +10,10 @@ import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.Invitation;
 import com.epam.aidial.core.server.data.InvitationLink;
 import com.epam.aidial.core.server.data.ShareResourcesRequest;
+import com.epam.aidial.core.server.data.SharedByMeDto;
 import com.epam.aidial.core.server.data.SharedResource;
 import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
@@ -285,5 +287,25 @@ class ShareServiceTest {
                     ]
                 }
                 """;
+    }
+
+    @Test
+    void testSharedByMeDtoLimitsNotNullWhenDeserializedWithoutLimitsField() {
+        String json = """
+                {
+                    "resourceToUsers": {
+                        "files/bucket/folder/": ["Users/user1/"]
+                    },
+                    "writableResourcesToUsers": {},
+                    "shareableResourcesToUsers": {},
+                    "userIdToDisplayName": {
+                        "Users/user1/": "user1"
+                    }
+                }
+                """;
+        SharedByMeDto dto = ProxyUtil.convertToObject(json, SharedByMeDto.class);
+        assertNotNull(dto);
+        assertNotNull(dto.getLimits());
+        assertTrue(dto.getLimits().isEmpty());
     }
 }

--- a/server/src/test/resources/dial-config/share-limit-config.json
+++ b/server/src/test/resources/dial-config/share-limit-config.json
@@ -1,0 +1,29 @@
+{
+  "keys": {
+    "proxyKey1": {
+      "project": "EPM-RTC-GPT",
+      "role": "share-limited"
+    },
+    "proxyKey2": {
+      "project": "EPM-RTC-RAIL",
+      "role": "share-limited"
+    },
+    "proxyKey3": {
+      "project": "EPM-RTC-DIAL",
+      "role": "share-limited"
+    }
+  },
+  "roles": {
+    "share-limited": {
+      "limits": {
+        "test-model-v1": {}
+      },
+      "share": {
+        "FILE": {
+          "max_accepted_users": 1,
+          "invitation_ttl": 72
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Share limits for files were bypassed when URLs contained percent-encoded characters because limits were stored under the original client URL but looked up using the normalized URL from the invitation.

### Applicable issues

- fixes #1495

### Description of changes

- Fixed URL normalization mismatch in `ShareService.initializeShare()`: limits are now stored under the normalized URL (via `ResourceDescriptor.getUrl()`) instead of the raw client-provided URL, ensuring the lookup during acceptance matches the stored key
- Added null-guard for `SharedByMeDto.limits` field to prevent NPE when deserializing legacy data that lacks the `"limits"` JSON key
- Added integration tests verifying share file limit enforcement with percent-encoded URLs and folder sharing
- Added unit test for `SharedByMeDto` deserialization without the limits field

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.