### PR TITLE
feat: auto-sharing for annotation citation attachments #1558

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectResponseChatCompletionAttachmentsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectResponseChatCompletionAttachmentsFn.java
@@ -60,6 +60,16 @@ public class CollectResponseChatCompletionAttachmentsFn extends CollectResponseA
                     }
                 }
             }
+            ArrayNode annotations = (ArrayNode) customContent.get("annotations");
+            if (annotations != null) {
+                for (int j = 0; j < annotations.size(); j++) {
+                    JsonNode attachment = annotations.get(j).path("body").path("source").path("attachment");
+                    String url = ChatUtil.readCustomAttachment(attachment);
+                    if (url != null) {
+                        result.add(url);
+                    }
+                }
+            }
         }
 
         return result;

--- a/server/src/main/java/com/epam/aidial/core/server/function/request/ChatCompletionRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/request/ChatCompletionRequest.java
@@ -51,6 +51,7 @@ public class ChatCompletionRequest implements RequestObject {
         result.addAll(ChatUtil.collectCustomAttachments(tree, List.of(
                 "$.messages[*].custom_content.attachments[*]",
                 "$.messages[*].custom_content.stages[*].attachments[*]",
+                "$.messages[*].custom_content.annotations[*].body.source.attachment",
                 "$.custom_input[*]")));
         return result;
     }

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
@@ -1,9 +1,14 @@
 package com.epam.aidial.core.server;
 
+import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.server.data.LimitStats;
+import com.epam.aidial.core.server.service.ApplicationService;
 import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
+import com.epam.aidial.core.storage.util.EtagHeader;
 import com.sun.net.httpserver.HttpServer;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
 import okhttp3.mockwebserver.MockResponse;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
@@ -116,6 +121,89 @@ public class DeploymentPostApiTest extends ResourceBaseTest {
             if (adapterRef.getValue() != null) {
                 adapterRef.getValue().stop(0);
             }
+        }
+    }
+
+    @Test
+    public void testAutoShareAnnotationCitationAttachment() {
+        // Register a public application that internally calls gpt-3-turbo.
+        // Auto-sharing of annotation citation attachments only activates when the
+        // inner request carries a per-request key, i.e. goes through an application.
+        ApplicationService applicationService = dial.getProxy().getApplicationService();
+        Application app = new Application();
+        app.setEndpoint("http://localhost:4848/app");
+        applicationService.putApplication(
+                ResourceDescriptorFactory.fromPublicUrl("applications/public/annot-test-app"),
+                EtagHeader.ANY, null, app);
+
+        // Shared state between the two mock handlers that run sequentially
+        MutableObject<String> citedFileUrl = new MutableObject<>();
+
+        try (TestWebServer server = new TestWebServer(4848)) {
+            // Inner gpt-3-turbo handler: returns annotation whose citation points at the uploaded file.
+            // By the time this handler runs, the outer handler has already set citedFileUrl.
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                String body = """
+                        {"id":"id1","object":"chat.completion","created":1,"model":"gpt-35-turbo",
+                         "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"summary",
+                           "custom_content":{"annotations":[
+                             {"index":0,"body":{"title":"Source","source":{"attachment":{"type":"text/plain","url":"%s"}}}}
+                           ]}
+                         }}],
+                         "usage":{"completion_tokens":5,"prompt_tokens":5,"total_tokens":10}}
+                        """.formatted(citedFileUrl.getValue());
+                return new MockResponse().setResponseCode(200).setBody(body);
+            });
+
+            // Outer application handler: uploads a file, calls gpt-3-turbo,
+            // then verifies it can access the cited file via auto-sharing.
+            server.map(HttpMethod.POST, "/app", request -> {
+                try {
+                    String apiKey = request.getHeader(Proxy.HEADER_API_KEY);
+
+                    // resolve the application's own bucket via per-request key
+                    Response bucketResponse = send(HttpMethod.GET, "/v1/bucket", null, "", "api-key", apiKey);
+                    assertEquals(200, bucketResponse.status());
+                    String appBucket = new JsonObject(bucketResponse.body()).getString("bucket");
+
+                    // upload the file that will be cited in the annotation
+                    String fileUrl = "files/%s/cited/source.txt".formatted(appBucket);
+                    Response upload = upload(HttpMethod.PUT, "/v1/" + fileUrl, null, "cited content", "api-key", apiKey);
+                    assertEquals(200, upload.status());
+                    citedFileUrl.setValue(fileUrl);
+
+                    // call gpt-3-turbo — its response will include the annotation citation
+                    Response nested = send(HttpMethod.POST,
+                            "/openai/deployments/gpt-3-turbo/chat/completions", null,
+                            """
+                            {"model":"gpt-3-turbo","messages":[{"role":"user","content":"Summarize"}]}
+                            """,
+                            "api-key", apiKey,
+                            "content-type", Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON);
+                    assertEquals(200, nested.status());
+
+                    // the annotation's attachment should now be auto-shared to this per-request key
+                    Response fileResponse = send(HttpMethod.GET, "/v1/" + fileUrl, null, null, "api-key", apiKey);
+                    verify(fileResponse, 200);
+
+                    return new MockResponse().setResponseCode(200).setBody("""
+                            {"id":"id2","object":"chat.completion","created":1,"model":"app",
+                             "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"ok"}}],
+                             "usage":{"completion_tokens":1,"prompt_tokens":1,"total_tokens":2}}
+                            """);
+                } catch (Throwable e) {
+                    return new MockResponse().setResponseCode(500);
+                }
+            });
+
+            // User sends a chat completion to the application
+            Response response = send(HttpMethod.POST,
+                    "/openai/deployments/applications/public/annot-test-app/chat/completions", null,
+                    """
+                    {"model":"annot-test-app","messages":[{"role":"user","content":"Summarize"}]}
+                    """,
+                    "content-type", Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON);
+            verify(response, 200);
         }
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectResponseChatCompletionAttachmentsFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectResponseChatCompletionAttachmentsFnTest.java
@@ -76,6 +76,95 @@ class CollectResponseChatCompletionAttachmentsFnTest {
     }
 
     @Test
+    public void testCollectAttachmentsFromResponse_AnnotationCitationInMessage() throws JsonProcessingException {
+        String response = """
+                {
+                  "choices": [
+                    {
+                      "index": 0,
+                      "finish_reason": "stop",
+                      "message": {
+                        "role": "assistant",
+                        "content": "Here is the summary.",
+                        "custom_content": {
+                          "annotations": [
+                            {
+                              "index": 0,
+                              "body": {
+                                "title": "Source doc",
+                                "source": {
+                                  "attachment": {
+                                    "type": "application/pdf",
+                                    "url": "files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/docs/report.pdf"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "index": 1,
+                              "body": {
+                                "title": "Pure annotation - no source attachment"
+                              }
+                            },
+                            {
+                              "index": 2
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """;
+        when(context.isStreamingRequest()).thenReturn(false);
+
+        Set<String> files = new CollectResponseChatCompletionAttachmentsFn(null, context)
+                .collectAttachments((ObjectNode) ProxyUtil.MAPPER.readTree(response));
+
+        assertEquals(Set.of("files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/docs/report.pdf"), files);
+    }
+
+    @Test
+    public void testCollectAttachmentsFromResponse_AnnotationCitationInDelta() throws JsonProcessingException {
+        String response = """
+                {
+                  "choices": [
+                    {
+                      "index": 0,
+                      "finish_reason": "stop",
+                      "delta": {
+                        "role": "assistant",
+                        "content": "Here is the summary.",
+                        "custom_content": {
+                          "annotations": [
+                            {
+                              "index": 0,
+                              "body": {
+                                "title": "Source doc",
+                                "source": {
+                                  "attachment": {
+                                    "type": "application/pdf",
+                                    "url": "files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/docs/report.pdf"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """;
+        when(context.isStreamingRequest()).thenReturn(true);
+
+        Set<String> files = new CollectResponseChatCompletionAttachmentsFn(null, context)
+                .collectAttachments((ObjectNode) ProxyUtil.MAPPER.readTree(response));
+
+        assertEquals(Set.of("files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/docs/report.pdf"), files);
+    }
+
+    @Test
     public void testCollectAttachmentsFromResponse_ChatStreamingResponse() throws JsonProcessingException {
         String response = """
                 {

--- a/server/src/test/java/com/epam/aidial/core/server/function/request/ChatCompletionRequestTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/request/ChatCompletionRequestTest.java
@@ -172,6 +172,47 @@ class ChatCompletionRequestTest {
     }
 
     @Test
+    void testCollectAttachedFiles_AnnotationCitationAttachment() throws IOException {
+        String body = """
+                {
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "Summarize the document.",
+                      "custom_content": {
+                        "annotations": [
+                          {
+                            "index": 0,
+                            "body": {
+                              "source": {
+                                "attachment": {
+                                  "type": "application/pdf",
+                                  "url": "files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/docs/report.pdf"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "index": 1,
+                            "body": {
+                              "title": "Pure annotation - no source"
+                            }
+                          },
+                          {
+                            "index": 2
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """;
+        ChatCompletionRequest request = request(body);
+        Set<String> actual = request.collectAttachments();
+        assertEquals(Set.of("files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/docs/report.pdf"), actual);
+    }
+
+    @Test
     void testCollectAttachedFiles_EmbeddingRequest_valid() throws IOException {
         String content = """
                 {


### PR DESCRIPTION
Extends DIAL Core's attachment auto-sharing scanner to cover annotation citation sources (`custom_content.annotations[*].body.source.attachment`) in both request messages and response choices/deltas, so that files cited in annotation bodies are automatically shared to the requesting party when going through an application with a per-request key.

### Applicable issues

- fixes #1558

### Description of changes

- `ChatCompletionRequest.collectAttachments()`: added `$.messages[*].custom_content.annotations[*].body.source.attachment` to the request-side JSONPath scan list
- `CollectResponseChatCompletionAttachmentsFn.collectAttachments()`: added traversal of `choices[*].(message|delta).custom_content.annotations[*].body.source.attachment` for both streaming and non-streaming responses
- Added unit tests in `ChatCompletionRequestTest` and `CollectResponseChatCompletionAttachmentsFnTest` covering annotation citations with and without source attachments
- Added integration test `testAutoShareAnnotationCitationAttachment` in `DeploymentPostApiTest` verifying the full User → Application → Model flow where the model response contains an annotation citation and the application can access the cited file via auto-sharing

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.