### PR TITLE
fix: drop URL-encoding from OAuth Basic auth header #1527 (#1574)

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
@@ -10,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -114,12 +113,13 @@ public class TokenService {
         };
     }
 
-    // RFC 6749 §2.3.1: client_id and client_secret are application/x-www-form-urlencoded
-    // before being concatenated with ":" and base64-encoded.
+    // RFC 6749 §2.3.1 specifies URL-encoding credentials before base64, but real-world
+    // authorization servers — Snowflake's /oauth/token-request among them — follow plain
+    // RFC 7617 HTTP Basic (Base64(client_id:client_secret), no URL-encoding). URL-encoding
+    // a client_id like "abc/xyz=" turns "/" and "=" into "%2F" and "%3D"; servers that don't
+    // URL-decode the header then see the wrong credentials and return invalid_client.
     private static String buildBasicAuthHeader(String clientId, String clientSecret) {
-        String encId = URLEncoder.encode(StringUtils.defaultString(clientId), StandardCharsets.UTF_8);
-        String encSecret = URLEncoder.encode(StringUtils.defaultString(clientSecret), StandardCharsets.UTF_8);
-        String credentials = encId + ":" + encSecret;
+        String credentials = StringUtils.defaultString(clientId) + ":" + StringUtils.defaultString(clientSecret);
         return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
@@ -247,9 +247,11 @@ class TokenServiceTest {
         assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
 
-        // RFC 6749 §2.3.1: client_id and client_secret are application/x-www-form-urlencoded before base64
+        // Plain RFC 7617 Basic: client_id and client_secret are concatenated as-is and base64'd
+        // without URL-encoding. This is what Snowflake and most real-world authorization servers
+        // expect (see comment in TokenService#buildBasicAuthHeader).
         String expected = "Basic " + Base64.getEncoder().encodeToString(
-                ("client+id:s3cret%2Fwith%2Bspecial%3Achars").getBytes(StandardCharsets.UTF_8));
+                "client id:s3cret/with+special:chars".getBytes(StandardCharsets.UTF_8));
         assertEquals(expected, headersCaptor.getValue().get("Authorization"));
     }
 


### PR DESCRIPTION
(cherry picked from commit cf85f197f4b9b3e70241f052e1ff12fa3346a7ef)

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1527 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
