### PR TITLE
feat: support user defined upstream endpoints #1567

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Upstream.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Upstream.java
@@ -31,4 +31,7 @@ public class Upstream {
     private int weight = 1;
     @JsonAlias({"tier", "dial:tier"})
     private int tier = 0;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonAlias({"id", "dial:id"})
+    private String id;
 }

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -91,6 +91,7 @@ public class Proxy implements Handler<HttpServerRequest> {
     public static final String HEADER_API_KEY = "API-KEY";
     public static final String HEADER_JOB_TITLE = "X-JOB-TITLE";
     public static final String HEADER_CONVERSATION_ID = "X-CONVERSATION-ID";
+    public static final String HEADER_UPSTREAM_ID = "X-UPSTREAM-ID";
     public static final String HEADER_UPSTREAM_ENDPOINT = "X-UPSTREAM-ENDPOINT";
     public static final String HEADER_UPSTREAM_KEY = "X-UPSTREAM-KEY";
     public static final String HEADER_UPSTREAM_EXTRA_DATA = "X-UPSTREAM-EXTRA-DATA";

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -235,7 +235,14 @@ public class DeploymentPostController extends BaseDeploymentPostController {
             return;
         }
 
-        UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, context.getCacheBreakpointContext());
+        String upstreamId = context.getRequest().headers().get(Proxy.HEADER_UPSTREAM_ID);
+        UpstreamRoute upstreamRoute;
+        try {
+            upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, context.getCacheBreakpointContext(), upstreamId);
+        } catch (HttpException e) {
+            respond(e.getStatus(), e.getMessage());
+            return;
+        }
         context.setUpstreamRoute(upstreamRoute);
 
         sendRequest();

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -148,8 +148,9 @@ public class ResponsesController extends BaseDeploymentPostController {
         context.setRequestBody(Buffer.buffer(request.serialize()));
 
         Deployment deployment = context.getDeployment();
+        String upstreamId = context.getRequest().headers().get(Proxy.HEADER_UPSTREAM_ID);
         UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider()
-                .get(deployment, context.getCacheBreakpointContext());
+                .get(deployment, context.getCacheBreakpointContext(), upstreamId);
 
         context.setRequestBodyTimestamp(System.currentTimeMillis());
         context.setUpstreamRoute(upstreamRoute);

--- a/server/src/main/java/com/epam/aidial/core/server/data/cache/CachedUpstreamEntry.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/cache/CachedUpstreamEntry.java
@@ -1,4 +1,4 @@
 package com.epam.aidial.core.server.data.cache;
 
-public record CachedUpstreamEntry(String endpoint, String prefixPath, String extraMetadata) {
+public record CachedUpstreamEntry(String endpoint, String id, String prefixPath, String extraMetadata) {
 }

--- a/server/src/main/java/com/epam/aidial/core/server/service/UpstreamCacheService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/UpstreamCacheService.java
@@ -37,11 +37,12 @@ public class UpstreamCacheService {
     private static final Duration DEFAULT_TTL = Duration.ofMinutes(10);
 
     private static final String UPSTREAM_ENDPOINT_FIELD = "upstream_endpoint";
+    private static final String UPSTREAM_ID_FIELD = "upstream_id";
     private static final String PREFIX_PATH_FIELD = "prefix_path";
     private static final String EXTRA_METADATA_FIELD = "extra_metadata";
 
 
-    private static final Set<String> ALL_FIELDS = Set.of(UPSTREAM_ENDPOINT_FIELD, PREFIX_PATH_FIELD, EXTRA_METADATA_FIELD);
+    private static final Set<String> ALL_FIELDS = Set.of(UPSTREAM_ENDPOINT_FIELD, UPSTREAM_ID_FIELD, PREFIX_PATH_FIELD, EXTRA_METADATA_FIELD);
 
     private static final int BATCH_SIZE = 64;
 
@@ -120,14 +121,18 @@ public class UpstreamCacheService {
                     RMap<String, String> map = redisClient.getMap(key, REDIS_MAP_CODEC);
                     Map<String, String> fields = map.getAll(ALL_FIELDS);
                     if (!fields.isEmpty()) {
-                        return new CachedUpstreamEntry(fields.get(UPSTREAM_ENDPOINT_FIELD), fields.get(PREFIX_PATH_FIELD), fields.get(EXTRA_METADATA_FIELD));
+                        return new CachedUpstreamEntry(
+                                fields.get(UPSTREAM_ENDPOINT_FIELD),
+                                fields.get(UPSTREAM_ID_FIELD),
+                                fields.get(PREFIX_PATH_FIELD),
+                                fields.get(EXTRA_METADATA_FIELD));
                     }
                 }
             }
         }
         // take the last breakpoint
         String prefixPath = breakpoints.get(breakpoints.size() - 1);
-        return new CachedUpstreamEntry(null, prefixPath, null);
+        return new CachedUpstreamEntry(null, null, prefixPath, null);
     }
 
     public void updateEntry(String hash, CachedUpstreamEntry entry, Model model, String expireAtStr) {
@@ -135,6 +140,9 @@ public class UpstreamCacheService {
         Map<String, String> fields = new HashMap<>();
         fields.put(UPSTREAM_ENDPOINT_FIELD, entry.endpoint());
         fields.put(PREFIX_PATH_FIELD, entry.prefixPath());
+        if (entry.id() != null) {
+            fields.put(UPSTREAM_ID_FIELD, entry.id());
+        }
         if (entry.extraMetadata() != null) {
             fields.put(EXTRA_METADATA_FIELD, entry.extraMetadata());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRoute.java
+++ b/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRoute.java
@@ -164,7 +164,7 @@ public class UpstreamRoute {
         }
         String expireAt = proxyResponse.getHeader(Proxy.HEADER_CACHE_EXPIRE_AT);
         String extraMetadata = proxyResponse.getHeader(Proxy.HEADER_CACHE_EXTRA_METADATA);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry(upstream.getEndpoint(), breakpointPath, extraMetadata);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry(upstream.getEndpoint(), upstream.getId(), breakpointPath, extraMetadata);
         taskExecutor.submit(() -> {
             upstreamCacheService.updateEntry(hash, entry, model, expireAt);
             return null;

--- a/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
+++ b/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
@@ -75,7 +75,8 @@ public class UpstreamRouteProvider {
         if (upstreamId != null && !upstreamId.isBlank()) {
             Upstream selected = null;
             for (Upstream upstream : upstreams) {
-                if (upstreamId.equals(upstream.getId())) {
+                String id = Objects.requireNonNullElse(upstream.getId(), upstream.getEndpoint());
+                if (upstreamId.equals(id)) {
                     selected = upstream;
                     break;
                 }

--- a/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
+++ b/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
@@ -10,6 +10,8 @@ import com.epam.aidial.core.server.data.cache.CacheBreakpointContext;
 import com.epam.aidial.core.server.data.cache.CachedUpstreamEntry;
 import com.epam.aidial.core.server.service.UpstreamCacheService;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,13 +56,36 @@ public class UpstreamRouteProvider {
     }
 
     public UpstreamRoute get(Deployment deployment, CacheBreakpointContext breakpointContext) {
-        return get(deployment, breakpointContext, Deployment::getEndpoint);
+        return get(deployment, breakpointContext, Deployment::getEndpoint, null);
+    }
+
+    public UpstreamRoute get(Deployment deployment, CacheBreakpointContext breakpointContext, String upstreamId) {
+        return get(deployment, breakpointContext, Deployment::getEndpoint, upstreamId);
     }
 
     public UpstreamRoute get(Deployment deployment, CacheBreakpointContext breakpointContext,
                              Function<Deployment, String> endpointSupplier) {
+        return get(deployment, breakpointContext, endpointSupplier, null);
+    }
+
+    public UpstreamRoute get(Deployment deployment, CacheBreakpointContext breakpointContext,
+                             Function<Deployment, String> endpointSupplier, String upstreamId) {
         String key = getKey(deployment);
         List<Upstream> upstreams = getUpstreams(deployment, endpointSupplier);
+        if (upstreamId != null && !upstreamId.isBlank()) {
+            Upstream selected = null;
+            for (Upstream upstream : upstreams) {
+                if (upstreamId.equals(upstream.getId())) {
+                    selected = upstream;
+                    break;
+                }
+            }
+            if (selected == null) {
+                throw new HttpException(HttpStatus.BAD_REQUEST, "Unknown upstream id " + upstreamId);
+            }
+            upstreams = List.of(selected);
+            key = key + ":upstream:" + upstreamId;
+        }
         UpstreamCacheContext context = null;
         if (deployment instanceof Model model && breakpointContext != null) {
             CachedUpstreamEntry entry = upstreamCacheService.getCacheEntry(breakpointContext, model);

--- a/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
+++ b/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
@@ -121,18 +121,30 @@ public class UpstreamRouteProvider {
             throw new IllegalArgumentException("max retry attempts must be positive integer");
         }
         if (context != null && context.getEntry() != null) {
-            String endpoint = context.getEntry().endpoint();
+            String cachedId = context.getEntry().id();
+            String cachedEndpoint = context.getEntry().endpoint();
             Upstream originalUpstream = null;
-            for (Upstream upstream : upstreams) {
-                if (upstream.getEndpoint().equals(endpoint)) {
-                    originalUpstream = upstream;
-                    break;
+            if (cachedId != null) {
+                for (Upstream upstream : upstreams) {
+                    if (cachedId.equals(upstream.getId())) {
+                        originalUpstream = upstream;
+                        break;
+                    }
+                }
+            }
+            // fallback to upstream endpoint if id is not set
+            if (originalUpstream == null && cachedEndpoint != null) {
+                for (Upstream upstream : upstreams) {
+                    if (cachedEndpoint.equals(upstream.getEndpoint())) {
+                        originalUpstream = upstream;
+                        break;
+                    }
                 }
             }
             if (originalUpstream != null) {
                 context.setOriginalUpstream(originalUpstream);
             } else {
-                log.warn("cached upstream doesn't exist any longer in config: {}", endpoint);
+                log.warn("cached upstream doesn't exist any longer in config: id={}, endpoint={}", cachedId, cachedEndpoint);
             }
         }
         return new UpstreamRoute(taskExecutor, upstreamCacheService, wrapper.balancer, result, context);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -255,7 +255,7 @@ public class DeploymentPostControllerTest {
     public void testHandleRequestBody_OverrideModelName() throws IOException {
         when(context.getRequest()).thenReturn(request);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, 0, 0));
+        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, 0, 0, null));
         when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
         HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
         when(context.getRequest()).thenReturn(request);
@@ -297,7 +297,7 @@ public class DeploymentPostControllerTest {
     public void testHandleRequestBody_NotOverrideModelName() throws IOException {
         when(context.getRequest()).thenReturn(request);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, 0, 0));
+        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, 0, 0, null));
         when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
         HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
         when(context.getRequest()).thenReturn(request);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
@@ -214,7 +214,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, 0, 0);
+        Upstream upstream = new Upstream(null, "endpoint", null, null, 0, 0, null);
         ApiKeyData apiKeyData = new ApiKeyData();
         apiKeyData.setSourceDeployment("test-deployment");
         apiKeyData.setPerRequestKey(PER_REQUEST_KEY);
@@ -369,7 +369,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, 0, 0);
+        Upstream upstream = new Upstream(null, "endpoint", null, null, 0, 0, null);
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
         Buffer requestBody = Buffer.buffer("{\"model\":\"test\"}");
@@ -420,7 +420,7 @@ public class ResponsesControllerTest {
         when(proxy.getTokenStatsTracker().updateModelStats(context))
                 .thenReturn(Future.succeededFuture());
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
-        when(proxy.getUpstreamRouteProvider().get(deployment, null)).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(deployment, null, (String) null)).thenReturn(upstreamRoute);
         when(proxy.getClient().request(any()))
                 .thenReturn(Future.succeededFuture(proxyRequest));
         when(proxy.getApplicationSchemaService().modifyEndpointsForCustomApplication(deployment))

--- a/server/src/test/java/com/epam/aidial/core/server/service/UpstreamCacheServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/UpstreamCacheServiceTest.java
@@ -81,7 +81,7 @@ public class UpstreamCacheServiceTest {
     public void testUpdateEntry() {
         service = new UpstreamCacheService(redissonClient, lockService, System::currentTimeMillis, null);
 
-        service.updateEntry("hash", new CachedUpstreamEntry("http://localhost:8080/chat", "prefix.body.messages[1]", null), new Model(), null);
+        service.updateEntry("hash", new CachedUpstreamEntry("http://localhost:8080/chat", null, "prefix.body.messages[1]", null), new Model(), null);
 
         assertTrue(redissonClient.getKeys().getKeys().iterator().hasNext());
     }
@@ -357,7 +357,7 @@ public class UpstreamCacheServiceTest {
         CacheBreakpointContext context = service.buildCacheBreakpointContext(request, CachePolicy.AVAILABILITY_PRIORITY, model);
         Map<String, String> prefixToHash = context.prefixToHash();
         for (var breakpoint : context.breakpoints()) {
-            CachedUpstreamEntry cachedUpstreamEntry = new CachedUpstreamEntry("http://host/chat", breakpoint, null);
+            CachedUpstreamEntry cachedUpstreamEntry = new CachedUpstreamEntry("http://host/chat", null, breakpoint, null);
             service.updateEntry(prefixToHash.get(breakpoint), cachedUpstreamEntry, model, null);
         }
 

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/RandomizedWeightedBalancerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/RandomizedWeightedBalancerTest.java
@@ -23,10 +23,10 @@ public class RandomizedWeightedBalancerTest {
     @Test
     void testWeightedLoadBalancer() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, 1, 0),
-                new Upstream("endpoint2", null, null, null, 2, 0),
-                new Upstream("endpoint3", null, null, null, 3, 0),
-                new Upstream("endpoint4", null, null, null, 4, 0)
+                new Upstream("endpoint1", null, null, null, 1, 0, null),
+                new Upstream("endpoint2", null, null, null, 2, 0, null),
+                new Upstream("endpoint3", null, null, null, 3, 0, null),
+                new Upstream("endpoint4", null, null, null, 4, 0, null)
         );
 
         RandomizedWeightedBalancer balancer = new RandomizedWeightedBalancer("model1", upstreams, generator);
@@ -60,8 +60,8 @@ public class RandomizedWeightedBalancerTest {
     @Test
     void testZeroWeightLoadBalancer() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, 0, 1),
-                new Upstream("endpoint2", null, null, null, -9, 1)
+                new Upstream("endpoint1", null, null, null, 0, 1, null),
+                new Upstream("endpoint2", null, null, null, -9, 1, null)
         );
         RandomizedWeightedBalancer balancer = new RandomizedWeightedBalancer("model1", upstreams, generator);
 

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/TieredBalancerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/TieredBalancerTest.java
@@ -47,8 +47,8 @@ public class TieredBalancerTest {
     @Test
     void testTierPriority() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, 1, 0),
-                new Upstream("endpoint2", null, null, null, 9, 1)
+                new Upstream("endpoint1", null, null, null, 1, 0, null),
+                new Upstream("endpoint2", null, null, null, 9, 1, null)
         );
         TieredBalancer balancer = new TieredBalancer("model1", upstreams, generator);
 
@@ -63,8 +63,8 @@ public class TieredBalancerTest {
     @Test
     void testFail() throws InterruptedException {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, 1, 0),
-                new Upstream("endpoint2", null, null, null, 9, 1)
+                new Upstream("endpoint1", null, null, null, 1, 0, null),
+                new Upstream("endpoint2", null, null, null, 9, 1, null)
         );
         TieredBalancer balancer = new TieredBalancer("model1", upstreams, generator);
 
@@ -93,8 +93,8 @@ public class TieredBalancerTest {
     @Test
     void test5xxErrorsHandling() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint0", null, null, null, 1, 0),
-                new Upstream("endpoint1", null, null, null, 1, 1)
+                new Upstream("endpoint0", null, null, null, 1, 0, null),
+                new Upstream("endpoint1", null, null, null, 1, 1, null)
         );
         TieredBalancer balancer = new TieredBalancer("model1", upstreams, generator);
 
@@ -118,7 +118,7 @@ public class TieredBalancerTest {
         Model model = new Model();
         model.setName("model1");
         List<Upstream> upstreams = Stream.of(1, 2, 3, 4)
-                .map(index  -> new Upstream("endpoint" + index, null, null, null, 1, 1))
+                .map(index  -> new Upstream("endpoint" + index, null, null, null, 1, 1, null))
                 .toList();
         model.setUpstreams(upstreams);
         AtomicInteger counter = new AtomicInteger(-1);

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
@@ -135,4 +135,54 @@ public class UpstreamRouteProviderTest {
 
         assertEquals(upstream1, result);
     }
+
+    @Test
+    public void testGet_UpstreamId_Match() {
+        Model model = new Model();
+        model.setName("model");
+        Upstream upstream1 = new Upstream();
+        upstream1.setId("alpha");
+        upstream1.setEndpoint("ep1");
+        Upstream upstream2 = new Upstream();
+        upstream2.setId("beta");
+        upstream2.setEndpoint("ep2");
+        model.setUpstreams(List.of(upstream1, upstream2));
+
+        UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
+        UpstreamRoute route = provider.get(model, null, "beta");
+        Upstream result = route.next();
+
+        assertEquals(upstream2, result);
+        assertThrows(HttpException.class, route::next);
+    }
+
+    @Test
+    public void testGet_UpstreamId_Unknown() {
+        Model model = new Model();
+        model.setName("model");
+        Upstream upstream1 = new Upstream();
+        upstream1.setId("alpha");
+        upstream1.setEndpoint("ep1");
+        model.setUpstreams(List.of(upstream1));
+
+        UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
+        HttpException ex = assertThrows(HttpException.class, () -> provider.get(model, null, "missing"));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
+        assertEquals("Unknown upstream id missing", ex.getMessage());
+    }
+
+    @Test
+    public void testGet_UpstreamId_BlankIgnored() {
+        Model model = new Model();
+        model.setName("model");
+        Upstream upstream1 = new Upstream();
+        upstream1.setEndpoint("ep1");
+        Upstream upstream2 = new Upstream();
+        upstream2.setEndpoint("ep2");
+        model.setUpstreams(List.of(upstream1, upstream2));
+
+        UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
+        UpstreamRoute route = provider.get(model, null, "   ");
+        assertNotNull(route.next());
+    }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
@@ -102,7 +102,7 @@ public class UpstreamRouteProviderTest {
 
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of(), Map.of(), CachePolicy.AVAILABILITY_PRIORITY);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry("upstream2", "prefix", null);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("upstream2", null, "prefix", null);
         when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
 
         UpstreamRoute route1 = provider.get(model, cacheBreakpointContext);
@@ -127,7 +127,7 @@ public class UpstreamRouteProviderTest {
 
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of(), Map.of(), CachePolicy.AVAILABILITY_PRIORITY);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry("test", "prefix", null);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("test", null, "prefix", null);
         when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
 
         UpstreamRoute route1 = provider.get(model, cacheBreakpointContext);
@@ -184,5 +184,32 @@ public class UpstreamRouteProviderTest {
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         UpstreamRoute route = provider.get(model, null, "   ");
         assertNotNull(route.next());
+    }
+
+    @Test
+    public void testGet_CachedUpstreamMatchedById() {
+        Model model = new Model();
+        model.setName("model");
+        Upstream upstream1 = new Upstream();
+        upstream1.setId("alpha");
+        upstream1.setEndpoint("shared-endpoint");
+        upstream1.setTier(0);
+        upstream1.setWeight(2);
+        Upstream upstream2 = new Upstream();
+        upstream2.setId("beta");
+        upstream2.setEndpoint("shared-endpoint");
+        upstream2.setTier(0);
+        upstream2.setWeight(2);
+        model.setUpstreams(List.of(upstream1, upstream2));
+
+        UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
+        CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of(), Map.of(), CachePolicy.CACHE_PRIORITY);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("shared-endpoint", "beta", "prefix", null);
+        when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
+
+        UpstreamRoute route = provider.get(model, cacheBreakpointContext);
+        Upstream result = route.next();
+
+        assertEquals(upstream2, result);
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteTest.java
@@ -147,7 +147,7 @@ public class UpstreamRouteTest {
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of(), Map.of(), CachePolicy.AVAILABILITY_PRIORITY);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", "prefix", null);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", null, "prefix", null);
         when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
         UpstreamRoute route = upstreamRouteProvider.get(model, cacheBreakpointContext);
         assertNotNull(route.next());
@@ -171,7 +171,7 @@ public class UpstreamRouteTest {
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of(), Map.of(), CachePolicy.CACHE_PRIORITY);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", "prefix", null);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", null, "prefix", null);
         when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
         UpstreamRoute route = upstreamRouteProvider.get(model, cacheBreakpointContext);
         assertNotNull(route.next());
@@ -195,7 +195,7 @@ public class UpstreamRouteTest {
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of("prefix"), Map.of("prefix", "hash"), CachePolicy.CACHE_PRIORITY);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", "prefix", null);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", null, "prefix", null);
         when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
         UpstreamRoute route = upstreamRouteProvider.get(model, cacheBreakpointContext);
         assertNotNull(route.next());
@@ -228,7 +228,7 @@ public class UpstreamRouteTest {
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
         CacheBreakpointContext cacheBreakpointContext = new CacheBreakpointContext(List.of("prefix"), Map.of("prefix", "hash"), CachePolicy.CACHE_PRIORITY);
-        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", "prefix", null);
+        CachedUpstreamEntry entry = new CachedUpstreamEntry("endpoint2", null, "prefix", null);
         when(upstreamCacheService.getCacheEntry(eq(cacheBreakpointContext), eq(model))).thenReturn(entry);
         UpstreamRoute route = upstreamRouteProvider.get(model, cacheBreakpointContext);
         assertNotNull(route.next());

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteTest.java
@@ -58,10 +58,10 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 1),
-                new Upstream("endpoint3", null, null, null, 1, 1),
-                new Upstream("endpoint4", null, null, null, 1, 1)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 1, null),
+                new Upstream("endpoint3", null, null, null, 1, 1, null),
+                new Upstream("endpoint4", null, null, null, 1, 1, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -108,8 +108,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 1)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 1, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -141,8 +141,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 1)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 1, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -165,8 +165,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 1)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 1, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -189,8 +189,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 1)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 1, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -222,8 +222,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 1)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 1, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -252,8 +252,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, 1, 1),
-                new Upstream("endpoint2", null, null, null, 1, 0)
+                new Upstream("endpoint1", null, null, null, 1, 1, null),
+                new Upstream("endpoint2", null, null, null, 1, 0, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);


### PR DESCRIPTION
Adds support for an `X-UPSTREAM-ID` request header that lets clients pin a single upstream for chat completion and Responses API requests. If the id matches a configured upstream for the deployment it is the only upstream used; otherwise Core responds 400 `Unknown upstream id {id}`.

### Applicable issues

- fixes #1567

### Description of changes

- Added optional `id` field on `Upstream` (config), JSON-aliased as `id` / `dial:id`.
- Introduced `X-UPSTREAM-ID` header constant in `Proxy`.
- New `UpstreamRouteProvider.get(deployment, breakpointContext, upstreamId)` overload that narrows the upstream list to the single match and throws `HttpException(400, "Unknown upstream id <id>")` on miss. Blank/null id is ignored (full load balancing).
- Wired the header through `DeploymentPostController` (chat completions) and `ResponsesController` (responses API); each translates the 400 to a response via its existing error path.
- Tests for the new provider logic; existing test call sites and the `ResponsesControllerTest` deep-stub updated for the new constructor / overload.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.