### PR TITLE
feat: fix toolset tool listing response format and pagination #1537

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -31,7 +31,6 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpClient;
@@ -161,8 +160,14 @@ public class ToolSetToolsController implements Controller {
                 .jsonSchemaValidator(NOOP_SCHEMA_VALIDATOR)
                 .build()) {
             client.initialize();
-            McpSchema.ListToolsResult result = client.listTools();
-            processToolsResult(result);
+            if (filterAllowed) {
+                // listTools() auto-paginates all pages via the SDK's expand() chain
+                processUserToolsResult(client.listTools().tools());
+            } else {
+                // listTools(cursor) fetches exactly one page; null = first page
+                String cursor = context.getRequest().getParam("nextCursor");
+                processAdminToolsResult(client.listTools(cursor));
+            }
         } catch (Exception e) {
             log.error("Failed to fetch tools from MCP server for toolset: {}", toolSetId, e);
             throw new HttpException(HttpStatus.BAD_GATEWAY, "Failed to fetch tools from MCP server");
@@ -193,23 +198,28 @@ public class ToolSetToolsController implements Controller {
         }
     }
 
-    private void processToolsResult(McpSchema.ListToolsResult result) {
+    private void processAdminToolsResult(McpSchema.ListToolsResult result) {
         ObjectNode responseBody = ProxyUtil.MAPPER.createObjectNode();
-        responseBody.put("jsonrpc", "2.0");
-        responseBody.put("id", 1);
-        ObjectNode resultNode = responseBody.putObject("result");
-        ArrayNode toolsArray = resultNode.putArray("tools");
-
-        List<String> allowedTools = filterAllowed ? getAllowedTools(context.getDeployment()) : List.of();
-
+        ArrayNode toolsArray = responseBody.putArray("tools");
         for (McpSchema.Tool tool : result.tools()) {
-            if (filterAllowed && !allowedTools.isEmpty() && !allowedTools.contains(tool.name())) {
-                continue;
-            }
-            JsonNode toolNode = ProxyUtil.MAPPER.valueToTree(tool);
-            toolsArray.add(toolNode);
+            toolsArray.add(ProxyUtil.MAPPER.valueToTree(tool));
         }
+        if (result.nextCursor() != null) {
+            responseBody.put("nextCursor", result.nextCursor());
+        }
+        finalizeRequest();
+        context.respond(HttpStatus.OK, responseBody);
+    }
 
+    private void processUserToolsResult(List<McpSchema.Tool> tools) {
+        List<String> allowedTools = getAllowedTools(context.getDeployment());
+        ObjectNode responseBody = ProxyUtil.MAPPER.createObjectNode();
+        ArrayNode toolsArray = responseBody.putArray("tools");
+        for (McpSchema.Tool tool : tools) {
+            if (allowedTools.isEmpty() || allowedTools.contains(tool.name())) {
+                toolsArray.add(ProxyUtil.MAPPER.valueToTree(tool));
+            }
+        }
         finalizeRequest();
         context.respond(HttpStatus.OK, responseBody);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1884,8 +1884,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
 
             assertEquals(200, resp.status());
             var json = ProxyUtil.MAPPER.readTree(resp.body());
-            ArrayNode tools = Optional.ofNullable(json.get("result"))
-                    .map(res -> res.get("tools"))
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
                     .map(node -> (ArrayNode) node)
                     .orElse(ProxyUtil.MAPPER.createArrayNode());
             assertEquals(3, tools.size());
@@ -1925,8 +1924,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
 
             assertEquals(200, resp.status());
             var json = ProxyUtil.MAPPER.readTree(resp.body());
-            ArrayNode tools = Optional.ofNullable(json.get("result"))
-                    .map(res -> res.get("tools"))
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
                     .map(node -> (ArrayNode) node)
                     .orElse(ProxyUtil.MAPPER.createArrayNode());
             assertEquals(2, tools.size());
@@ -1949,8 +1947,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
 
             assertEquals(200, resp.status());
             var json = ProxyUtil.MAPPER.readTree(resp.body());
-            ArrayNode tools = Optional.ofNullable(json.get("result"))
-                    .map(res -> res.get("tools"))
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
                     .map(node -> (ArrayNode) node)
                     .orElse(ProxyUtil.MAPPER.createArrayNode());
             assertEquals(2, tools.size());
@@ -1980,8 +1977,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
 
             assertEquals(200, resp.status());
             var json = ProxyUtil.MAPPER.readTree(resp.body());
-            ArrayNode tools = Optional.ofNullable(json.get("result"))
-                    .map(res -> res.get("tools"))
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
                     .map(node -> (ArrayNode) node)
                     .orElse(ProxyUtil.MAPPER.createArrayNode());
             assertEquals(2, tools.size());
@@ -2027,8 +2023,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
 
             assertEquals(200, resp.status());
             var json = ProxyUtil.MAPPER.readTree(resp.body());
-            ArrayNode tools = Optional.ofNullable(json.get("result"))
-                    .map(res -> res.get("tools"))
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
                     .map(node -> (ArrayNode) node)
                     .orElse(ProxyUtil.MAPPER.createArrayNode());
             assertEquals(2, tools.size());
@@ -2039,13 +2034,145 @@ public class ToolSetApiTest extends ResourceBaseTest {
 
             assertEquals(200, resp.status());
             json = ProxyUtil.MAPPER.readTree(resp.body());
-            tools = Optional.ofNullable(json.get("result"))
-                    .map(res -> res.get("tools"))
+            tools = Optional.ofNullable(json.get("tools"))
                     .map(node -> (ArrayNode) node)
                     .orElse(ProxyUtil.MAPPER.createArrayNode());
             assertEquals(1, tools.size());
             assertEquals("tool1", tools.get(0).get("name").asText());
         }
+    }
+
+    @Test
+    void testGetAllTools_Pagination() throws JsonProcessingException {
+        String page1Response = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "tools": [
+                      {"name": "branch", "description": "Manage branches"},
+                      {"name": "tag", "description": "Manage tags"}
+                    ],
+                    "nextCursor": "page2"
+                  }
+                }
+                """;
+        String page2Response = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "tools": [
+                      {"name": "remote", "description": "Manage remotes"}
+                    ]
+                  }
+                }
+                """;
+        try (TestWebServer ignore = new TestWebServer(9876, mcpPaginatedToolsHandler(page1Response, page2Response))) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/git/tools", null, null, "authorization", "admin");
+
+            assertEquals(200, resp.status());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            assertEquals(2, tools.size());
+            assertEquals("branch", tools.get(0).get("name").asText());
+            assertEquals("tag", tools.get(1).get("name").asText());
+            assertEquals("page2", json.get("nextCursor").asText());
+
+            resp = send(HttpMethod.GET, "/v1/toolset/git/tools?nextCursor=page2",
+                    null, null, "authorization", "admin");
+
+            assertEquals(200, resp.status());
+            json = ProxyUtil.MAPPER.readTree(resp.body());
+            tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            assertEquals(1, tools.size());
+            assertEquals("remote", tools.get(0).get("name").asText());
+            assertTrue(json.get("nextCursor") == null || json.get("nextCursor").isNull());
+        }
+    }
+
+    @Test
+    void testGetAllowedTools_AutoPagination() throws JsonProcessingException {
+        // git toolset has allowedTools: ["branch", "remote"]; page1 has branch+tag, page2 has remote
+        String page1Response = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "tools": [
+                      {"name": "branch", "description": "Manage branches"},
+                      {"name": "tag", "description": "Manage tags"}
+                    ],
+                    "nextCursor": "page2"
+                  }
+                }
+                """;
+        String page2Response = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                    "tools": [
+                      {"name": "remote", "description": "Manage remotes"}
+                    ]
+                  }
+                }
+                """;
+        try (TestWebServer ignore = new TestWebServer(9876, mcpPaginatedToolsHandler(page1Response, page2Response))) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/git/allowed-tools");
+
+            assertEquals(200, resp.status());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            // "tag" filtered out, "branch" and "remote" (from page 2) included
+            assertEquals(2, tools.size());
+            assertEquals("branch", tools.get(0).get("name").asText());
+            assertEquals("remote", tools.get(1).get("name").asText());
+            assertTrue(json.get("nextCursor") == null || json.get("nextCursor").isNull());
+        }
+    }
+
+    private static String extractCursor(String body) {
+        try {
+            JsonNode node = ProxyUtil.MAPPER.readTree(body);
+            JsonNode cursor = node.path("params").path("cursor");
+            return cursor.isMissingNode() || cursor.isNull() ? null : cursor.asText();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static TestWebServer.Handler mcpPaginatedToolsHandler(
+            String firstPageResponse, String subsequentPageResponse) {
+        return request -> {
+            String body = request.getBody().readString(StandardCharsets.UTF_8);
+            if ("GET".equals(request.getMethod())) {
+                return new MockResponse().setResponseCode(405);
+            }
+            if (body.contains("\"method\":\"initialize\"") || body.contains("\"method\": \"initialize\"")) {
+                String id = extractJsonRpcId(body);
+                String initResponse = """
+                        {"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},"serverInfo":{"name":"test-server","version":"1.0"}}}
+                        """.formatted(id);
+                return new MockResponse().setBody(initResponse).setHeader("Content-Type", "application/json");
+            } else if (body.contains("\"method\":\"notifications/initialized\"")
+                    || body.contains("\"method\": \"notifications/initialized\"")) {
+                return new MockResponse().setResponseCode(202).setHeader("Content-Type", "application/json");
+            } else if (body.contains("\"method\":\"tools/list\"") || body.contains("\"method\": \"tools/list\"")) {
+                String cursor = extractCursor(body);
+                String id = extractJsonRpcId(body);
+                String template = cursor == null ? firstPageResponse : subsequentPageResponse;
+                String response = template.replaceFirst("\"id\"\\s*:\\s*\\d+", "\"id\":" + id);
+                return new MockResponse().setBody(response).setHeader("Content-Type", "application/json");
+            }
+            return new MockResponse().setResponseCode(400).setBody("Unknown method");
+        };
     }
 
     @Test


### PR DESCRIPTION
Fix the two toolset tool-discovery REST endpoints to return the MCP specification's `result` object as the response root (removing the JSON-RPC 2.0 envelope), and add proper pagination support.

### Applicable issues

- fixes #1537

### Description of changes

- **`/v1/toolset/{id}/tools` (admin)**: removes `jsonrpc`/`id`/`result` wrapper; returns MCP result object directly as root; supports `?nextCursor=` query param to fetch a specific page; includes `nextCursor` in response when the MCP server returns one
- **`/v1/toolset/{id}/allowed-tools` (user)**: removes `jsonrpc`/`id`/`result` wrapper; uses the MCP SDK's built-in auto-pagination (`listTools()`) to collect all pages before filtering by `allowedTools`, ensuring tools on page 2+ are not silently omitted
- Updated existing test assertions to match the new flat response shape
- Added `testGetAllTools_Pagination` and `testGetAllowedTools_AutoPagination` integration tests with a paginated mock MCP handler

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.