### PR TITLE
fix: clear auth error for toolset tool discovery endpoint #1554

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -36,10 +36,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.net.http.HttpRequest;
 import java.time.Duration;
@@ -169,6 +171,14 @@ public class ToolSetToolsController implements Controller {
                 processAdminToolsResult(client.listTools(cursor));
             }
         } catch (Exception e) {
+            McpHttpClientTransportAuthorizationException authError =
+                    ExceptionUtils.throwableOfType(e, McpHttpClientTransportAuthorizationException.class);
+            if (authError != null) {
+                log.warn("Authorization error when fetching tools from MCP server for toolset: {}", toolSetId, e);
+                HttpStatus status = HttpStatus.fromStatusCode(authError.getResponseInfo().statusCode(), HttpStatus.UNAUTHORIZED);
+                throw new HttpException(status, "Authorization required to fetch tools from toolset '"
+                        + toolSetId + "'. Please sign in to the toolset.");
+            }
             log.error("Failed to fetch tools from MCP server for toolset: {}", toolSetId, e);
             throw new HttpException(HttpStatus.BAD_GATEWAY, "Failed to fetch tools from MCP server");
         }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -66,6 +66,16 @@ public class ToolSetApiTest extends ResourceBaseTest {
         };
     }
 
+    private static TestWebServer.Handler mcpAuthErrorHandler(int statusCode) {
+        return request -> {
+            if ("GET".equals(request.getMethod())) {
+                return new MockResponse().setResponseCode(405);
+            }
+            // MCP server rejects authorization during the initialize handshake
+            return new MockResponse().setResponseCode(statusCode);
+        };
+    }
+
     private static String extractJsonRpcId(String body) {
         try {
             JsonNode node = ProxyUtil.MAPPER.readTree(body);
@@ -2208,6 +2218,28 @@ public class ToolSetApiTest extends ResourceBaseTest {
         Response resp = send(HttpMethod.GET, "/v1/toolset/unknown-toolset/tools",
                 null, null, "authorization", "admin");
         assertEquals(404, resp.status());
+    }
+
+    @Test
+    void testGetAllTools_Unauthorized() {
+        try (TestWebServer ignore = new TestWebServer(9876, mcpAuthErrorHandler(401))) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/git/tools",
+                    null, null, "authorization", "admin");
+
+            assertEquals(401, resp.status());
+            assertTrue(resp.body().contains("Please sign in to the toolset"), resp.body());
+        }
+    }
+
+    @Test
+    void testGetAllTools_Forbidden() {
+        try (TestWebServer ignore = new TestWebServer(9876, mcpAuthErrorHandler(403))) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/git/tools",
+                    null, null, "authorization", "admin");
+
+            assertEquals(403, resp.status());
+            assertTrue(resp.body().contains("Please sign in to the toolset"), resp.body());
+        }
     }
 
     @Test


### PR DESCRIPTION
When a user isn't authenticated to a toolset's MCP server, `GET /v1/toolset/{id}/tools` (and `/allowed-tools`) previously returned a confusing 502 Bad Gateway. This detects the MCP authorization failure and returns the upstream's actual 401/403 status with an actionable message telling the user to sign in to the toolset.

### Applicable issues

- fixes #1554

### Description of changes

- In `ToolSetToolsController.fetchTools()`, the blanket `catch (Exception e)` now inspects the cause chain (via `ExceptionUtils.throwableOfType`) for `McpHttpClientTransportAuthorizationException`, thrown by the MCP SDK during `client.initialize()` when the upstream replies 401/403.
- On an auth error, it propagates the upstream status (401/403 via `HttpStatus.fromStatusCode`) with the message "Authorization required to fetch tools from toolset '<id>'. Please sign in to the toolset." Logged at `warn` since it's a user-fixable condition. Non-auth errors keep the existing 502.
- Added `ToolSetApiTest` cases (`testGetAllTools_Unauthorized`, `testGetAllTools_Forbidden`) using a new `mcpAuthErrorHandler` that returns an auth error on the MCP initialize handshake.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.