### PR TITLE
feat: add mcp endpoint in schemas listing result #1564

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationTypeSchemaController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationTypeSchemaController.java
@@ -124,6 +124,9 @@ public class ApplicationTypeSchemaController {
                 if (schemaNode.has(MetaSchemaHolder.APPLICATION_TYPE_ROUTES)) {
                     filteredNode.set(MetaSchemaHolder.APPLICATION_TYPE_ROUTES, schemaNode.get(MetaSchemaHolder.APPLICATION_TYPE_ROUTES));
                 }
+                if (schemaNode.has(MetaSchemaHolder.DIAL_APPLICATION_TYPE_MCP)) {
+                    filteredNode.set(MetaSchemaHolder.DIAL_APPLICATION_TYPE_MCP, schemaNode.get(MetaSchemaHolder.DIAL_APPLICATION_TYPE_MCP));
+                }
 
                 filteredSchemas.add(filteredNode);
             }

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationTypeSchemaApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationTypeSchemaApiTest.java
@@ -44,6 +44,10 @@ public class ApplicationTypeSchemaApiTest extends ResourceBaseTest {
         JsonNode routes = specificType.get("dial:applicationTypeRoutes");
         Assertions.assertNotNull(routes, "dial:applicationTypeRoutes must be exposed in the schema list");
         Assertions.assertTrue(routes.has("data_sync"));
+
+        JsonNode mcp = specificType.get("dial:applicationTypeMcp");
+        Assertions.assertNotNull(mcp, "dial:applicationTypeMcp must be exposed in the schema list");
+        Assertions.assertTrue(mcp.has("dial:endpoint"));
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -1292,7 +1292,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                        "auto_caching" : false,
                        "parallel_tool_calls" : true,
                        "assistant_attachments_in_request": false,
-                       "mcp" : false
+                       "mcp" : true
                      },
                      "defaults" : { },
                      "responses_defaults" : { },

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -307,6 +307,10 @@
           ]
         }
       },
+      "dial:applicationTypeMcp": {
+        "dial:endpoint": "http://localhost:4848/mcp",
+        "dial:transport": "HTTP"
+      },
       "properties": {
         "property1": {
           "title": "Property 1",


### PR DESCRIPTION
Expose `dial:applicationTypeMcp` in the `/v1/application_type_schemas/schemas` listing endpoint so clients can discover whether a schema supports MCP and retrieve the endpoint and transport configuration needed to connect.

### Applicable issues

- fixes #1564

### Description of changes

- `ApplicationTypeSchemaController.listSchemas()`: added `dial:applicationTypeMcp` to the allowlist of fields included in the schema listing response, following the same pattern as `dial:applicationTypeRoutes`
- `aidial.config.json` (test): added `dial:applicationTypeMcp` to the `specific_application_type` test schema
- `ApplicationTypeSchemaApiTest`: added assertions verifying `dial:applicationTypeMcp` and `dial:endpoint` are present in the list response
- `CustomApplicationApiTest`: updated expectation — applications whose schema includes `dial:applicationTypeMcp` now correctly report `"mcp": true` in their capabilities

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.