### PR TITLE
chore: bump the ai-dial-ci group with 4 updates (cherry-pick #1577)

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -14,7 +14,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.2.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.3.1
     with:
       gitlab-project-id: "2966"
     secrets:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.2.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.3.1
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@4.2.0
+    uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@4.3.1
     secrets: inherit
     with:
       platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/java_release.yml@4.2.0
+    uses: epam/ai-dial-ci/.github/workflows/java_release.yml@4.3.1
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       platforms: "linux/amd64,linux/arm64"


### PR DESCRIPTION
Cherry-picks #1577 into `release-0.44`.

Original PR: epam/ai-dial-core#1577 — dependabot bump of the `ai-dial-ci` reusable-workflow group. Bumps `epam/ai-dial-ci` from `4.2.0` → `4.3.1` (latest) across 4 workflow files.

Files changed:
- `.github/workflows/deploy-development.yml`
- `.github/workflows/pr-title-check.yml`
- `.github/workflows/pr.yml`
- `.github/workflows/release.yml`

The cherry-pick conflicted because `release-0.44` pinned `4.2.0`; resolved by taking the incoming `4.3.1` reference. Net diff vs `release-0.44` is exactly those 4 version-string changes and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)