### PR TITLE
feat: Expose feature flags for max_tokens, max_completion_tokens, and temperature

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Features.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Features.java
@@ -58,4 +58,14 @@ public class Features {
     private Boolean assistantAttachmentsInRequestSupported;
     @JsonAlias({"supportCommentInRateResponse", "support_comment_in_rate_response"})
     private Boolean supportCommentInRateResponse;
+
+    // Feature flags that control which chat-completions parameters the upstream accepts.
+    @JsonAlias({"maxTokensSupported", "max_tokens_supported"})
+    private Boolean maxTokensSupported;
+
+    @JsonAlias({"maxCompletionTokensSupported", "max_completion_tokens_supported"})
+    private Boolean maxCompletionTokensSupported;
+
+    @JsonAlias({"customTemperatureSupported", "custom_temperature_supported"})
+    private Boolean customTemperatureSupported;
 }

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -197,6 +197,9 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
 * `folderAttachmentsSupported`: A boolean parameter to enable/disable attaching folders (batching multiple files). Default is `false`.
 * `accessibleByPerRequestKey`: A boolean parameter to enable/disable access to the model with a [per-request API key](https://docs.dialx.ai/platform/core/per-request-keys). Default is `true`.
 * `contentPartsSupported`: A boolean parameter that indicates whether the deployment supports requests with content parts. Default is `false`.
+* `maxTokensSupported`: A boolean parameter that indicates whether the upstream accepts the legacy `max_tokens` parameter in chat completions requests. Default is `true`.
+* `maxCompletionTokensSupported`: A boolean parameter that indicates whether the upstream accepts `max_completion_tokens` parameter in chat completions requests. Default is `false`.
+* `customTemperatureSupported`: A boolean parameter that indicates whether arbitrary `temperature` values are accepted. If `false`, only the API default (usually `1`) should be used and the client is recommended not to send the `temperature` parameter. Default is `true`.
 * `cacheSupported`: A boolean parameter that indicates whether the deployment supports [LLM caching](https://docs.dialx.ai/tutorials/developers/prompt-caching). Default is `false`.
 * `autoCachingSupported`: A boolean parameter that indicates whether the deployment supports [automatic caching](https://docs.dialx.ai/tutorials/developers/prompt-caching), where it's possible. Default is `false`.
 * `parallelToolCallsSupported`: A boolean parameter that indicates whether the deployment supports `parallel_tool_calls` parameter in a chat completion request. Default is `true`.
@@ -213,6 +216,9 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
                 "tokenizeEndpoint": "http://host/tokinize",
                 "truncatePromptEndpoint": "http://host/truncate",
                 "configurationEndpoint": "http://host/configure",
+                "maxTokensSupported": true,
+                "maxCompletionTokensSupported": false,
+                "customTemperatureSupported": true,
                 "systemPromptSupported": false,
                 "toolsSupported": false,
                 "seedSupported":false,

--- a/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
@@ -30,6 +30,9 @@ public class FeaturesData {
     private boolean parallelToolCalls = true;
     private boolean assistantAttachmentsInRequest = false;
     private boolean mcp = false;
+    private boolean maxTokensSupported = true;
+    private boolean maxCompletionTokensSupported = false;
+    private boolean customTemperatureSupported = true;
 
     @JsonIgnore
     public static FeaturesData createFeatures(Features features) {
@@ -94,6 +97,18 @@ public class FeaturesData {
 
         if (features.getAssistantAttachmentsInRequestSupported() != null) {
             data.setAssistantAttachmentsInRequest(features.getAssistantAttachmentsInRequestSupported());
+        }
+
+        if (features.getMaxTokensSupported() != null) {
+            data.setMaxTokensSupported(features.getMaxTokensSupported());
+        }
+
+        if (features.getMaxCompletionTokensSupported() != null) {
+            data.setMaxCompletionTokensSupported(features.getMaxCompletionTokensSupported());
+        }
+
+        if (features.getCustomTemperatureSupported() != null) {
+            data.setCustomTemperatureSupported(features.getCustomTemperatureSupported());
         }
 
         return data;

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
@@ -946,7 +946,10 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "auto_caching" : false,
                       "parallel_tool_calls" : true,
                       "assistant_attachments_in_request": false,
-                      "mcp" : false
+                      "mcp" : false,
+                      "max_tokens_supported": true,
+                      "max_completion_tokens_supported": false,
+                      "custom_temperature_supported": true
                     },
                     "defaults" : { },
                     "responses_defaults" : { },
@@ -1006,7 +1009,10 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "auto_caching" : false,
                       "parallel_tool_calls" : true,
                       "assistant_attachments_in_request": false,
-                      "mcp" : false
+                      "mcp" : false,
+                      "max_tokens_supported": true,
+                      "max_completion_tokens_supported": false,
+                      "custom_temperature_supported": true
                     },
                     "defaults" : { },
                     "responses_defaults" : { },
@@ -1046,7 +1052,10 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                         "auto_caching" : false,
                         "parallel_tool_calls" : true,
                         "assistant_attachments_in_request": false,
-                        "mcp" : false
+                        "mcp" : false,
+                      "max_tokens_supported": true,
+                      "max_completion_tokens_supported": false,
+                      "custom_temperature_supported": true
                       },
                       "defaults" : { },
                       "responses_defaults" : { },
@@ -1095,7 +1104,10 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "auto_caching" : false,
                       "parallel_tool_calls" : true,
                       "assistant_attachments_in_request": false,
-                      "mcp" : false
+                      "mcp" : false,
+                      "max_tokens_supported": true,
+                      "max_completion_tokens_supported": false,
+                      "custom_temperature_supported": true
                     },
                     "defaults" : { },
                     "responses_defaults" : { },

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -541,7 +541,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "auto_caching" : false,
                                 "parallel_tool_calls" : true,
                                 "assistant_attachments_in_request": false,
-                                "mcp" : false
+                                "mcp" : false,
+                                "max_tokens_supported": true,
+                                "max_completion_tokens_supported": false,
+                                "custom_temperature_supported": true
                                 },
                             "defaults":{},
                             "responses_defaults":{},
@@ -580,7 +583,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                "auto_caching" : false,
                                "parallel_tool_calls" : true,
                                "assistant_attachments_in_request": false,
-                               "mcp" : false
+                               "mcp" : false,
+                                "max_tokens_supported": true,
+                                "max_completion_tokens_supported": false,
+                                "custom_temperature_supported": true
                              },
                              "defaults" : { },
                              "responses_defaults" : { },
@@ -653,7 +659,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                         "auto_caching" : false,
                         "parallel_tool_calls" : true,
                         "assistant_attachments_in_request": false,
-                        "mcp" : false
+                        "mcp" : false,
+                                "max_tokens_supported": true,
+                                "max_completion_tokens_supported": false,
+                                "custom_temperature_supported": true
                     },
                     "defaults":{},
                     "responses_defaults":{},
@@ -701,7 +710,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "auto_caching" : false,
                                 "parallel_tool_calls" : true,
                                 "assistant_attachments_in_request": false,
-                                "mcp" : false
+                                "mcp" : false,
+                                "max_tokens_supported": true,
+                                "max_completion_tokens_supported": false,
+                                "custom_temperature_supported": true
                                 },
                             "defaults":{},
                             "responses_defaults":{},
@@ -741,7 +753,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                               "auto_caching" : false,
                               "parallel_tool_calls" : true,
                               "assistant_attachments_in_request": false,
-                              "mcp" : false
+                              "mcp" : false,
+                                "max_tokens_supported": true,
+                                "max_completion_tokens_supported": false,
+                                "custom_temperature_supported": true
                             },
                             "defaults" : { },
                             "responses_defaults" : { },
@@ -790,7 +805,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                               "auto_caching" : false,
                               "parallel_tool_calls" : true,
                               "assistant_attachments_in_request": false,
-                              "mcp" : false
+                              "mcp" : false,
+                                "max_tokens_supported": true,
+                                "max_completion_tokens_supported": false,
+                                "custom_temperature_supported": true
                             },
                             "defaults" : { },
                             "responses_defaults" : { },
@@ -1292,7 +1310,10 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                        "auto_caching" : false,
                        "parallel_tool_calls" : true,
                        "assistant_attachments_in_request": false,
-                       "mcp" : true
+                       "mcp" : true,
+                       "max_tokens_supported": true,
+                       "max_completion_tokens_supported": false,
+                       "custom_temperature_supported": true
                      },
                      "defaults" : { },
                      "responses_defaults" : { },

--- a/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
@@ -54,7 +54,9 @@ public class ListingTest extends ResourceBaseTest {
                     , "configuration": false, "allow_resume": true, "accessible_by_per_request_key": true,
                     "content_parts": false, "temperature" : true, "cache" : false,
                     "auto_caching" : false, "parallel_tool_calls": true,
-                    "assistant_attachments_in_request": false, "mcp" : false
+                    "assistant_attachments_in_request": false, "mcp" : false,
+                    "max_tokens_supported": true, "max_completion_tokens_supported": false,
+                    "custom_temperature_supported": true
                     }
                 """));
     }
@@ -68,7 +70,9 @@ public class ListingTest extends ResourceBaseTest {
                     , "configuration": true, "allow_resume": true, "accessible_by_per_request_key": true,
                     "content_parts": false, "temperature" : true, "cache" : false,
                     "auto_caching" : false, "parallel_tool_calls": true,
-                    "assistant_attachments_in_request": false, "mcp" : false
+                    "assistant_attachments_in_request": false, "mcp" : false,
+                    "max_tokens_supported": true, "max_completion_tokens_supported": false,
+                    "custom_temperature_supported": true
                     }
                 """));
     }
@@ -82,7 +86,9 @@ public class ListingTest extends ResourceBaseTest {
                     , "configuration": true, "allow_resume": true, "accessible_by_per_request_key": true,
                     "content_parts": false, "temperature" : true, "cache" : false,
                     "auto_caching" : false, "parallel_tool_calls": true,
-                    "assistant_attachments_in_request": false, "mcp" : false
+                    "assistant_attachments_in_request": false, "mcp" : false,
+                    "max_tokens_supported": true, "max_completion_tokens_supported": false,
+                    "custom_temperature_supported": true
                     }
                 """));
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -142,7 +142,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "auto_caching" : false,
                            "parallel_tool_calls" : true,
                            "assistant_attachments_in_request": false,
-                           "mcp" : true
+                           "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                       },
                      "description_keywords" : [ ],
                      "max_retry_attempts" : 1,
@@ -182,7 +185,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                           "auto_caching" : false,
                           "parallel_tool_calls" : true,
                           "assistant_attachments_in_request" : false,
-                          "mcp" : true
+                          "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                         },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,
@@ -223,7 +229,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                           "auto_caching" : false,
                           "parallel_tool_calls" : true,
                           "assistant_attachments_in_request" : false,
-                          "mcp" : true
+                          "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                         },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,
@@ -273,7 +282,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "auto_caching" : false,
                            "parallel_tool_calls" : true,
                            "assistant_attachments_in_request": false,
-                           "mcp" : true
+                           "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                       },
                      "description_keywords" : [ ],
                      "max_retry_attempts" : 1,
@@ -407,7 +419,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                         "auto_caching" : false,
                         "parallel_tool_calls" : true,
                         "assistant_attachments_in_request": false,
-                        "mcp" : true
+                        "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                   },
                   "description_keywords": [],
                   "max_retry_attempts": 1,
@@ -456,7 +471,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                             "auto_caching" : false,
                             "parallel_tool_calls" : true,
                             "assistant_attachments_in_request": false,
-                            "mcp" : true
+                            "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                           },
                       "description_keywords" : [ ],
                       "max_retry_attempts" : 1,
@@ -498,7 +516,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                             "auto_caching" : false,
                             "parallel_tool_calls" : true,
                             "assistant_attachments_in_request": false,
-                            "mcp" : true
+                            "mcp" : true,
+                           "max_tokens_supported": true,
+                           "max_completion_tokens_supported": false,
+                           "custom_temperature_supported": true
                           },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Adds three deployment feature flags so clients can discover which chat-completion parameters an upstream accepts (without guessing from model/deployment name):

- `max_tokens_supported` (default: `true`)
- `max_completion_tokens_supported` (default: `false`)
- `custom_temperature_supported` (default: `true`)

Configured in dynamic settings (`models.*.features`), exposed in deployment listing `features` (same as `tools`, `seed`, etc.). Helps clients avoid 400s when newer models require `max_completion_tokens` instead of `max_tokens` or only default `temperature` ([context](https://community.openai.com/t/why-was-max-tokens-changed-to-max-completion-tokens/938077)).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
