### PR TITLE
feat(deployment): add reasoningEffortsSupported feature flag

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Features.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Features.java
@@ -43,6 +43,7 @@ public class Features {
     /**
      * Try to create automatic cache, where it's possible. We will route request that is cached to same upstream.
      * But in case, when cache upstream is not available, we will fallback to another available upstream, and will create cache there.
+     *
      * <p>
      *  <b>Note</b>. Core should calculate hash for all prefixes for each request, and check their existence in Redis.
      * </p>
@@ -68,4 +69,7 @@ public class Features {
 
     @JsonAlias({"customTemperatureSupported", "custom_temperature_supported"})
     private Boolean customTemperatureSupported;
+
+    @JsonAlias({"reasoningEffortsSupported", "reasoning_efforts_supported"})
+    private Boolean reasoningEffortsSupported;
 }

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -156,6 +156,7 @@ The following features are supported:
 * `contentPartsSupported`: A boolean parameter that indicates whether the deployment supports requests with content parts or not.Default is `false`.
 * `consentRequired`: A boolean parameter that indicates whether the application requires user consent before use.
 * `supportCommentInRateResponse`: A boolean parameters that indicates whether the application supports the field `comment` in rate response payload.
+* `reasoningEffortsSupported`: A boolean parameter that indicates whether the deployment supports the `effort` parameter in chat completions requests. When enabled, clients can specify the reasoning effort level (e.g., `low`, `medium`, `high`) for reasoning models. Default is `false`.
 
 **Example**:
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -205,6 +205,7 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
 * `parallelToolCallsSupported`: A boolean parameter that indicates whether the deployment supports `parallel_tool_calls` parameter in a chat completion request. Default is `true`.
 * `assistantAttachmentsInRequestSupported`: A boolean parameter that indicates whether the deployment supports DIAL attachments in the assistant messages. Default is `false`. When set to `true`, DIAL Chat must preserve attachments in the assistant messages, instead of removing them. The feature is especially useful for models that can generate attachments as well as take attachments in its input. A typical example of such a model is an image-editing model.
 * `supportCommentInRateResponse`: A boolean parameters that indicates whether the application supports the field `comment` in rate response payload.
+* `reasoningEffortsSupported`: A boolean parameter that indicates whether the deployment supports the `effort` parameter in chat completions requests. When enabled, clients can specify the reasoning effort level (e.g., `low`, `medium`, `high`) for reasoning models. Default is `false`.
 
 **Example**
 
@@ -226,7 +227,8 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
                 "folderAttachmentsSupported": false,
                 "accessibleByPerRequestKey": true,
                 "contentPartsSupported": false,
-                "assistantAttachmentsInRequestSupported": false
+                "assistantAttachmentsInRequestSupported": false,
+                "reasoningEffortsSupported": false
             },
         }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/config/FileConfigStore.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/FileConfigStore.java
@@ -239,6 +239,9 @@ public final class FileConfigStore implements ConfigStore {
         if (modelFeatures.getAutoCachingSupported() == null) {
             modelFeatures.setAutoCachingSupported(features.getAutoCachingSupported());
         }
+        if (modelFeatures.getReasoningEffortsSupported() == null) {
+            modelFeatures.setReasoningEffortsSupported(features.getReasoningEffortsSupported());
+        }
     }
 
     private JsonMapper buildJsonMapper(JsonObject settings) {

--- a/server/src/main/java/com/epam/aidial/core/server/config/FileConfigStore.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/FileConfigStore.java
@@ -186,64 +186,6 @@ public final class FileConfigStore implements ConfigStore {
         }
     }
 
-    private static void setMissingFeatures(Deployment model, Features features) {
-        if (features == null) {
-            return;
-        }
-
-        Features modelFeatures = model.getFeatures();
-        if (modelFeatures == null) {
-            model.setFeatures(features);
-            return;
-        }
-
-        if (modelFeatures.getRateEndpoint() == null) {
-            modelFeatures.setRateEndpoint(features.getRateEndpoint());
-        }
-        if (modelFeatures.getTokenizeEndpoint() == null) {
-            modelFeatures.setTokenizeEndpoint(features.getTokenizeEndpoint());
-        }
-        if (modelFeatures.getTruncatePromptEndpoint() == null) {
-            modelFeatures.setTruncatePromptEndpoint(features.getTruncatePromptEndpoint());
-        }
-        if (modelFeatures.getSystemPromptSupported() == null) {
-            modelFeatures.setSystemPromptSupported(features.getSystemPromptSupported());
-        }
-        if (modelFeatures.getToolsSupported() == null) {
-            modelFeatures.setToolsSupported(features.getToolsSupported());
-        }
-        if (modelFeatures.getSeedSupported() == null) {
-            modelFeatures.setSeedSupported(features.getSeedSupported());
-        }
-        if (modelFeatures.getUrlAttachmentsSupported() == null) {
-            modelFeatures.setUrlAttachmentsSupported(features.getUrlAttachmentsSupported());
-        }
-        if (modelFeatures.getFolderAttachmentsSupported() == null) {
-            modelFeatures.setFolderAttachmentsSupported(features.getFolderAttachmentsSupported());
-        }
-        if (modelFeatures.getAllowResume() == null) {
-            modelFeatures.setAllowResume(features.getAllowResume());
-        }
-        if (modelFeatures.getAccessibleByPerRequestKey() == null) {
-            modelFeatures.setAccessibleByPerRequestKey(features.getAccessibleByPerRequestKey());
-        }
-        if (modelFeatures.getContentPartsSupported() == null) {
-            modelFeatures.setContentPartsSupported(features.getContentPartsSupported());
-        }
-        if (modelFeatures.getTemperatureSupported() == null) {
-            modelFeatures.setTemperatureSupported(features.getTemperatureSupported());
-        }
-        if (modelFeatures.getCacheSupported() == null) {
-            modelFeatures.setCacheSupported(features.getCacheSupported());
-        }
-        if (modelFeatures.getAutoCachingSupported() == null) {
-            modelFeatures.setAutoCachingSupported(features.getAutoCachingSupported());
-        }
-        if (modelFeatures.getReasoningEffortsSupported() == null) {
-            modelFeatures.setReasoningEffortsSupported(features.getReasoningEffortsSupported());
-        }
-    }
-
     private JsonMapper buildJsonMapper(JsonObject settings) {
         JsonMapper mapper = JsonMapper.builder()
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)

--- a/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
@@ -33,6 +33,7 @@ public class FeaturesData {
     private boolean maxTokensSupported = true;
     private boolean maxCompletionTokensSupported = false;
     private boolean customTemperatureSupported = true;
+    private boolean reasoningEffortsSupported = false;
 
     @JsonIgnore
     public static FeaturesData createFeatures(Features features) {
@@ -109,6 +110,10 @@ public class FeaturesData {
 
         if (features.getCustomTemperatureSupported() != null) {
             data.setCustomTemperatureSupported(features.getCustomTemperatureSupported());
+        }
+
+        if (features.getReasoningEffortsSupported() != null) {
+            data.setReasoningEffortsSupported(features.getReasoningEffortsSupported());
         }
 
         return data;

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
@@ -949,7 +949,8 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "mcp" : false,
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
-                      "custom_temperature_supported": true
+                      "custom_temperature_supported": true,
+                      "reasoning_efforts_supported": false
                     },
                     "defaults" : { },
                     "responses_defaults" : { },
@@ -1012,7 +1013,8 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "mcp" : false,
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
-                      "custom_temperature_supported": true
+                      "custom_temperature_supported": true,
+                      "reasoning_efforts_supported": false
                     },
                     "defaults" : { },
                     "responses_defaults" : { },
@@ -1055,7 +1057,8 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                         "mcp" : false,
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
-                      "custom_temperature_supported": true
+                      "custom_temperature_supported": true,
+                      "reasoning_efforts_supported": false
                       },
                       "defaults" : { },
                       "responses_defaults" : { },
@@ -1107,7 +1110,8 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "mcp" : false,
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
-                      "custom_temperature_supported": true
+                      "custom_temperature_supported": true,
+                      "reasoning_efforts_supported": false
                     },
                     "defaults" : { },
                     "responses_defaults" : { },

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -544,7 +544,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "mcp" : false,
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
-                                "custom_temperature_supported": true
+                                "custom_temperature_supported": true,
+                                "reasoning_efforts_supported": false
                                 },
                             "defaults":{},
                             "responses_defaults":{},
@@ -586,7 +587,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                "mcp" : false,
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
-                                "custom_temperature_supported": true
+                                "custom_temperature_supported": true,
+                                "reasoning_efforts_supported": false
                              },
                              "defaults" : { },
                              "responses_defaults" : { },
@@ -662,7 +664,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                         "mcp" : false,
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
-                                "custom_temperature_supported": true
+                                "custom_temperature_supported": true,
+                                "reasoning_efforts_supported": false
                     },
                     "defaults":{},
                     "responses_defaults":{},
@@ -713,7 +716,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "mcp" : false,
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
-                                "custom_temperature_supported": true
+                                "custom_temperature_supported": true,
+                                "reasoning_efforts_supported": false
                                 },
                             "defaults":{},
                             "responses_defaults":{},
@@ -756,7 +760,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                               "mcp" : false,
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
-                                "custom_temperature_supported": true
+                                "custom_temperature_supported": true,
+                                "reasoning_efforts_supported": false
                             },
                             "defaults" : { },
                             "responses_defaults" : { },
@@ -808,7 +813,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                               "mcp" : false,
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
-                                "custom_temperature_supported": true
+                                "custom_temperature_supported": true,
+                                "reasoning_efforts_supported": false
                             },
                             "defaults" : { },
                             "responses_defaults" : { },
@@ -1313,7 +1319,8 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                        "mcp" : true,
                        "max_tokens_supported": true,
                        "max_completion_tokens_supported": false,
-                       "custom_temperature_supported": true
+                       "custom_temperature_supported": true,
+                       "reasoning_efforts_supported": false
                      },
                      "defaults" : { },
                      "responses_defaults" : { },

--- a/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
@@ -56,7 +56,7 @@ public class ListingTest extends ResourceBaseTest {
                     "auto_caching" : false, "parallel_tool_calls": true,
                     "assistant_attachments_in_request": false, "mcp" : false,
                     "max_tokens_supported": true, "max_completion_tokens_supported": false,
-                    "custom_temperature_supported": true
+                    "custom_temperature_supported": true, "reasoning_efforts_supported": false
                     }
                 """));
     }
@@ -72,7 +72,7 @@ public class ListingTest extends ResourceBaseTest {
                     "auto_caching" : false, "parallel_tool_calls": true,
                     "assistant_attachments_in_request": false, "mcp" : false,
                     "max_tokens_supported": true, "max_completion_tokens_supported": false,
-                    "custom_temperature_supported": true
+                    "custom_temperature_supported": true, "reasoning_efforts_supported": false
                     }
                 """));
     }
@@ -88,7 +88,7 @@ public class ListingTest extends ResourceBaseTest {
                     "auto_caching" : false, "parallel_tool_calls": true,
                     "assistant_attachments_in_request": false, "mcp" : false,
                     "max_tokens_supported": true, "max_completion_tokens_supported": false,
-                    "custom_temperature_supported": true
+                    "custom_temperature_supported": true, "reasoning_efforts_supported": false
                     }
                 """));
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -155,7 +155,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                       },
                      "description_keywords" : [ ],
                      "max_retry_attempts" : 1,
@@ -198,7 +199,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                           "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                         },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,
@@ -242,7 +244,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                           "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                         },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,
@@ -295,7 +298,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                       },
                      "description_keywords" : [ ],
                      "max_retry_attempts" : 1,
@@ -432,7 +436,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                         "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                   },
                   "description_keywords": [],
                   "max_retry_attempts": 1,
@@ -484,7 +489,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                             "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                           },
                       "description_keywords" : [ ],
                       "max_retry_attempts" : 1,
@@ -529,7 +535,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                             "mcp" : true,
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
-                           "custom_temperature_supported": true
+                           "custom_temperature_supported": true,
+                           "reasoning_efforts_supported": false
                           },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Add easoningEffortsSupported feature flag to deployments — indicates whether a deployment supports the ffort parameter (OpenAI chat completions/responses API).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.