### PR TITLE
fix: "Invalid client" error for Snowflake-managed MCP #1527

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/ResourceAuthSettings.java
+++ b/config/src/main/java/com/epam/aidial/core/config/ResourceAuthSettings.java
@@ -68,4 +68,7 @@ public class ResourceAuthSettings {
 
     @JsonAlias({"scopesSupported", "scopes_supported"})
     private List<String> scopesSupported;
+
+    @JsonAlias({"tokenEndpointAuthMethod", "token_endpoint_auth_method"})
+    private String tokenEndpointAuthMethod;
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenEndpointAuthMethod.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenEndpointAuthMethod.java
@@ -4,11 +4,16 @@ package com.epam.aidial.core.credentials.data.credentials;
  * Client authentication methods at the OAuth 2.0 token endpoint
  * (RFC 6749 §2.3 and RFC 8414 §2 — {@code token_endpoint_auth_methods_supported}).
  *
- * <p>For backward compatibility with toolsets registered before this field existed,
- * a null/blank value resolves to {@link #CLIENT_SECRET_POST} (the method DIAL has
- * always used). Per RFC 6749 §2.3.1 the spec-recommended default is
- * {@code client_secret_basic}, but mapping null → basic would break existing
- * working toolsets whose authorization servers only accept credentials in the body.</p>
+ * <p>A null/blank value resolves to {@link #CLIENT_SECRET_BASIC} per RFC 6749 §2.3.1
+ * (BASIC is {@code MUST} for compliant authorization servers; POST is {@code MAY} and
+ * {@code NOT RECOMMENDED}). OAuth 2.1, which MCP references, deprecates POST entirely.
+ *
+ * <p>DIAL historically sent {@code client_secret_post} unconditionally. Operators whose AS
+ * only accepts POST must set this field explicitly — those servers are non-compliant with
+ * RFC 6749 §2.3.1 and would be unable to interop with most OAuth 2.1 clients anyway.
+ *
+ * <p>TODO: require the field at creation time so the default applies only to pre-PR
+ * persisted data and can eventually be removed.
  */
 public enum TokenEndpointAuthMethod {
 
@@ -22,8 +27,15 @@ public enum TokenEndpointAuthMethod {
 
     public static TokenEndpointAuthMethod resolveOrDefault(String value) {
         if (value == null || value.isBlank()) {
-            return CLIENT_SECRET_POST;
+            return CLIENT_SECRET_BASIC;
         }
+        return parse(value);
+    }
+
+    /**
+     * Parses a value or throws if unsupported. Callers must null-check first.
+     */
+    public static TokenEndpointAuthMethod parse(String value) {
         try {
             return valueOf(value.toUpperCase());
         } catch (IllegalArgumentException e) {

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenEndpointAuthMethod.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenEndpointAuthMethod.java
@@ -1,0 +1,33 @@
+package com.epam.aidial.core.credentials.data.credentials;
+
+/**
+ * Client authentication methods at the OAuth 2.0 token endpoint
+ * (RFC 6749 §2.3 and RFC 8414 §2 — {@code token_endpoint_auth_methods_supported}).
+ *
+ * <p>For backward compatibility with toolsets registered before this field existed,
+ * a null/blank value resolves to {@link #CLIENT_SECRET_POST} (the method DIAL has
+ * always used). Per RFC 6749 §2.3.1 the spec-recommended default is
+ * {@code client_secret_basic}, but mapping null → basic would break existing
+ * working toolsets whose authorization servers only accept credentials in the body.</p>
+ */
+public enum TokenEndpointAuthMethod {
+
+    CLIENT_SECRET_POST,
+    CLIENT_SECRET_BASIC,
+    NONE;
+
+    public String value() {
+        return name().toLowerCase();
+    }
+
+    public static TokenEndpointAuthMethod resolveOrDefault(String value) {
+        if (value == null || value.isBlank()) {
+            return CLIENT_SECRET_POST;
+        }
+        try {
+            return valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unsupported token_endpoint_auth_method: " + value);
+        }
+    }
+}

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/registration/ClientRegistration.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/registration/ClientRegistration.java
@@ -17,4 +17,5 @@ public class ClientRegistration {
     private String redirectUri;
     private String codeChallengeMethod;
     private List<String> scopesSupported;
+    private String tokenEndpointAuthMethod;
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -74,6 +74,11 @@ public class ResourceAuthSettingsService {
                 resourceAuthSettings.setClientSecret(existingResourceAuthSettings.getClientSecret());
             }
 
+            // preserve tokenEndpointAuthMethod on updates that omit it
+            if (resourceAuthSettings.getTokenEndpointAuthMethod() == null) {
+                resourceAuthSettings.setTokenEndpointAuthMethod(existingResourceAuthSettings.getTokenEndpointAuthMethod());
+            }
+
             resolveCodeChallengeSettings(resourceAuthSettings, existingResourceAuthSettings);
         }
     }
@@ -128,6 +133,7 @@ public class ResourceAuthSettingsService {
         resourceAuthSettings.setTokenEndpoint(clientRegistration.getTokenEndpoint());
         resourceAuthSettings.setRedirectUri(clientRegistration.getRedirectUri());
         resourceAuthSettings.setScopesSupported(clientRegistration.getScopesSupported());
+        resourceAuthSettings.setTokenEndpointAuthMethod(clientRegistration.getTokenEndpointAuthMethod());
         setCodeChallengeProperties(resourceAuthSettings, clientRegistration.getCodeChallengeMethod());
     }
 

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -60,6 +60,11 @@ public class ResourceAuthorizationClient {
     }
 
     public <R> R executePost(String url, Object requestPayload, String contentType, Class<R> responseType) {
+        return executePost(url, requestPayload, contentType, Map.of(), responseType);
+    }
+
+    public <R> R executePost(String url, Object requestPayload, String contentType,
+                             Map<String, String> extraHeaders, Class<R> responseType) {
         String stringPayload;
         if (contentType.equals(ContentType.APPLICATION_JSON.toString())) {
             stringPayload = JsonMapperUtil.convertToString(requestPayload);
@@ -68,11 +73,13 @@ public class ResourceAuthorizationClient {
         }
 
         assert stringPayload != null;
-        HttpRequest request = HttpRequest.newBuilder()
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(createRequestConfig())
                 .header("Content-Type", contentType)
-                .header("Accept", ContentType.APPLICATION_JSON.toString())
+                .header("Accept", ContentType.APPLICATION_JSON.toString());
+        extraHeaders.forEach(requestBuilder::header);
+        HttpRequest request = requestBuilder
                 .POST(HttpRequest.BodyPublishers.ofString(stringPayload, StandardCharsets.UTF_8))
                 .build();
 

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
@@ -3,13 +3,19 @@ package com.epam.aidial.core.credentials.service;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.data.credentials.RefreshTokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.data.credentials.TokenEndpointAuthMethod;
 import com.epam.aidial.core.credentials.data.credentials.TokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 @AllArgsConstructor
 @Slf4j
@@ -23,17 +29,20 @@ public class TokenService {
                                   ResourceSignInRequest resourceSignInRequest) {
         log.debug("Start Resource {} token retrieval", resourceId);
         String redirectUri = resolveRedirectUri(resourceAuthSettings, resourceSignInRequest);
-        TokenRequest tokenRequest = TokenRequest.builder()
-                .clientId(resourceAuthSettings.getClientId())
-                .clientSecret(resourceAuthSettings.getClientSecret())
+        TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolveOrDefault(resourceAuthSettings.getTokenEndpointAuthMethod());
+
+        TokenRequest.TokenRequestBuilder builder = TokenRequest.builder()
                 .code(resourceSignInRequest.getCode())
                 // TODO: do we need to support different?
                 .grantType("authorization_code")
                 .codeVerifier(resourceAuthSettings.getCodeVerifier())
-                .redirectUri(redirectUri)
-                .build();
+                .redirectUri(redirectUri);
+        Map<String, String> headers = applyClientAuthentication(authMethod,
+                resourceAuthSettings.getClientId(), resourceAuthSettings.getClientSecret(),
+                builder::clientId, builder::clientSecret);
+        TokenRequest tokenRequest = builder.build();
 
-        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData());
+        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData(), headers);
         log.debug("Finished Resource {} token retrieval", resourceId);
         return tokenResponse;
     }
@@ -42,14 +51,17 @@ public class TokenService {
                                   ResourceAuthSettings resourceAuthSettings,
                                   String refreshToken) {
         log.debug("Start Resource {} refresh token retrieval", resourceId);
-        RefreshTokenRequest tokenRequest = RefreshTokenRequest.builder()
-                .clientId(resourceAuthSettings.getClientId())
-                .clientSecret(resourceAuthSettings.getClientSecret())
-                .grantType("refresh_token")
-                .refreshToken(refreshToken)
-                .build();
+        TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolveOrDefault(resourceAuthSettings.getTokenEndpointAuthMethod());
 
-        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData());
+        RefreshTokenRequest.RefreshTokenRequestBuilder builder = RefreshTokenRequest.builder()
+                .grantType("refresh_token")
+                .refreshToken(refreshToken);
+        Map<String, String> headers = applyClientAuthentication(authMethod,
+                resourceAuthSettings.getClientId(), resourceAuthSettings.getClientSecret(),
+                builder::clientId, builder::clientSecret);
+        RefreshTokenRequest tokenRequest = builder.build();
+
+        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData(), headers);
         log.debug("Finished Resource {} refresh token retrieval", resourceId);
         return tokenResponse;
     }
@@ -75,10 +87,39 @@ public class TokenService {
                 || uri.equals(resourceAuthSettings.getRedirectUri());
     }
 
-    private TokenResponse doTokenCall(String tokenEndpoint, String tokenRequest) {
+    private TokenResponse doTokenCall(String tokenEndpoint, String tokenRequest, Map<String, String> extraHeaders) {
         return resourceAuthorizationClient.executePost(
                 tokenEndpoint, tokenRequest,
                 "application/x-www-form-urlencoded",
+                extraHeaders,
                 TokenResponse.class);
+    }
+
+    private static Map<String, String> applyClientAuthentication(TokenEndpointAuthMethod authMethod,
+                                                                 String clientId,
+                                                                 String clientSecret,
+                                                                 Consumer<String> setClientId,
+                                                                 Consumer<String> setClientSecret) {
+        return switch (authMethod) {
+            case CLIENT_SECRET_BASIC -> Map.of("Authorization", buildBasicAuthHeader(clientId, clientSecret));
+            case NONE -> {
+                setClientId.accept(clientId);
+                yield Map.of();
+            }
+            case CLIENT_SECRET_POST -> {
+                setClientId.accept(clientId);
+                setClientSecret.accept(clientSecret);
+                yield Map.of();
+            }
+        };
+    }
+
+    // RFC 6749 §2.3.1: client_id and client_secret are application/x-www-form-urlencoded
+    // before being concatenated with ":" and base64-encoded.
+    private static String buildBasicAuthHeader(String clientId, String clientSecret) {
+        String encId = URLEncoder.encode(StringUtils.defaultString(clientId), StandardCharsets.UTF_8);
+        String encSecret = URLEncoder.encode(StringUtils.defaultString(clientSecret), StandardCharsets.UTF_8);
+        String credentials = encId + ":" + encSecret;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.credentials.service.registration;
 
 import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.credentials.data.credentials.TokenEndpointAuthMethod;
 import com.epam.aidial.core.credentials.data.registration.AuthorizationServerMetadata;
 import com.epam.aidial.core.credentials.data.registration.AuthorizationServerProtectedResourceMetadata;
 import com.epam.aidial.core.credentials.data.registration.ClientRegistration;
@@ -83,6 +84,12 @@ public class DynamicResourceRegistrationStrategy implements ResourceRegistration
                 ContentType.APPLICATION_JSON.toString(),
                 ClientRegistrationResponse.class);
 
+        // Reject methods DIAL can't honor (e.g. private_key_jwt) at registration time so the
+        // operator gets a clear error before any end-user sign-in attempt; null response falls
+        // back to the DIAL default so the persisted value always reflects what DIAL will use.
+        String tokenEndpointAuthMethod = TokenEndpointAuthMethod.resolveOrDefault(
+                clientRegistrationResponse.getTokenEndpointAuthMethod()).value();
+
         ClientRegistration clientRegistration = ClientRegistration.builder()
                 .resourceId(clientRegistrationResponse.getClientName())
                 .clientId(clientRegistrationResponse.getClientId())
@@ -91,7 +98,7 @@ public class DynamicResourceRegistrationStrategy implements ResourceRegistration
                 .authorizationEndpoint(authServerMetadata.getAuthorizationEndpoint())
                 .tokenEndpoint(authServerMetadata.getTokenEndpoint())
                 .scopesSupported(supportedScopes)
-                .tokenEndpointAuthMethod(clientRegistrationResponse.getTokenEndpointAuthMethod())
+                .tokenEndpointAuthMethod(tokenEndpointAuthMethod)
                 .build();
 
         Optional<String> codeChallengeMethod = getCodeChallengeMethod(authServerMetadata);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
@@ -85,8 +85,9 @@ public class DynamicResourceRegistrationStrategy implements ResourceRegistration
                 ClientRegistrationResponse.class);
 
         // Reject methods DIAL can't honor (e.g. private_key_jwt) at registration time so the
-        // operator gets a clear error before any end-user sign-in attempt; null response falls
-        // back to the DIAL default so the persisted value always reflects what DIAL will use.
+        // operator gets a clear error before any end-user sign-in attempt. Null falls back to
+        // client_secret_basic per RFC 6749 §2.3.1; the persisted value always reflects what
+        // DIAL will use.
         String tokenEndpointAuthMethod = TokenEndpointAuthMethod.resolveOrDefault(
                 clientRegistrationResponse.getTokenEndpointAuthMethod()).value();
 

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
@@ -91,6 +91,7 @@ public class DynamicResourceRegistrationStrategy implements ResourceRegistration
                 .authorizationEndpoint(authServerMetadata.getAuthorizationEndpoint())
                 .tokenEndpoint(authServerMetadata.getTokenEndpoint())
                 .scopesSupported(supportedScopes)
+                .tokenEndpointAuthMethod(clientRegistrationResponse.getTokenEndpointAuthMethod())
                 .build();
 
         Optional<String> codeChallengeMethod = getCodeChallengeMethod(authServerMetadata);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategy.java
@@ -100,6 +100,7 @@ public class StaticResourceRegistrationStrategy implements ResourceRegistrationS
                 .tokenEndpoint(tokenEndpoint)
                 .codeChallengeMethod(codeChallengeMethod)
                 .scopesSupported(supportedScopes)
+                .tokenEndpointAuthMethod(resourceAuthSettings.getTokenEndpointAuthMethod())
                 .build();
 
         log.info("Finished static registration for Resource: {}", resourceId);

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/validation/OauthAuthSettingsValidator.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/validation/OauthAuthSettingsValidator.java
@@ -1,5 +1,7 @@
 package com.epam.aidial.core.credentials.validation;
 
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.credentials.data.credentials.TokenEndpointAuthMethod;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsChangeMode;
 
 import java.util.Set;
@@ -20,6 +22,20 @@ import java.util.Set;
  * </ul>
  */
 public class OauthAuthSettingsValidator extends BaseAuthSettingsValidator {
+
+    @Override
+    public void validate(ResourceAuthSettings resourceAuthSettings,
+                         ResourceAuthSettingsChangeMode resourceAuthSettingsChangeMode) {
+        super.validate(resourceAuthSettings, resourceAuthSettingsChangeMode);
+        // Reject unsupported token_endpoint_auth_method at save time so the failure surfaces
+        // here rather than during the first sign-in attempt deep inside TokenService.
+        // Dynamic registration ignores the user-supplied value (DCR response wins), so skip
+        // the check there to avoid rejecting harmless input.
+        if (resourceAuthSettingsChangeMode != ResourceAuthSettingsChangeMode.CREATE_DYNAMIC_CLIENT
+                && resourceAuthSettings.getTokenEndpointAuthMethod() != null) {
+            TokenEndpointAuthMethod.parse(resourceAuthSettings.getTokenEndpointAuthMethod());
+        }
+    }
 
     /**
      * Determines validation fields for `ResourceAuthSettings` based on the mode of authentication configuration change.

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
@@ -325,6 +325,34 @@ class ResourceAuthSettingsServiceTest {
     }
 
     @Test
+    void testProcessResourceAuthSettings_OauthUpdate_TokenEndpointAuthMethodNull_PreservesExisting() {
+        ToolSet updatedToolSet = createOauthToolSetWithTokenEndpointAuthMethod("clientId", "clientSecret", null);
+        ToolSet existingToolSet = createOauthToolSetWithTokenEndpointAuthMethod("clientId", "clientSecret",
+                "client_secret_basic");
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        verifyNoInteractions(resourceRegistrationService);
+        assertEquals("client_secret_basic", updatedToolSet.getAuthSettings().getTokenEndpointAuthMethod());
+    }
+
+    @Test
+    void testProcessResourceAuthSettings_OauthUpdate_TokenEndpointAuthMethodChanged_Overrides() {
+        ToolSet updatedToolSet = createOauthToolSetWithTokenEndpointAuthMethod("clientId", "clientSecret", "none");
+        ToolSet existingToolSet = createOauthToolSetWithTokenEndpointAuthMethod("clientId", "clientSecret",
+                "client_secret_basic");
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        verifyNoInteractions(resourceRegistrationService);
+        assertEquals("none", updatedToolSet.getAuthSettings().getTokenEndpointAuthMethod());
+    }
+
+    @Test
     void testProcessResourceAuthSettings_UpdatedApiKeyToolSet() {
         // Given
         ToolSet updatedToolSet = createApiKeyToolSet("newApiKeyHeader");
@@ -492,6 +520,17 @@ class ResourceAuthSettingsServiceTest {
         authSettings.setClientId(clientId);
         authSettings.setClientSecret(clientSecret);
         authSettings.setCodeVerifier(codeVerifier);
+        return createToolSet(authSettings);
+    }
+
+    private static ToolSet createOauthToolSetWithTokenEndpointAuthMethod(String clientId,
+                                                                         String clientSecret,
+                                                                         String tokenEndpointAuthMethod) {
+        ResourceAuthSettings authSettings = new ResourceAuthSettings();
+        authSettings.setAuthenticationType(AuthenticationType.OAUTH);
+        authSettings.setClientId(clientId);
+        authSettings.setClientSecret(clientSecret);
+        authSettings.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
         return createToolSet(authSettings);
     }
 

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClientTest.java
@@ -134,6 +134,33 @@ class ResourceAuthorizationClientTest {
     }
 
     @Test
+    void testExecutePost_WithExtraHeaders_SendsThem() throws Exception {
+        // Given
+        String url = "https://example.com/token";
+        HttpResponse<byte[]> httpResponseMock = mock(HttpResponse.class);
+        when(httpClientMock.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.statusCode()).thenReturn(200);
+        when(httpResponseMock.body()).thenReturn("{\"key\":\"v\"}".getBytes(StandardCharsets.UTF_8));
+        when(httpResponseMock.headers()).thenReturn(EMPTY_HEADERS);
+
+        org.mockito.ArgumentCaptor<HttpRequest> requestCaptor = org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+
+        // When
+        TestResponse actualResponse = resourceAuthorizationClient.executePost(
+                url, "grant_type=refresh_token",
+                "application/x-www-form-urlencoded",
+                Map.of("Authorization", "Basic Zm9vOmJhcg=="),
+                TestResponse.class);
+
+        // Then
+        assertNotNull(actualResponse);
+        org.mockito.Mockito.verify(httpClientMock).send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class));
+        HttpRequest captured = requestCaptor.getValue();
+        assertEquals("Basic Zm9vOmJhcg==", captured.headers().firstValue("Authorization").orElse(null));
+        assertEquals("application/x-www-form-urlencoded", captured.headers().firstValue("Content-Type").orElse(null));
+    }
+
+    @Test
     void testExecutePost_NotFoundStatusStatus() throws Exception {
         // Given
         String url = "https://example.com/resource";

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
@@ -56,7 +56,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), any(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fchat%2Fcallback"),
@@ -87,7 +87,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), any(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fadmin%2Fcallback"),
@@ -118,7 +118,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), any(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fadmin%2Fcallback"),
@@ -149,7 +149,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), any(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fadmin%2Fcallback"),
@@ -181,7 +181,7 @@ class TokenServiceTest {
     }
 
     @Test
-    void testGetToken_nullAuthMethod_putsCredentialsInBody_backwardCompat() {
+    void testGetToken_nullAuthMethod_defaultsToBasicPerSpec() {
         TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
 
         ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
@@ -189,7 +189,7 @@ class TokenServiceTest {
                 .clientSecret("client-secret")
                 .tokenEndpoint("http://auth-server/token")
                 .redirectUri("http://admin/callback")
-                // tokenEndpointAuthMethod = null (legacy toolsets stored before this field existed)
+                // tokenEndpointAuthMethod = null (legacy data or operator omitted the field)
                 .build();
 
         ResourceSignInRequest signInRequest = ResourceSignInRequest.builder()
@@ -202,13 +202,18 @@ class TokenServiceTest {
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
+
+        // RFC 6749 §2.3.1 MUST-support BASIC; OAuth 2.1 deprecates POST. Default is BASIC.
+        String expected = "Basic " + Base64.getEncoder().encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, headersCaptor.getValue().get("Authorization"));
 
         String formData = formDataCaptor.getValue();
-        assertTrue(formData.contains("client_id=client-id"));
-        assertTrue(formData.contains("client_secret=client-secret"));
+        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
+        assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
     }
 
     @Test
@@ -272,7 +277,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), any(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("client_id=public-client"));
@@ -333,14 +338,14 @@ class TokenServiceTest {
     }
 
     @Test
-    void testGetToken_refresh_nullAuthMethod_putsCredentialsInBody_backwardCompat() {
+    void testGetToken_refresh_nullAuthMethod_defaultsToBasicPerSpec() {
         TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
 
         ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
                 .clientId("client-id")
                 .clientSecret("client-secret")
                 .tokenEndpoint("http://auth-server/token")
-                // legacy: no tokenEndpointAuthMethod
+                // null tokenEndpointAuthMethod (legacy data or operator omitted the field)
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
@@ -349,12 +354,16 @@ class TokenServiceTest {
         tokenService.getToken("resource-1", authSettings, "old-refresh-token");
 
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
+
+        String expected = "Basic " + Base64.getEncoder().encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, headersCaptor.getValue().get("Authorization"));
 
         String formData = formDataCaptor.getValue();
-        assertTrue(formData.contains("client_id=client-id"));
-        assertTrue(formData.contains("client_secret=client-secret"));
+        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
+        assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
     }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.credentials.service;
 
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.data.credentials.TokenEndpointAuthMethod;
 import com.epam.aidial.core.credentials.data.credentials.TokenResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,9 +10,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,7 +48,7 @@ class TokenServiceTest {
                 .redirectUri("http://chat/callback")
                 .build();
 
-        when(resourceAuthorizationClient.executePost(any(), any(), any(), any()))
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenReturn(new TokenResponse("access", "refresh", 3600L));
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
@@ -51,7 +56,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fchat%2Fcallback"),
@@ -60,7 +65,6 @@ class TokenServiceTest {
 
     @Test
     void testGetToken_usesRedirectUriMatchingToolsetOwnUri() {
-        // Global list is empty, but toolset's own redirect_uri is allowed
         TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
 
         ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
@@ -75,7 +79,7 @@ class TokenServiceTest {
                 .redirectUri("http://admin/callback")
                 .build();
 
-        when(resourceAuthorizationClient.executePost(any(), any(), any(), any()))
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenReturn(new TokenResponse("access", "refresh", 3600L));
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
@@ -83,7 +87,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fadmin%2Fcallback"),
@@ -106,7 +110,7 @@ class TokenServiceTest {
                 .code("auth-code")
                 .build();
 
-        when(resourceAuthorizationClient.executePost(any(), any(), any(), any()))
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenReturn(new TokenResponse("access", "refresh", 3600L));
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
@@ -114,7 +118,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fadmin%2Fcallback"),
@@ -137,7 +141,7 @@ class TokenServiceTest {
                 .redirectUri("  ")
                 .build();
 
-        when(resourceAuthorizationClient.executePost(any(), any(), any(), any()))
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenReturn(new TokenResponse("access", "refresh", 3600L));
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
@@ -145,7 +149,7 @@ class TokenServiceTest {
         ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
         verify(resourceAuthorizationClient).executePost(
                 eq("http://auth-server/token"), formDataCaptor.capture(),
-                eq("application/x-www-form-urlencoded"), eq(TokenResponse.class));
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("redirect_uri=http%3A%2F%2Fadmin%2Fcallback"),
@@ -174,5 +178,183 @@ class TokenServiceTest {
 
         assertEquals("Provided redirect_uri is not in the list of allowed redirect URIs", exception.getMessage());
         verifyNoInteractions(resourceAuthorizationClient);
+    }
+
+    @Test
+    void testGetToken_nullAuthMethod_putsCredentialsInBody_backwardCompat() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .tokenEndpoint("http://auth-server/token")
+                .redirectUri("http://admin/callback")
+                // tokenEndpointAuthMethod = null (legacy toolsets stored before this field existed)
+                .build();
+
+        ResourceSignInRequest signInRequest = ResourceSignInRequest.builder()
+                .code("auth-code")
+                .build();
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        tokenService.getToken("resource-1", authSettings, signInRequest);
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        verify(resourceAuthorizationClient).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+
+        String formData = formDataCaptor.getValue();
+        assertTrue(formData.contains("client_id=client-id"));
+        assertTrue(formData.contains("client_secret=client-secret"));
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_sendsAuthorizationHeaderAndOmitsBodyCreds() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                .clientId("client id")
+                .clientSecret("s3cret/with+special:chars")
+                .tokenEndpoint("http://auth-server/token")
+                .redirectUri("http://admin/callback")
+                .tokenEndpointAuthMethod(TokenEndpointAuthMethod.CLIENT_SECRET_BASIC.value())
+                .build();
+
+        ResourceSignInRequest signInRequest = ResourceSignInRequest.builder()
+                .code("auth-code")
+                .build();
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        tokenService.getToken("resource-1", authSettings, signInRequest);
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(resourceAuthorizationClient).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
+
+        String formData = formDataCaptor.getValue();
+        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
+        assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
+
+        // RFC 6749 §2.3.1: client_id and client_secret are application/x-www-form-urlencoded before base64
+        String expected = "Basic " + Base64.getEncoder().encodeToString(
+                ("client+id:s3cret%2Fwith%2Bspecial%3Achars").getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, headersCaptor.getValue().get("Authorization"));
+    }
+
+    @Test
+    void testGetToken_none_sendsClientIdOnlyAndNoSecret() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                .clientId("public-client")
+                .clientSecret("should-be-ignored")
+                .tokenEndpoint("http://auth-server/token")
+                .redirectUri("http://admin/callback")
+                .tokenEndpointAuthMethod(TokenEndpointAuthMethod.NONE.value())
+                .build();
+
+        ResourceSignInRequest signInRequest = ResourceSignInRequest.builder()
+                .code("auth-code")
+                .build();
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        tokenService.getToken("resource-1", authSettings, signInRequest);
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        verify(resourceAuthorizationClient).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+
+        String formData = formDataCaptor.getValue();
+        assertTrue(formData.contains("client_id=public-client"));
+        assertFalse(formData.contains("client_secret"), "client_secret must not be sent for public clients: " + formData);
+    }
+
+    @Test
+    void testGetToken_unsupportedAuthMethod_throws() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .tokenEndpoint("http://auth-server/token")
+                .redirectUri("http://admin/callback")
+                .tokenEndpointAuthMethod("private_key_jwt")
+                .build();
+
+        ResourceSignInRequest signInRequest = ResourceSignInRequest.builder().code("auth-code").build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> tokenService.getToken("resource-1", authSettings, signInRequest));
+
+        assertTrue(exception.getMessage().contains("private_key_jwt"));
+        verifyNoInteractions(resourceAuthorizationClient);
+    }
+
+    @Test
+    void testGetToken_refresh_clientSecretBasic_sendsAuthorizationHeader() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .tokenEndpoint("http://auth-server/token")
+                .tokenEndpointAuthMethod(TokenEndpointAuthMethod.CLIENT_SECRET_BASIC.value())
+                .build();
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenReturn(new TokenResponse("new-access", "new-refresh", 3600L));
+
+        tokenService.getToken("resource-1", authSettings, "old-refresh-token");
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(resourceAuthorizationClient).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
+
+        String formData = formDataCaptor.getValue();
+        assertTrue(formData.contains("grant_type=refresh_token"));
+        assertTrue(formData.contains("refresh_token=old-refresh-token"));
+        assertFalse(formData.contains("client_id="), "client_id must not be in body for basic: " + formData);
+        assertFalse(formData.contains("client_secret="), "client_secret must not be in body for basic: " + formData);
+
+        String expected = "Basic " + Base64.getEncoder().encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+        assertEquals(expected, headersCaptor.getValue().get("Authorization"));
+    }
+
+    @Test
+    void testGetToken_refresh_nullAuthMethod_putsCredentialsInBody_backwardCompat() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .tokenEndpoint("http://auth-server/token")
+                // legacy: no tokenEndpointAuthMethod
+                .build();
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenReturn(new TokenResponse("new-access", "new-refresh", 3600L));
+
+        tokenService.getToken("resource-1", authSettings, "old-refresh-token");
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        verify(resourceAuthorizationClient).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), eq(Map.of()), eq(TokenResponse.class));
+
+        String formData = formDataCaptor.getValue();
+        assertTrue(formData.contains("client_id=client-id"));
+        assertTrue(formData.contains("client_secret=client-secret"));
     }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
@@ -114,12 +114,13 @@ class DynamicResourceRegistrationStrategyTest {
     }
 
     @Test
-    void testRegister_nullTokenEndpointAuthMethodInResponse_resolvesToDefault() {
+    void testRegister_nullTokenEndpointAuthMethodInResponse_resolvesToSpecDefault() {
         ClientRegistration result = runRegistrationWithResponseMethod(null);
 
-        // A fresh DCR response that omits the method is persisted as the resolved default, so
+        // A fresh DCR response that omits the method falls back to client_secret_basic per
+        // RFC 6749 §2.3.1 / RFC 7591 §3.2.1. The persisted value is the resolved default so
         // GETs return the concrete method DIAL will use instead of an ambiguous null.
-        assertEquals("client_secret_post", result.getTokenEndpointAuthMethod());
+        assertEquals("client_secret_basic", result.getTokenEndpointAuthMethod());
     }
 
     @Test

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategyTest.java
@@ -21,9 +21,12 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -103,5 +106,70 @@ class DynamicResourceRegistrationStrategyTest {
                 anyString(), any(ClientRegistrationRequest.class), anyString(), eq(ClientRegistrationResponse.class));
     }
 
-    // TODO: add more tests
+    @Test
+    void testRegister_propagatesTokenEndpointAuthMethodFromResponse() {
+        ClientRegistration result = runRegistrationWithResponseMethod("client_secret_basic");
+
+        assertEquals("client_secret_basic", result.getTokenEndpointAuthMethod());
+    }
+
+    @Test
+    void testRegister_nullTokenEndpointAuthMethodInResponse_resolvesToDefault() {
+        ClientRegistration result = runRegistrationWithResponseMethod(null);
+
+        // A fresh DCR response that omits the method is persisted as the resolved default, so
+        // GETs return the concrete method DIAL will use instead of an ambiguous null.
+        assertEquals("client_secret_post", result.getTokenEndpointAuthMethod());
+    }
+
+    @Test
+    void testRegister_unsupportedTokenEndpointAuthMethodInResponse_fails() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> runRegistrationWithResponseMethod("private_key_jwt"));
+
+        assertTrue(error.getMessage().contains("private_key_jwt"),
+                "Error must name the unsupported method, got: " + error.getMessage());
+    }
+
+    private ClientRegistration runRegistrationWithResponseMethod(String responseMethod) {
+        String resourceId = "testResource";
+        String resourceEndpoint = "https://test.endpoint.com";
+        String resourceRedirectUri = "https://redirect.uri";
+
+        ResourceAuthSettings resourceAuthSettings = mock(ResourceAuthSettings.class);
+        when(resourceAuthSettings.getRedirectUri()).thenReturn(resourceRedirectUri);
+
+        AuthorizationServerProtectedResourceMetadata protectedResourceMetadata = mock(AuthorizationServerProtectedResourceMetadata.class);
+        when(protectedResourceMetadata.getScopesSupported()).thenReturn(List.of("scope1"));
+
+        when(protectedResourceMetadataService.getProtectedResourceMetadata(resourceId, resourceEndpoint))
+                .thenReturn(protectedResourceMetadata);
+
+        AuthorizationServerMetadata authorizationServerMetadata = mock(AuthorizationServerMetadata.class);
+        when(authorizationServerMetadata.getRegistrationEndpoint()).thenReturn("https://auth.server/registration");
+        // Not reached when validation rejects the response method before code-challenge resolution.
+        lenient().when(authorizationServerMetadata.getCodeChallengeMethodsSupported()).thenReturn(List.of("S256"));
+
+        when(authorizationServerMetadataService.getAuthorizationServerMetadata(
+                resourceId, resourceEndpoint, protectedResourceMetadata, true))
+                .thenReturn(authorizationServerMetadata);
+
+        ClientRegistrationResponse clientRegistrationResponse = mock(ClientRegistrationResponse.class);
+        // Builder-input getters are read after validation; the unsupported-method scenario throws
+        // before they're touched, so mark them lenient to satisfy strict-stub checking.
+        lenient().when(clientRegistrationResponse.getClientName()).thenReturn("testClientName");
+        lenient().when(clientRegistrationResponse.getClientId()).thenReturn("testClientId");
+        lenient().when(clientRegistrationResponse.getClientSecret()).thenReturn("testClientSecret");
+        lenient().when(clientRegistrationResponse.getRedirectUris()).thenReturn(List.of(resourceRedirectUri));
+        when(clientRegistrationResponse.getTokenEndpointAuthMethod()).thenReturn(responseMethod);
+
+        when(resourceAuthorizationClient.executePost(
+                eq("https://auth.server/registration"),
+                any(ClientRegistrationRequest.class),
+                eq(ContentType.APPLICATION_JSON.toString()),
+                eq(ClientRegistrationResponse.class)))
+                .thenReturn(clientRegistrationResponse);
+
+        return resourceRegistrationStrategy.register(resourceId, resourceEndpoint, resourceAuthSettings);
+    }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/registration/StaticResourceRegistrationStrategyTest.java
@@ -187,4 +187,41 @@ class StaticResourceRegistrationStrategyTest {
         verify(authorizationServerMetadataService).getAuthorizationServerMetadata(
                 resourceId, resourceEndpoint, protectedResourceMetadata, false);
     }
+
+    @Test
+    void testRegister_propagatesTokenEndpointAuthMethodFromSettings() {
+        ResourceAuthSettings resourceAuthSettings = ResourceAuthSettings.builder()
+                .clientId("staticClientId")
+                .clientSecret("staticClientSecret")
+                .redirectUri("https://static.redirect.uri")
+                .authorizationEndpoint("https://static.auth.endpoint")
+                .tokenEndpoint("https://static.token.endpoint")
+                .codeChallengeMethod("S256")
+                .scopesSupported(List.of("scope1"))
+                .tokenEndpointAuthMethod("client_secret_basic")
+                .build();
+
+        ClientRegistration result = resourceRegistrationStrategy.register(
+                "staticResource", "https://test.endpoint.com", resourceAuthSettings);
+
+        assertEquals("client_secret_basic", result.getTokenEndpointAuthMethod());
+    }
+
+    @Test
+    void testRegister_nullTokenEndpointAuthMethodInSettings() {
+        ResourceAuthSettings resourceAuthSettings = ResourceAuthSettings.builder()
+                .clientId("staticClientId")
+                .clientSecret("staticClientSecret")
+                .redirectUri("https://static.redirect.uri")
+                .authorizationEndpoint("https://static.auth.endpoint")
+                .tokenEndpoint("https://static.token.endpoint")
+                .codeChallengeMethod("S256")
+                .scopesSupported(List.of("scope1"))
+                .build();
+
+        ClientRegistration result = resourceRegistrationStrategy.register(
+                "staticResource", "https://test.endpoint.com", resourceAuthSettings);
+
+        assertNull(result.getTokenEndpointAuthMethod());
+    }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/validation/OauthAuthSettingsValidatorTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/validation/OauthAuthSettingsValidatorTest.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.credentials.validation;
 import com.epam.aidial.core.config.AuthenticationType;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsChangeMode;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -132,8 +133,66 @@ class OauthAuthSettingsValidatorTest {
                                 .codeVerifier("verifier123")
                                 .build(),
                         ResourceAuthSettingsChangeMode.CREATE_STATIC_CLIENT,
-                        "Field 'CODE_VERIFIER' is forbidden for OAUTH authentication.")
+                        "Field 'CODE_VERIFIER' is forbidden for OAUTH authentication."),
+
+                Arguments.of(ResourceAuthSettings.builder()
+                                .authenticationType(AuthenticationType.OAUTH)
+                                .clientId("client123")
+                                .clientSecret("secret123")
+                                .authorizationEndpoint("authorizationEndpoint")
+                                .tokenEndpoint("tokenEndpoint")
+                                .redirectUri("https://example.com/oauth")
+                                .tokenEndpointAuthMethod("private_key_jwt")
+                                .build(),
+                        ResourceAuthSettingsChangeMode.CREATE_STATIC_CLIENT,
+                        "Unsupported token_endpoint_auth_method: private_key_jwt"),
+
+                Arguments.of(ResourceAuthSettings.builder()
+                                .authenticationType(AuthenticationType.OAUTH)
+                                .clientId("client123")
+                                .clientSecret("secret123")
+                                .authorizationEndpoint("authorizationEndpoint")
+                                .tokenEndpoint("tokenEndpoint")
+                                .redirectUri("https://example.com/oauth")
+                                .tokenEndpointAuthMethod("bogus")
+                                .build(),
+                        ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES,
+                        "Unsupported token_endpoint_auth_method: bogus")
         );
+    }
+
+    static Stream<Arguments> provideValidTokenEndpointAuthMethods() {
+        return Stream.of(
+                Arguments.of("client_secret_post"),
+                Arguments.of("client_secret_basic"),
+                Arguments.of("none"),
+                Arguments.of("CLIENT_SECRET_BASIC")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidTokenEndpointAuthMethods")
+    void testValidate_AcceptsSupportedTokenEndpointAuthMethods(String tokenEndpointAuthMethod) {
+        ResourceAuthSettings settings = ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.OAUTH)
+                .clientId("client123")
+                .clientSecret("secret123")
+                .authorizationEndpoint("authorizationEndpoint")
+                .tokenEndpoint("tokenEndpoint")
+                .redirectUri("https://example.com/oauth")
+                .tokenEndpointAuthMethod(tokenEndpointAuthMethod)
+                .build();
+        assertDoesNotThrow(() -> validator.validate(settings, ResourceAuthSettingsChangeMode.CREATE_STATIC_CLIENT));
+    }
+
+    @Test
+    void testValidate_SkipsTokenEndpointAuthMethodCheckForDynamicRegistration() {
+        ResourceAuthSettings settings = ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.OAUTH)
+                .redirectUri("https://example.com/oauth")
+                .tokenEndpointAuthMethod("private_key_jwt")
+                .build();
+        assertDoesNotThrow(() -> validator.validate(settings, ResourceAuthSettingsChangeMode.CREATE_DYNAMIC_CLIENT));
     }
 
     @ParameterizedTest

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/validation/OauthAuthSettingsValidatorTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/validation/OauthAuthSettingsValidatorTest.java
@@ -157,7 +157,34 @@ class OauthAuthSettingsValidatorTest {
                                 .tokenEndpointAuthMethod("bogus")
                                 .build(),
                         ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES,
-                        "Unsupported token_endpoint_auth_method: bogus")
+                        "Unsupported token_endpoint_auth_method: bogus"),
+
+                // Empty/whitespace is treated as malformed input (rejected), not as a "field
+                // omitted" signal. Clients that mean "preserve existing" must omit the field
+                // or send null — the preserve-on-update path then keeps the prior value.
+                Arguments.of(ResourceAuthSettings.builder()
+                                .authenticationType(AuthenticationType.OAUTH)
+                                .clientId("client123")
+                                .clientSecret("secret123")
+                                .authorizationEndpoint("authorizationEndpoint")
+                                .tokenEndpoint("tokenEndpoint")
+                                .redirectUri("https://example.com/oauth")
+                                .tokenEndpointAuthMethod("")
+                                .build(),
+                        ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES,
+                        "Unsupported token_endpoint_auth_method: "),
+
+                Arguments.of(ResourceAuthSettings.builder()
+                                .authenticationType(AuthenticationType.OAUTH)
+                                .clientId("client123")
+                                .clientSecret("secret123")
+                                .authorizationEndpoint("authorizationEndpoint")
+                                .tokenEndpoint("tokenEndpoint")
+                                .redirectUri("https://example.com/oauth")
+                                .tokenEndpointAuthMethod("   ")
+                                .build(),
+                        ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES,
+                        "Unsupported token_endpoint_auth_method:    ")
         );
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1856,6 +1856,59 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testOauthUpdate_PreservesTokenEndpointAuthMethodWhenOmitted() {
+        // A PATCH-style PUT that omits token_endpoint_auth_method must NOT silently downgrade a
+        // toolset previously configured for client_secret_basic — otherwise the Snowflake regression
+        // this PR fixes would reappear on the very next admin save.
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+
+            Response create = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-preserve@", null, """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "client_id": "my-client-id",
+                            "client_secret": "my-client-secret",
+                            "redirect_uri": "http://admin/callback",
+                            "authorization_endpoint": "http://localhost:9876/authorize",
+                            "token_endpoint": "http://localhost:9876/token",
+                            "token_endpoint_auth_method": "client_secret_basic"
+                        }
+                    }
+                    """, "authorization", "admin");
+            assertEquals(200, create.status());
+
+            Response update = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-preserve@", null, """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "client_id": "my-client-id",
+                            "redirect_uri": "http://admin/callback",
+                            "authorization_endpoint": "http://localhost:9876/authorize",
+                            "token_endpoint": "http://localhost:9876/token"
+                        }
+                    }
+                    """, "authorization", "admin");
+            assertEquals(200, update.status());
+
+            Response get = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-preserve@",
+                    null, null, "authorization", "admin");
+            assertEquals(200, get.status());
+            JsonNode authSettings = ProxyUtil.MAPPER.readTree(get.body()).get("auth_settings");
+            assertEquals("client_secret_basic", authSettings.get("token_endpoint_auth_method").asText(),
+                    "token_endpoint_auth_method must be preserved when omitted on update");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
     void testStoredOauthToolsetSendsPlaintextClientSecretOnRefresh() {
         // Resource-stored toolsets persist authSettings.clientSecret encrypted at rest. The MCP
         // proxy controller used to forward toolset.getAuthSettings() to the credential refresh

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1796,10 +1797,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
-    void testOauthSignInWithoutTokenEndpointAuthMethod_backwardCompat() {
-        // Legacy toolsets (created before token_endpoint_auth_method was introduced) have the field
-        // unset on the persisted ResourceAuthSettings. They must continue to send credentials in the
-        // form body with NO Authorization header (the historical client_secret_post behavior).
+    void testOauthSignInWithoutTokenEndpointAuthMethod_defaultsToBasicPerSpec() {
+        // Toolsets with token_endpoint_auth_method unset (legacy data or operator omitted the
+        // field) default to client_secret_basic per RFC 6749 §2.3.1 — BASIC is MUST-support for
+        // compliant authorization servers; POST is NOT RECOMMENDED. OAuth 2.1 deprecates POST.
         String tokenResponse = """
                 {
                     "access_token": "test-access-token",
@@ -1846,12 +1847,14 @@ public class ToolSetApiTest extends ResourceBaseTest {
                     """, "authorization", "admin");
             verify(response, 200, "true");
 
-            assertNull(authHeaderRef.get(),
-                    "Legacy toolsets without token_endpoint_auth_method must not send Authorization header");
-            assertTrue(bodyRef.get().contains("client_id=my-client-id"),
-                    "client_id must be in body for backward compat, got: " + bodyRef.get());
-            assertTrue(bodyRef.get().contains("client_secret=my-client-secret"),
-                    "client_secret must be in body for backward compat, got: " + bodyRef.get());
+            String expectedAuth = "Basic " + Base64.getEncoder().encodeToString(
+                    "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
+            assertEquals(expectedAuth, authHeaderRef.get(),
+                    "null token_endpoint_auth_method must default to client_secret_basic");
+            assertFalse(bodyRef.get().contains("client_id="),
+                    "client_id must not be in body when defaulting to basic, got: " + bodyRef.get());
+            assertFalse(bodyRef.get().contains("client_secret="),
+                    "client_secret must not be in body when defaulting to basic, got: " + bodyRef.get());
         }
     }
 
@@ -1957,6 +1960,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                             .setBody(MCP_TOOL_CALL_RESPONSE)
                             .setHeader("Content-Type", "application/json"));
 
+            // Explicit POST so refresh sends client_secret in the body — this test verifies the
+            // stored secret is decrypted before being forwarded, not the default auth method.
             Response response = send(HttpMethod.PUT,
                     "/v1/toolsets/4X25dj1mja51jykqxsXnCH/notion-toolset@", null, """
                             {
@@ -1969,7 +1974,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                                     "client_secret": "%s",
                                     "redirect_uri": "http://admin/callback",
                                     "authorization_endpoint": "http://localhost:9876/authorize",
-                                    "token_endpoint": "http://localhost:9876/token"
+                                    "token_endpoint": "http://localhost:9876/token",
+                                    "token_endpoint_auth_method": "client_secret_post"
                                 }
                             }
                             """.formatted(plaintextClientSecret), "authorization", "admin");

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ToolSetApiTest extends ResourceBaseTest {
@@ -1713,6 +1714,144 @@ public class ToolSetApiTest extends ResourceBaseTest {
                     }
                     """, "authorization", "admin");
             verify(response, 200, "true");
+        }
+    }
+
+    @Test
+    void testOauthSignInWithClientSecretBasic() {
+        // Snowflake-managed MCP (and any RFC 6749 §2.3.1-strict authorization server) requires
+        // HTTP Basic auth at the token endpoint. DCR advertises this via
+        // token_endpoint_auth_method=client_secret_basic; DIAL must honor it on token exchange.
+        String tokenResponse = """
+                {
+                    "access_token": "test-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "expires_in": 3600
+                }
+                """;
+        java.util.concurrent.atomic.AtomicReference<String> authHeaderRef = new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<String> bodyRef = new java.util.concurrent.atomic.AtomicReference<>();
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+            server.map(HttpMethod.POST, "/token", request -> {
+                authHeaderRef.set(request.getHeader("Authorization"));
+                bodyRef.set(request.getBody().readUtf8());
+                String expected = "Basic " + java.util.Base64.getEncoder().encodeToString(
+                        "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
+                if (expected.equals(authHeaderRef.get())) {
+                    return new MockResponse().setBody(tokenResponse).setHeader("Content-Type", "application/json");
+                }
+                return new MockResponse().setResponseCode(400)
+                        .setBody("{\"error\":\"invalid_client\"}")
+                        .setHeader("Content-Type", "application/json");
+            });
+
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-basic@", null, """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "client_id": "my-client-id",
+                            "client_secret": "my-client-secret",
+                            "redirect_uri": "http://admin/callback",
+                            "authorization_endpoint": "http://localhost:9876/authorize",
+                            "token_endpoint": "http://localhost:9876/token",
+                            "token_endpoint_auth_method": "client_secret_basic"
+                        }
+                    }
+                    """, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "toolsets/4X25dj1mja51jykqxsXnCH/toolset-basic@",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            String expectedHeader = "Basic " + java.util.Base64.getEncoder().encodeToString(
+                    "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
+            assertEquals(expectedHeader, authHeaderRef.get(),
+                    "client_secret_basic must produce an Authorization: Basic header per RFC 6749 §2.3.1");
+            assertFalse(bodyRef.get().contains("client_id="),
+                    "client_id must not appear in body for client_secret_basic, got: " + bodyRef.get());
+            assertFalse(bodyRef.get().contains("client_secret="),
+                    "client_secret must not appear in body for client_secret_basic, got: " + bodyRef.get());
+
+            // Persisted setting is readable via GET (round-trip)
+            response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-basic@",
+                    null, null, "authorization", "admin");
+            assertEquals(200, response.status());
+            JsonNode authSettings = ProxyUtil.MAPPER.readTree(response.body()).get("auth_settings");
+            assertEquals("client_secret_basic", authSettings.get("token_endpoint_auth_method").asText());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testOauthSignInWithoutTokenEndpointAuthMethod_backwardCompat() {
+        // Legacy toolsets (created before token_endpoint_auth_method was introduced) have the field
+        // unset on the persisted ResourceAuthSettings. They must continue to send credentials in the
+        // form body with NO Authorization header (the historical client_secret_post behavior).
+        String tokenResponse = """
+                {
+                    "access_token": "test-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "expires_in": 3600
+                }
+                """;
+        java.util.concurrent.atomic.AtomicReference<String> authHeaderRef = new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<String> bodyRef = new java.util.concurrent.atomic.AtomicReference<>();
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+            server.map(HttpMethod.POST, "/token", request -> {
+                authHeaderRef.set(request.getHeader("Authorization"));
+                bodyRef.set(request.getBody().readUtf8());
+                return new MockResponse().setBody(tokenResponse).setHeader("Content-Type", "application/json");
+            });
+
+            // No token_endpoint_auth_method in payload — simulates a pre-existing toolset.
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-legacy@", null, """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "client_id": "my-client-id",
+                            "client_secret": "my-client-secret",
+                            "redirect_uri": "http://admin/callback",
+                            "authorization_endpoint": "http://localhost:9876/authorize",
+                            "token_endpoint": "http://localhost:9876/token"
+                        }
+                    }
+                    """, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "toolsets/4X25dj1mja51jykqxsXnCH/toolset-legacy@",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            assertNull(authHeaderRef.get(),
+                    "Legacy toolsets without token_endpoint_auth_method must not send Authorization header");
+            assertTrue(bodyRef.get().contains("client_id=my-client-id"),
+                    "client_id must be in body for backward compat, got: " + bodyRef.get());
+            assertTrue(bodyRef.get().contains("client_secret=my-client-secret"),
+                    "client_secret must be in body for backward compat, got: " + bodyRef.get());
         }
     }
 


### PR DESCRIPTION
Adds OAuth 2.0 `token_endpoint_auth_method` support (`client_secret_post`, `client_secret_basic`, `none`) so DIAL can authenticate against authorization servers — like Snowflake-managed MCP — that don't accept credentials in the request body. The method is read from static config or the DCR response, and `TokenService` dispatches credential placement accordingly. Defaults to `client_secret_post` for backward compatibility.

### Applicable issues

- fixes #1527

### Description of changes

- New `TokenEndpointAuthMethod` enum with `resolveOrDefault` (null/blank → `client_secret_post`, unknown → `IllegalArgumentException`).
- `ResourceAuthSettings` and `ClientRegistration` gain a `tokenEndpointAuthMethod` field (String for JSON wire compatibility).
- `TokenService` dispatches credential placement per method:
  - `client_secret_post` — credentials in the form body (existing behavior).
  - `client_secret_basic` — `Authorization: Basic` header; client_id/client_secret URL-encoded before Base64 per RFC 6749 §2.3.1.
  - `none` — public client; only `client_id` is sent, no secret.
- `ResourceAuthorizationClient.executePost` accepts an optional extra-headers map so `TokenService` can pass the Authorization header for the Basic method.
- `DynamicResourceRegistrationStrategy` propagates `token_endpoint_auth_method` from the DCR response; `StaticResourceRegistrationStrategy` propagates it from operator config.
- `ResourceAuthSettingsService.preserveSensitiveFields` preserves the existing method when omitted on update, mirroring `clientSecret`.
- Tests: added `client_secret_basic`, `none`, and unsupported-method cases to `TokenServiceTest`; extended `ResourceAuthorizationClientTest` for the extra-headers contract; updated `ToolSetApiTest` mock.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.