### PR TITLE
feat: auto-sharing for prompts #1548

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/ApiKeyData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ApiKeyData.java
@@ -49,6 +49,8 @@ public class ApiKeyData {
     @JsonAlias({"attachedToolSets", "attachedDeployments"})
     private Map<String, AutoSharedData> attachedDeployments = new HashMap<>();
     private Map<String, AutoSharedData> attachedResourceCredentials = new HashMap<>();
+    // list of prompts included into application properties
+    private Map<String, AutoSharedData> attachedPrompts = new HashMap<>();
     // deployment name of the source(application/model/interceptor) associated with the current request
     private String sourceDeployment;
     // Execution path of the root request

--- a/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
@@ -43,6 +43,7 @@ public class AutoShareDeploymentFn extends BaseRequestFunction<RequestObject> {
         Deployment deployment = proxy.getDeploymentService().findDeployment(context, initialDeployment);
         if (deployment instanceof Application app && app.hasApplicationTypeSchemaId()) {
             shareApplicationFiles(app);
+            shareApplicationPrompts(app);
             shareApplicationDeployments(app);
         }
         return false;

--- a/server/src/main/java/com/epam/aidial/core/server/function/BaseRequestFunction.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/BaseRequestFunction.java
@@ -59,6 +59,23 @@ public abstract class BaseRequestFunction<T> extends BaseFunction<T, Boolean> {
         }
     }
 
+    void shareApplicationPrompts(Application application) {
+        List<ResourceDescriptor> prompts = proxy.getApplicationSchemaService().getPrompts(application);
+        ApiKeyData apiKeyData = context.getProxyApiKeyData();
+        AccessService accessService = proxy.getAccessService();
+        for (ResourceDescriptor resource : prompts) {
+            if (resource.isPublic()) {
+                continue;
+            }
+            String resourceUrl = resource.getUrl();
+            if (accessService.hasReadAccess(resource, context)) {
+                apiKeyData.getAttachedPrompts().put(resourceUrl, new AutoSharedData(ResourceAccessType.READ_ONLY));
+            } else {
+                throw new HttpException(HttpStatus.FORBIDDEN, "Access denied to the prompt %s".formatted(resourceUrl));
+            }
+        }
+    }
+
     void shareApplicationFiles(Application application) {
         List<ResourceDescriptor> files = proxy.getApplicationSchemaService().getFiles(application);
         ApiKeyData apiKeyData = context.getProxyApiKeyData();

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
@@ -28,6 +28,7 @@ public class CollectRequestApplicationFilesFn extends BaseRequestFunction<Reques
                 throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR, "Typed application's properties not set");
             }
             shareApplicationFiles(application);
+            shareApplicationPrompts(application);
             return false;
         } catch (HttpException ex) {
             throw ex;

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -212,6 +212,11 @@ public class AccessService {
                 result.put(resource, autoSharedData.accessTypes());
                 continue;
             }
+            autoSharedData = apiKeyData.getAttachedPrompts().get(resourceUrl);
+            if (autoSharedData != null) {
+                result.put(resource, autoSharedData.accessTypes());
+                continue;
+            }
             autoSharedData = apiKeyData.getAttachedDeployments().get(resourceUrl);
             if (autoSharedData != null) {
                 result.put(resource, autoSharedData.accessTypes());

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
@@ -410,6 +410,40 @@ public class ApplicationSchemaService {
         }
     }
 
+    public List<ResourceDescriptor> getPrompts(Application application) {
+        return getPrompts(application, ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ResourceDescriptor> getPrompts(Application application, ListCollector.ResourceCollectorType collectorName, boolean forceReload) {
+        try {
+            ListCollector<String> propsCollector = (ListCollector<String>) getCollector(application, collectorName.getValue(), forceReload);
+            if (propsCollector == null) {
+                return Collections.emptyList();
+            }
+            List<ResourceDescriptor> result = new ArrayList<>();
+            for (String item : propsCollector.collect()) {
+                try {
+                    ResourceDescriptor descriptor = ResourceDescriptorFactory.fromAnyUrl(item, encryptionService);
+                    if (descriptor.getType() != ResourceTypes.PROMPT) {
+                        continue;
+                    }
+                    if (descriptor.isFolder() || !resourceService.hasResource(descriptor)) {
+                        throw new ApplicationTypeResourceException("Prompt listed as dependent to the application is not found or inaccessible", item);
+                    }
+                    result.add(descriptor);
+                } catch (IllegalArgumentException e) {
+                    // ignore resource to be defined in DIAL config
+                }
+            }
+            return result;
+        } catch (ApplicationTypeSchemaValidationException | ApplicationTypeResourceException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApplicationTypeSchemaProcessingException("Failed to obtain list of prompts attached to the custom app", e);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     public List<ResourceDescriptor> getDeployments(Application application) {
         try {

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
@@ -373,82 +373,31 @@ public class ApplicationSchemaService {
     }
 
     public List<ResourceDescriptor> getServerFiles(Application application) {
-        return getFiles(application, ListCollector.ResourceCollectorType.ONLY_SERVER_RESOURCES, false);
+        return getApplicationResources(application, Set.of(ResourceTypes.FILE),
+                ListCollector.ResourceCollectorType.ONLY_SERVER_RESOURCES, false);
     }
 
     public List<ResourceDescriptor> getFiles(Application application) {
-        return getFiles(application, ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<ResourceDescriptor> getFiles(Application application, ListCollector.ResourceCollectorType collectorName, boolean forceReload) {
-        try {
-            ListCollector<String> propsCollector = (ListCollector<String>) getCollector(application, collectorName.getValue(), forceReload);
-            if (propsCollector == null) {
-                return Collections.emptyList();
-            }
-            List<ResourceDescriptor> result = new ArrayList<>();
-            for (String item : propsCollector.collect()) {
-                try {
-                    ResourceDescriptor descriptor = ResourceDescriptorFactory.fromAnyUrl(item, encryptionService);
-                    if (descriptor.getType() != ResourceTypes.FILE) {
-                        continue;
-                    }
-                    if (!descriptor.isFolder() && !resourceService.hasResource(descriptor)) {
-                        throw new ApplicationTypeResourceException("Resource listed as dependent to the application not found or inaccessible", item);
-                    }
-                    result.add(descriptor);
-                } catch (IllegalArgumentException e) {
-                    // ignore resource to be defined in DIAL config
-                }
-            }
-            return result;
-        } catch (ApplicationTypeSchemaValidationException | ApplicationTypeResourceException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ApplicationTypeSchemaProcessingException("Failed to obtain list of files attached to the custom app", e);
-        }
+        return getApplicationResources(application, Set.of(ResourceTypes.FILE),
+                ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
     }
 
     public List<ResourceDescriptor> getPrompts(Application application) {
-        return getPrompts(application, ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
+        return getApplicationResources(application, Set.of(ResourceTypes.PROMPT),
+                ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
     }
 
-    @SuppressWarnings("unchecked")
-    private List<ResourceDescriptor> getPrompts(Application application, ListCollector.ResourceCollectorType collectorName, boolean forceReload) {
-        try {
-            ListCollector<String> propsCollector = (ListCollector<String>) getCollector(application, collectorName.getValue(), forceReload);
-            if (propsCollector == null) {
-                return Collections.emptyList();
-            }
-            List<ResourceDescriptor> result = new ArrayList<>();
-            for (String item : propsCollector.collect()) {
-                try {
-                    ResourceDescriptor descriptor = ResourceDescriptorFactory.fromAnyUrl(item, encryptionService);
-                    if (descriptor.getType() != ResourceTypes.PROMPT) {
-                        continue;
-                    }
-                    if (descriptor.isFolder() || !resourceService.hasResource(descriptor)) {
-                        throw new ApplicationTypeResourceException("Prompt listed as dependent to the application is not found or inaccessible", item);
-                    }
-                    result.add(descriptor);
-                } catch (IllegalArgumentException e) {
-                    // ignore resource to be defined in DIAL config
-                }
-            }
-            return result;
-        } catch (ApplicationTypeSchemaValidationException | ApplicationTypeResourceException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ApplicationTypeSchemaProcessingException("Failed to obtain list of prompts attached to the custom app", e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
     public List<ResourceDescriptor> getDeployments(Application application) {
+        return getApplicationResources(application, Set.of(ResourceTypes.APPLICATION, ResourceTypes.TOOL_SET),
+                ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ResourceDescriptor> getApplicationResources(Application application, Set<ResourceTypes> resourceTypes,
+                                                             ListCollector.ResourceCollectorType collectorName, boolean forceReload) {
         try {
             ListCollector<String> propsCollector = (ListCollector<String>) getCollector(application,
-                    ListCollector.ResourceCollectorType.ALL_RESOURCES.getValue(), false);
+                    collectorName.getValue(), forceReload);
             if (propsCollector == null) {
                 return Collections.emptyList();
             }
@@ -457,9 +406,9 @@ public class ApplicationSchemaService {
                 try {
                     ResourceDescriptor descriptor = ResourceDescriptorFactory.fromAnyUrl(item, encryptionService);
                     ResourceType type = descriptor.getType();
-                    if (type == ResourceTypes.TOOL_SET || type == ResourceTypes.APPLICATION) {
-                        if (descriptor.isFolder() || !resourceService.hasResource(descriptor)) {
-                            throw new ApplicationTypeResourceException("Deployment listed as dependent to the application is not found or inaccessible", item);
+                    if (resourceTypes.contains(type)) {
+                        if (!descriptor.isFolder() && !resourceService.hasResource(descriptor)) {
+                            throw new ApplicationTypeResourceException("Resource listed as dependent to the application is not found", item);
                         }
                         result.add(descriptor);
                     }
@@ -471,7 +420,7 @@ public class ApplicationSchemaService {
         } catch (ApplicationTypeSchemaValidationException | ApplicationTypeResourceException e) {
             throw e;
         } catch (Exception e) {
-            throw new ApplicationTypeSchemaProcessingException("Failed to obtain list of toolsets attached to the custom app", e);
+            throw new ApplicationTypeSchemaProcessingException("Failed to obtain list of resources attached to the custom app", e);
         }
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
@@ -178,6 +178,49 @@ public class CollectRequestApplicationFilesFnTest {
     }
 
     @Test
+    void apply_appendsPromptsToApiKeyData_whenApplicationHasCustomSchemaId() {
+        String promptUrl = "prompts/bucket/my-prompt";
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        Map<String, Object> customProps = new HashMap<>();
+        customProps.put("prompt", Map.of("name", "my-prompt", "dial_id", promptUrl));
+        application.setApplicationProperties(customProps);
+        when(accessService.hasReadAccess(any(), any())).thenReturn(true);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+        when(proxy.getApplicationSchemaService()).thenReturn(applicationSchemaService);
+        when(proxy.getAccessService()).thenReturn(accessService);
+        ResourceDescriptor prompt = mock(ResourceDescriptor.class);
+        when(prompt.getUrl()).thenReturn(promptUrl);
+        when(applicationSchemaService.getPrompts(eq(application))).thenReturn(List.of(prompt));
+
+        boolean result = fn.apply(request);
+
+        assertFalse(result);
+        assertNotNull(apiKeyData.getAttachedPrompts().get(promptUrl));
+        assertEquals(1, apiKeyData.getAttachedPrompts().size());
+    }
+
+    @Test
+    void apply_throws_whenAccessServiceHasNoReadAccessToPrompt() {
+        String promptUrl = "prompts/bucket/my-prompt";
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        Map<String, Object> customProps = new HashMap<>();
+        customProps.put("prompt", Map.of("name", "my-prompt", "dial_id", promptUrl));
+        application.setApplicationProperties(customProps);
+        when(proxy.getApplicationSchemaService()).thenReturn(applicationSchemaService);
+        when(proxy.getAccessService()).thenReturn(accessService);
+        ResourceDescriptor prompt = mock(ResourceDescriptor.class);
+        when(applicationSchemaService.getPrompts(eq(application))).thenReturn(List.of(prompt));
+        when(accessService.hasReadAccess(any(), any())).thenReturn(false);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+
+        Assertions.assertThrows(HttpException.class, () -> fn.apply(request));
+    }
+
+    @Test
     void apply_throws_whenAccessServiceHasNoReadAccess() {
         when(context.getProxyApiKeyData()).thenReturn(new ApiKeyData());
         String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -687,11 +687,11 @@ public class ApplicationSchemaServiceTest {
         List<ResourceDescriptor> result = service.getPrompts(application);
 
         Assertions.assertEquals(1, result.size());
-        Assertions.assertEquals("my-prompt", result.get(0).getName());
+        Assertions.assertEquals("my-prompt", result.getFirst().getName());
     }
 
     @Test
-    public void getPrompts_throws_whenPromptUrlIsFolder() {
+    public void getPrompts_whenPromptUrlIsFolder() {
         customProperties.put("toolset", Map.of("name", "my-prompt", "dial_id", "prompts/bucket/my-folder/"));
         when(configStore.get()).thenReturn(config);
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
@@ -699,7 +699,10 @@ public class ApplicationSchemaServiceTest {
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
 
-        Assertions.assertThrows(ApplicationTypeResourceException.class, () -> service.getPrompts(application));
+        List<ResourceDescriptor> result = service.getPrompts(application);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("my-folder", result.getFirst().getName());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -675,6 +675,43 @@ public class ApplicationSchemaServiceTest {
     }
 
     @Test
+    public void getPrompts_returnsListOfPrompts_whenSchemaHasDialResourcePrompts() {
+        customProperties.put("toolset", Map.of("name", "my-prompt", "dial_id", "prompts/bucket/my-prompt"));
+        when(configStore.get()).thenReturn(config);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+        application.setApplicationProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        when(resourceService.hasResource(any())).thenReturn(true);
+        when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
+
+        List<ResourceDescriptor> result = service.getPrompts(application);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("my-prompt", result.get(0).getName());
+    }
+
+    @Test
+    public void getPrompts_throws_whenPromptUrlIsFolder() {
+        customProperties.put("toolset", Map.of("name", "my-prompt", "dial_id", "prompts/bucket/my-folder/"));
+        when(configStore.get()).thenReturn(config);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+        application.setApplicationProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
+
+        Assertions.assertThrows(ApplicationTypeResourceException.class, () -> service.getPrompts(application));
+    }
+
+    @Test
+    public void getPrompts_returnsEmptyList_whenSchemaIsNull() {
+        application.setApplicationTypeSchemaId(null);
+
+        List<ResourceDescriptor> result = service.getPrompts(application);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
     public void testGetToolsets_ToolsetExistsNotDialResourceFormat() {
         customProperties.put("toolset", Map.of("name", "my-toolset", "dial_id", "mytoolset"));
         when(configStore.get()).thenReturn(config);


### PR DESCRIPTION
Extends the schema-rich application auto-sharing pipeline to cover prompt resources, so configs marked with `"dial:resource": true` that reference a prompt URL no longer return 403 to the app runner.

### Applicable issues

- fixes #1548

### Description of changes

- `ApplicationSchemaService` — new `getPrompts(Application)` extractor that returns `ResourceTypes.PROMPT` descriptors collected from schema fields marked with `"dial:resource": true`; rejects folder URLs the same way `getDeployments` does.
- `ApiKeyData` — new `attachedPrompts` map alongside `attachedFiles`/`attachedDeployments`.
- `BaseRequestFunction` — new `shareApplicationPrompts(Application)` that checks read access and writes to `attachedPrompts`, throwing 403 on denial.
- Wired into both entry points: `CollectRequestApplicationFilesFn` (per-request: chat completions, responses, route controllers) and `AutoShareDeploymentFn` (interceptor flow).
- `AccessService.getAutoSharedAccess` now also consults `attachedPrompts`, resolving prompts to `READ_ONLY`.
- Unit tests added in `ApplicationSchemaServiceTest` and `CollectRequestApplicationFilesFnTest`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.