### PR TITLE
fix: expose application route upstreams and toolset endpoint securely #1565

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Route.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Route.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Min;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -11,6 +12,7 @@ import java.util.regex.Pattern;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Route extends RoleBasedEntity {
 
     public static final AttachmentPath EMPTY_ATTACHMENT_PATHS = new AttachmentPath();

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -197,16 +197,40 @@ public class ApplicationController {
     }
 
     private void respondError(Throwable error) {
-        if (error instanceof IllegalArgumentException) {
-            context.respond(HttpStatus.BAD_REQUEST, error.getMessage());
-        } else if (error instanceof PermissionDeniedException) {
-            context.respond(HttpStatus.FORBIDDEN, error.getMessage());
-        } else if (error instanceof ResourceNotFoundException) {
-            context.respond(HttpStatus.NOT_FOUND, error.getMessage());
-        } else {
-            context.respond(error, "Internal error");
-            log.error("Failed to handle application request", error);
+        switch (error) {
+            case IllegalArgumentException ignored ->
+                    context.respond(HttpStatus.BAD_REQUEST, error.getMessage());
+            case PermissionDeniedException ignored ->
+                    context.respond(HttpStatus.FORBIDDEN, error.getMessage());
+            case ResourceNotFoundException ignored ->
+                    context.respond(HttpStatus.NOT_FOUND, error.getMessage());
+            case null, default -> {
+                context.respond(error, "Internal error");
+                log.error("Failed to handle application request", error);
+            }
         }
+    }
+
+    private boolean hasWriteAccess(Application application) {
+        String appName = application.getName();
+        if (appName != null && appName.equals(context.getDecodedSourceDeployment())) {
+            return true;
+        }
+        if (appName != null) {
+            try {
+                ResourceDescriptor resource = ResourceDescriptorFactory.fromAnyUrl(appName, encryptionService);
+                if (resource.getType() == ResourceTypes.APPLICATION) {
+                    return accessService.hasWriteAccess(resource, context);
+                }
+            } catch (Exception e) {
+                // appName is a config-based deployment name, fall through to admin check
+            }
+        }
+        return accessService.hasAdminAccess(context);
+    }
+
+    private static void clearUpstreams(Map<String, Route> routes) {
+        routes.forEach((name, route) -> route.setUpstreams(null));
     }
 
     private ApplicationData mapApplication(Application application) {
@@ -254,6 +278,9 @@ public class ApplicationController {
         }
         if (routes == null) {
             routes = application.getRoutes();
+        }
+        if (!hasWriteAccess(application) && routes != null) {
+            clearUpstreams(routes);
         }
         data.setRoutes(routes);
         data.setViewerUrl(application.getViewerUrl());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -223,7 +223,7 @@ public class ApplicationController {
                     return accessService.hasWriteAccess(resource, context);
                 }
             } catch (Exception e) {
-                // appName is a config-based deployment name, fall through to admin check
+                // appName is not DIAL resource url, fall through to admin check
             }
         }
         return accessService.hasAdminAccess(context);

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceController.java
@@ -149,7 +149,7 @@ public class ResourceController extends AccessControlBaseController {
         if (descriptor.getType().equals(ResourceTypes.APPLICATION)) {
             responseFuture = getApplicationData(descriptor, hasWriteAccess, etagHeader);
         } else if (descriptor.getType().equals(ResourceTypes.TOOL_SET)) {
-            responseFuture = getToolsetData(descriptor, etagHeader);
+            responseFuture = getToolsetData(descriptor, hasWriteAccess, etagHeader);
         } else {
             responseFuture = getResourceData(descriptor, etagHeader);
         }
@@ -212,13 +212,16 @@ public class ResourceController extends AccessControlBaseController {
         });
     }
 
-    private Future<Pair<ResourceItemMetadata, String>> getToolsetData(ResourceDescriptor descriptor, EtagHeader etagHeader) {
+    private Future<Pair<ResourceItemMetadata, String>> getToolsetData(ResourceDescriptor descriptor, boolean hasWriteAccess, EtagHeader etagHeader) {
         return taskExecutor.submit(() -> {
             Pair<ResourceItemMetadata, ToolSet> result = toolSetService.getToolSet(descriptor, etagHeader);
             ResourceItemMetadata meta = result.getKey();
             ToolSet toolSet = result.getValue();
             toolSetService.setResourceAuthStatuses(context, toolSet, descriptor.getUrl());
             toolSet.clearAuthSettings();
+            if (!hasWriteAccess) {
+                toolSet.setEndpoint(null);
+            }
             String body = ProxyUtil.convertToString(toolSet);
             return Pair.of(meta, body);
         });

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
@@ -1054,13 +1054,9 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "max_retry_attempts" : 1,
                       "routes" : {
                         "index-search" : {
-                          "name" : null,
-                          "userRoles" : null,
-                          "response" : null,
                           "rewritePath" : true,
                           "paths" : [ "/v1/index(/[^/]+)*$" ],
                           "methods" : [ "DELETE", "POST", "PUT" ],
-                          "upstreams" : null,
                           "maxRetryAttempts" : 1,
                           "order" : 2147483647,
                           "permissions" : [ ],

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
@@ -1060,12 +1060,7 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                           "rewritePath" : true,
                           "paths" : [ "/v1/index(/[^/]+)*$" ],
                           "methods" : [ "DELETE", "POST", "PUT" ],
-                          "upstreams" : [ {
-                            "endpoint" : "http://localhost:4848",
-                            "extraData" : null,
-                            "weight" : 1,
-                            "tier" : 0
-                          } ],
+                          "upstreams" : null,
                           "maxRetryAttempts" : 1,
                           "order" : 2147483647,
                           "permissions" : [ ],

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
@@ -414,7 +414,7 @@ public class ApplicationRouteApiTest extends ResourceBaseTest {
         body = ProxyUtil.MAPPER.readTree(response.body());
         routes = body.get("routes");
         Assertions.assertNotNull(routes, "routes must still be present for read-only user");
-        Assertions.assertTrue(routes.get("data_sync").get("upstreams").isNull(),
+        Assertions.assertTrue(routes.get("data_sync").path("upstreams").isMissingNode(),
                 "upstreams must be null for read-only user");
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server;
 
+import com.epam.aidial.core.server.data.InvitationLink;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
@@ -356,6 +357,65 @@ public class ApplicationRouteApiTest extends ResourceBaseTest {
             verify(response, 200);
         }
 
+    }
+
+    @Test
+    public void testRouteUpstreamsHiddenForReadOnlyUser() throws Exception {
+        // Owner creates an application with routes containing upstreams
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/secure-app", null, """
+                {
+                "endpoint": "http://application1/v1/completions",
+                "display_name": "Secure App",
+                "routes": {
+                        "data_sync": {
+                          "paths": ["/v1/data/sync$"],
+                          "methods": ["POST"],
+                          "upstreams": [{"endpoint": "http://localhost:4848"}]
+                      }
+                  }
+                }
+                """);
+        Assertions.assertEquals(200, response.status());
+
+        // Owner GETs the app via OpenAI API - should see upstreams
+        response = send(HttpMethod.GET, "/openai/applications/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/secure-app");
+        Assertions.assertEquals(200, response.status());
+        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode routes = body.get("routes");
+        Assertions.assertNotNull(routes, "routes must be present for owner");
+        JsonNode upstreams = routes.get("data_sync").get("upstreams");
+        Assertions.assertNotNull(upstreams, "upstreams must be present for owner");
+        Assertions.assertFalse(upstreams.isEmpty(), "upstreams must not be empty for owner");
+
+        // Owner shares the app (read-only) with user via invitation
+        response = send(HttpMethod.POST, "/v1/ops/resource/share/create", null, """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    {
+                      "url": "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/secure-app"
+                    }
+                  ]
+                }
+                """);
+        Assertions.assertEquals(200, response.status());
+        InvitationLink invitationLink = ProxyUtil.convertToObject(response.body(), InvitationLink.class);
+        Assertions.assertNotNull(invitationLink);
+
+        // User accepts invitation
+        response = send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "authorization", "user");
+        Assertions.assertEquals(200, response.status());
+
+        // Read-only user GETs the app via OpenAI API - routes must be present but upstreams null
+        response = send(HttpMethod.GET,
+                "/openai/applications/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/secure-app",
+                null, null, "authorization", "user");
+        Assertions.assertEquals(200, response.status());
+        body = ProxyUtil.MAPPER.readTree(response.body());
+        routes = body.get("routes");
+        Assertions.assertNotNull(routes, "routes must still be present for read-only user");
+        Assertions.assertTrue(routes.get("data_sync").get("upstreams").isNull(),
+                "upstreams must be null for read-only user");
     }
 
 }

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -594,12 +594,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                  "rewritePath" : true,
                                  "paths" : [ "/v1/index(/[^/]+)*$" ],
                                  "methods" : [ "DELETE", "POST", "PUT" ],
-                                 "upstreams" : [ {
-                                   "endpoint" : "http://localhost:4848",
-                                   "extraData" : null,
-                                   "weight" : 1,
-                                   "tier" : 0
-                                 } ],
+                                 "upstreams" : null,
                                  "maxRetryAttempts" : 1,
                                  "order" : 2147483647,
                                  "permissions" : [ ],
@@ -764,12 +759,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "rewritePath" : true,
                                 "paths" : [ "/v1/index(/[^/]+)*$" ],
                                 "methods" : [ "DELETE", "POST", "PUT" ],
-                                "upstreams" : [ {
-                                  "endpoint" : "http://localhost:4848",
-                                  "extraData" : null,
-                                  "weight" : 1,
-                                  "tier" : 0
-                                } ],
+                                "upstreams" : null,
                                 "maxRetryAttempts" : 1,
                                 "order" : 2147483647,
                                 "permissions" : [ ],
@@ -1327,12 +1317,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                          "rewritePath" : true,
                          "paths" : [ "/v1/index/search" ],
                          "methods" : [ "POST" ],
-                         "upstreams" : [ {
-                           "endpoint" : "http://localhost:4848",
-                           "extraData" : null,
-                           "weight" : 1,
-                           "tier" : 0
-                         } ],
+                         "upstreams" : null,
                          "maxRetryAttempts" : 1,
                          "order" : 5,
                          "permissions" : [ "WRITE" ],

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -588,13 +588,9 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                              "max_retry_attempts" : 1,
                              "routes" : {
                                "index-search" : {
-                                 "name" : null,
-                                 "userRoles" : null,
-                                 "response" : null,
                                  "rewritePath" : true,
                                  "paths" : [ "/v1/index(/[^/]+)*$" ],
                                  "methods" : [ "DELETE", "POST", "PUT" ],
-                                 "upstreams" : null,
                                  "maxRetryAttempts" : 1,
                                  "order" : 2147483647,
                                  "permissions" : [ ],
@@ -753,13 +749,9 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                             "max_retry_attempts" : 1,
                             "routes" : {
                               "index-search" : {
-                                "name" : null,
-                                "userRoles" : null,
-                                "response" : null,
                                 "rewritePath" : true,
                                 "paths" : [ "/v1/index(/[^/]+)*$" ],
                                 "methods" : [ "DELETE", "POST", "PUT" ],
-                                "upstreams" : null,
                                 "maxRetryAttempts" : 1,
                                 "order" : 2147483647,
                                 "permissions" : [ ],
@@ -1311,13 +1303,9 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                      "viewer_url" : "https://mydial.somewhere.com/custom_application_schemas/viewer",
                      "routes" : {
                        "data_sync" : {
-                         "name" : null,
-                         "userRoles" : null,
-                         "response" : null,
                          "rewritePath" : true,
                          "paths" : [ "/v1/index/search" ],
                          "methods" : [ "POST" ],
-                         "upstreams" : null,
                          "maxRetryAttempts" : 1,
                          "order" : 5,
                          "permissions" : [ "WRITE" ],

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -2805,4 +2805,49 @@ public class ToolSetApiTest extends ResourceBaseTest {
         }
         return ProxyUtil.MAPPER.writeValueAsString(root);
     }
+
+    @Test
+    void testToolsetEndpointHiddenForReadOnlyUser() throws JsonProcessingException {
+        // Admin creates toolset with endpoint
+        Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/secure-toolset", null, """
+                {
+                    "endpoint": "http://localhost:9876",
+                    "transport": "HTTP",
+                    "allowedTools": [],
+                    "auth_settings": {
+                        "authentication_type": "NONE"
+                    }
+                }
+                """, "authorization", "admin");
+        verify(response, 200);
+
+        // Admin GETs the toolset - should see endpoint
+        response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/secure-toolset", null, null, "authorization", "admin");
+        verify(response, 200);
+        assertNotNull(ProxyUtil.MAPPER.readTree(response.body()).get("endpoint"));
+
+        // Admin shares toolset with user (read-only)
+        response = send(HttpMethod.POST, "/v1/ops/resource/share/create", null, """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    {
+                      "url": "toolsets/4X25dj1mja51jykqxsXnCH/secure-toolset"
+                    }
+                  ]
+                }
+                """, "authorization", "admin");
+        verify(response, 200);
+        InvitationLink invitationLink = ProxyUtil.convertToObject(response.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        // User accepts invitation
+        response = send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "authorization", "user");
+        verify(response, 200);
+
+        // User GETs the toolset - endpoint must be absent
+        response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/secure-toolset", null, null, "authorization", "user");
+        verify(response, 200);
+        assertNull(ProxyUtil.MAPPER.readTree(response.body()).get("endpoint"));
+    }
 }


### PR DESCRIPTION
Sensitive fields were exposed to all users regardless of permission level. Application route `upstreams` and toolset `endpoint` are now only visible to users with write access.

### Applicable issues

- fixes #1565

### Description of changes

- `ApplicationController`: added `hasWriteAccess(Application)` to determine write access for both config-based apps (admin check) and custom apps (resource descriptor write-access check); `mapApplication()` now strips `upstreams` from each route when the caller lacks write access
- `ResourceController`: `getToolsetData()` now nulls out `toolSet.endpoint` when `hasWriteAccess` is false
- Updated existing test assertions to reflect correct secure behavior; added `testToolsetEndpointHiddenForReadOnlyUser` and `testRouteUpstreamsHiddenForReadOnlyUser` tests

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.