### PR TITLE
fix: fix mcp feature flag for schema-rich application in single-app GET endpoint #1526

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.controller.extraction.ApplicationDeploymentExtractor;
@@ -62,6 +63,10 @@ public class ApplicationController {
                 .map(deployment -> {
                     if (deployment instanceof Application application) {
                         boolean applicationRequestInfoAboutItSelf = applicationId.equals(context.getDecodedSourceDeployment());
+                        if (application.hasApplicationTypeSchemaId()) {
+                            application.setMcp(applicationSchemaService.getMcp(application));
+                            application.setViewerUrl(applicationSchemaService.getStringProperty(application, MetaSchemaHolder.APPLICATION_TYPE_VIEWER_URL));
+                        }
                         return applicationSchemaService.modifySchemaRichApplication(application, !applicationRequestInfoAboutItSelf);
                     }
                     throw new ResourceNotFoundException("Application is not found: " + applicationId);

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -1318,6 +1318,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                      "max_retry_attempts" : 1,
                      "invalid" : true,
                      "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                     "viewer_url" : "https://mydial.somewhere.com/custom_application_schemas/viewer",
                      "routes" : { }
                 }
                 """);
@@ -1463,6 +1464,9 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                 }
                 """);
         verify(response, 200);
+
+        response = send(HttpMethod.GET, "/openai/applications/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my%20app");
+        verifyNotExact(response, 200, "\"mcp\":true");
 
         String mcpResponse = """
                 {


### PR DESCRIPTION
The `/openai/applications/{id}` endpoint returned `"mcp": false` for schema-rich applications whose MCP endpoint is defined via `applicationTypeSchemaId`, instead of `"mcp": true`.

### Applicable issues

- fixes #1526

### Description of changes

- `ApplicationController.getApplication()`: added `setMcp()` and `setViewerUrl()` calls for schema-rich apps (those with `applicationTypeSchemaId`) before `modifySchemaRichApplication()`, matching the pattern already used by the list endpoint's `ApplicationDeploymentExtractor`
- `CustomApplicationApiTest.testMcpCall()`: replaced incomplete GET line with a targeted assertion on the single-app endpoint verifying `"mcp": true` after updating the app to use a schema with `dial:applicationTypeMcp`
- `CustomApplicationApiTest.testOpenAiApplicationWithTypeSchemaGet_ReturnedInvalid_WhenAppDoesNotConformToSchema()`: updated expected JSON to include `viewer_url` now correctly returned by the single-GET endpoint

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.