### PR TITLE
fix: expose dial:applicationTypeRoutes via application endpoints #1555

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -29,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 
@@ -71,7 +73,7 @@ public class ApplicationController {
                     }
                     throw new ResourceNotFoundException("Application is not found: " + applicationId);
                 })
-                .map(ApplicationController::mapApplication)
+                .map(this::mapApplication)
                 .onSuccess(data -> context.respond(HttpStatus.OK, data))
                 .onFailure(this::respondError);
 
@@ -96,7 +98,7 @@ public class ApplicationController {
             if (applicationService.isIncludeCustomApps()) {
                 list.addAll(deploymentService.listDeployments(context, ResourceTypes.APPLICATION, deploymentExtractor));
             }
-            return list.stream().map(ApplicationController::mapApplication).toList();
+            return list.stream().map(this::mapApplication).toList();
         }).onSuccess(apps -> context.respond(HttpStatus.OK, new ListData<>(apps)))
                 .onFailure(this::respondError);
     }
@@ -207,7 +209,7 @@ public class ApplicationController {
         }
     }
 
-    private static ApplicationData mapApplication(Application application) {
+    private ApplicationData mapApplication(Application application) {
         ApplicationData data = new ApplicationData();
         data.setInvalid(application.getInvalid());
         data.setId(application.getName());
@@ -246,7 +248,14 @@ public class ApplicationController {
             data.setUpdatedAt(application.getUpdatedAt());
         }
 
-        data.setRoutes(application.getRoutes());
+        Map<String, Route> routes = null;
+        if (application.hasApplicationTypeSchemaId()) {
+            routes = applicationSchemaService.getRoutes(application);
+        }
+        if (routes == null) {
+            routes = application.getRoutes();
+        }
+        data.setRoutes(routes);
         data.setViewerUrl(application.getViewerUrl());
         data.setEditorUrl(application.getEditorUrl());
 

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationTypeSchemaController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationTypeSchemaController.java
@@ -121,6 +121,9 @@ public class ApplicationTypeSchemaController {
                 if (schemaNode.has(MetaSchemaHolder.DIAL_APPLICATION_TYPE_SCHEMA_ENDPOINT)) {
                     filteredNode.set(MetaSchemaHolder.DIAL_APPLICATION_TYPE_SCHEMA_ENDPOINT, schemaNode.get(MetaSchemaHolder.DIAL_APPLICATION_TYPE_SCHEMA_ENDPOINT));
                 }
+                if (schemaNode.has(MetaSchemaHolder.APPLICATION_TYPE_ROUTES)) {
+                    filteredNode.set(MetaSchemaHolder.APPLICATION_TYPE_ROUTES, schemaNode.get(MetaSchemaHolder.APPLICATION_TYPE_ROUTES));
+                }
 
                 filteredSchemas.add(filteredNode);
             }

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
@@ -1,5 +1,7 @@
 package com.epam.aidial.core.server;
 
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import okhttp3.mockwebserver.MockResponse;
@@ -155,6 +157,39 @@ public class ApplicationRouteApiTest extends ResourceBaseTest {
 
             verify(appResponse, 200, responseBody);
         }
+    }
+
+    @Test
+    public void testSchemaRichAppRoutesExposedInOpenAiApi() throws Exception {
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my-custom-application", null, """
+                {
+                "display_name": "My Custom Application",
+                "display_version": "1.0",
+                "icon_url": "http://application1/icon.svg",
+                "description": "My Custom Application Description",
+                "application_properties" : {
+                    "property1" : "test property1",
+                    "property2" : "test property2"
+                  },
+                "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type"
+                }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        response = send(HttpMethod.GET,
+                "/openai/applications/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my-custom-application");
+        Assertions.assertEquals(200, response.status());
+
+        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode routes = body.get("routes");
+        Assertions.assertNotNull(routes, "routes must be present in /openai/applications response");
+        JsonNode dataSync = routes.get("data_sync");
+        Assertions.assertNotNull(dataSync, "schema route data_sync must be exposed");
+        Assertions.assertEquals("/v1/index/search", dataSync.get("paths").get(0).asText());
+        Assertions.assertEquals("POST", dataSync.get("methods").get(0).asText());
+        Assertions.assertEquals(5, dataSync.get("order").asInt());
+        Assertions.assertEquals("WRITE", dataSync.get("permissions").get(0).asText());
+        Assertions.assertEquals("http://localhost:4848", dataSync.get("upstreams").get(0).get("endpoint").asText());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationTypeSchemaApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationTypeSchemaApiTest.java
@@ -32,6 +32,18 @@ public class ApplicationTypeSchemaApiTest extends ResourceBaseTest {
             Assertions.assertTrue(node.has("dial:applicationTypeDisplayName"));
             Assertions.assertTrue(node.has("dial:applicationTypeViewerUrl"));
         });
+
+        JsonNode specificType = null;
+        for (JsonNode node : jsonNode.get()) {
+            if (node.get("$id").asText().endsWith("/specific_application_type")) {
+                specificType = node;
+                break;
+            }
+        }
+        Assertions.assertNotNull(specificType, "specific_application_type schema must be present");
+        JsonNode routes = specificType.get("dial:applicationTypeRoutes");
+        Assertions.assertNotNull(routes, "dial:applicationTypeRoutes must be exposed in the schema list");
+        Assertions.assertTrue(routes.has("data_sync"));
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -1319,7 +1319,29 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                      "invalid" : true,
                      "application_type_schema_id" : "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
                      "viewer_url" : "https://mydial.somewhere.com/custom_application_schemas/viewer",
-                     "routes" : { }
+                     "routes" : {
+                       "data_sync" : {
+                         "name" : null,
+                         "userRoles" : null,
+                         "response" : null,
+                         "rewritePath" : true,
+                         "paths" : [ "/v1/index/search" ],
+                         "methods" : [ "POST" ],
+                         "upstreams" : [ {
+                           "endpoint" : "http://localhost:4848",
+                           "extraData" : null,
+                           "weight" : 1,
+                           "tier" : 0
+                         } ],
+                         "maxRetryAttempts" : 1,
+                         "order" : 5,
+                         "permissions" : [ "WRITE" ],
+                         "attachmentPaths" : {
+                           "requestBody" : [ ],
+                           "responseBody" : [ ]
+                         }
+                       }
+                     }
                 }
                 """);
     }


### PR DESCRIPTION
Application type schema routes (`dial:applicationTypeRoutes`) work at request time but were invisible to clients listing or describing applications. This change surfaces them through `GET /openai/applications[/{id}]` and `GET /v1/application_type_schemas/schemas` so tooling can discover reachable routes without prior knowledge.

### Applicable issues

- fixes #1555

### Description of changes

- `ApplicationController.mapApplication` now resolves routes the same way `ApplicationRouteController.getRoutes()` does at runtime: schema-scoped routes are returned when the application has a type schema with `dial:applicationTypeRoutes`; otherwise the per-instance `routes` field is used.
- `ApplicationTypeSchemaController.listSchemas` includes `dial:applicationTypeRoutes` in each listed schema entry. Route metadata has the same disclosure profile as instance-level routes already exposed by the application endpoints.
- Tests: new `ApplicationRouteApiTest.testSchemaRichAppRoutesExposedInOpenAiApi`; `ApplicationTypeSchemaApiTest.testApplicationTypeSchemaList_ok` extended to assert routes are exposed in the listing; `CustomApplicationApiTest.testOpenAiApplicationWithTypeSchemaGet_ReturnedInvalid_WhenAppDoesNotConformToSchema` expectation updated (schema routes remain visible for apps marked invalid, matching the runtime invoker's behavior).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.