### PR TITLE
fix: decode gzip-compressed MCP tools/list responses #1586

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthorizationClient.java
@@ -4,13 +4,12 @@ import com.epam.aidial.core.credentials.service.metadata.HttpHeadersHandler;
 import com.epam.aidial.core.credentials.util.JsonMapperUtil;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.util.Compression;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.Strings;
 import org.apache.hc.core5.http.ContentType;
 
-import java.io.ByteArrayInputStream;
 import java.net.ConnectException;
 import java.net.ProxySelector;
 import java.net.URI;
@@ -21,10 +20,7 @@ import java.nio.channels.UnresolvedAddressException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
 
 @Slf4j
@@ -130,31 +126,13 @@ public class ResourceAuthorizationClient {
 
     // Some OAuth servers (e.g., CDN-fronted) return Content-Encoding: gzip even when the client
     // did not request it. Java's built-in HttpClient does not auto-decompress, so we do it here.
-    // Per RFC 9110 §8.4, any coding we do not understand MUST be treated as undeliverable, and
-    // §8.4.1.3 requires "x-gzip" be considered equivalent to "gzip".
-    @SneakyThrows
     private static String decodeBody(HttpResponse<byte[]> response) {
-        byte[] body = response.body();
-        if (body == null || body.length == 0) {
-            return "";
+        try {
+            byte[] decoded = Compression.decodeHttpBody(response.headers().allValues("Content-Encoding"), response.body());
+            return decoded == null ? "" : new String(decoded, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
-        List<String> codings = response.headers().allValues("Content-Encoding").stream()
-                .flatMap(value -> Arrays.stream(value.split(",")))
-                .map(String::trim)
-                .filter(coding -> !coding.isEmpty())
-                .toList();
-        if (codings.isEmpty() || (codings.size() == 1 && Strings.CI.equals(codings.getFirst(), "identity"))) {
-            return new String(body, StandardCharsets.UTF_8);
-        }
-        if (codings.size() == 1 && (Strings.CI.equals(codings.getFirst(), "gzip")
-                || Strings.CI.equals(codings.getFirst(), "x-gzip"))) {
-            try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(body))) {
-                return new String(gzip.readAllBytes(), StandardCharsets.UTF_8);
-            }
-        }
-        throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR,
-                "Unsupported Content-Encoding '%s' from authorization server".formatted(String.join(", ", codings)),
-                Map.of(), "");
     }
 
     private java.time.Duration createRequestConfig() {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/McpProxyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/McpProxyController.java
@@ -25,6 +25,7 @@ import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.util.Compression;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.buffer.ByteBufInputStream;
@@ -248,7 +249,8 @@ public class McpProxyController implements Controller {
         String contentType = proxyResponse.getHeader(HttpHeaders.CONTENT_TYPE);
         if (Strings.CI.contains(contentType, HEADER_CONTENT_TYPE_APPLICATION_JSON)) {
             ProxyUtil.copyHeaders(proxyResponse.headers(), response.headers());
-            proxyResponse.body().onSuccess(body -> handleResponse(responseStatusCode, body))
+            List<String> contentEncodings = proxyResponse.headers().getAll(HttpHeaders.CONTENT_ENCODING);
+            proxyResponse.body().onSuccess(body -> handleResponse(responseStatusCode, body, contentEncodings))
                     .onFailure(this::handleResponseError);
         } else {
             handleSseProxyResponse(proxyResponse);
@@ -297,13 +299,17 @@ public class McpProxyController implements Controller {
         logStore.save(context);
     }
 
-    private void handleResponse(int responseStatus, Buffer proxyResponseBody) {
+    private void handleResponse(int responseStatus, Buffer proxyResponseBody, List<String> contentEncodings) {
         Future<Buffer> future;
         if (requireToolFiltering()) {
-            try (InputStream stream = new ByteBufInputStream(proxyResponseBody.getByteBuf())) {
-                JsonNode tree = ProxyUtil.MAPPER.readTree(stream);
+            try {
+                byte[] decoded = Compression.decodeHttpBody(contentEncodings, proxyResponseBody.getBytes());
+                JsonNode tree = ProxyUtil.MAPPER.readTree(decoded);
                 FilterAllowedToolsFn fn = new FilterAllowedToolsFn(proxy, context);
                 future = fn.apply(tree).map(result -> Buffer.buffer(result.toString()));
+                // We re-serialize the filtered tool list as plain JSON, so the Content-Encoding
+                // copied from the origin no longer describes the body we send to the client.
+                context.getResponse().headers().remove(HttpHeaders.CONTENT_ENCODING);
             } catch (Throwable e) {
                 if (e instanceof HttpException httpException) {
                     respond(httpException.getStatus(), httpException.getMessage());

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -674,6 +674,57 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testProxyMcpPostCall_ListTools_GzippedResponse() throws JsonProcessingException {
+        // Regression for the gzip MCP proxy bug: a CDN-fronted MCP server may gzip the tools/list
+        // response regardless of Accept-Encoding. Core must decompress before filtering, and must
+        // not leave the re-serialized (plain) body labeled Content-Encoding: gzip. Without the fix
+        // Core fails JSON parsing on the raw gzip bytes and returns 400 "Invalid response body from
+        // MCP server"; without the header removal the client cannot decode the response.
+        String mcpRequest = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 1,
+                   "method": "tools/list",
+                   "params": {
+                     "cursor": "optional-cursor-value"
+                   }
+                 }
+                """;
+        String mcpResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 1,
+                   "result": {
+                     "tools": [
+                       {
+                         "name": "branch",
+                         "title": "Manage branches"
+                       },
+                       {
+                         "name": "tag",
+                         "title": "Manage tags"
+                       }
+                     ],
+                     "nextCursor": "next-page-cursor"
+                   }
+                 }
+                """;
+        TestWebServer.Handler handler = request -> gzippedJsonResponse(mcpResponse);
+        try (TestWebServer ignore = new TestWebServer(9876, handler)) {
+            // "git" toolset has allowedTools: ["branch", "remote"]
+            Response resp = send(HttpMethod.POST, "/v1/toolset/git/mcp", null,
+                    mcpRequest, "Content-Type", "application/json");
+
+            assertEquals(200, resp.status(),
+                    () -> "expected gzipped tools/list to be decoded and filtered but got: " + resp.body());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = (ArrayNode) json.get("result").get("tools");
+            assertEquals(1, tools.size());
+            assertEquals("branch", tools.get(0).get("name").asText());
+        }
+    }
+
+    @Test
     void testProxyMcpPostCall_ListAllTools() throws JsonProcessingException {
         String mcpRequest = """
                 {

--- a/storage/src/main/java/com/epam/aidial/core/storage/util/Compression.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/util/Compression.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipException;
@@ -40,5 +42,39 @@ public class Compression {
             log.warn("Failed to decompress provided input: {}", e.getMessage());
             return input;
         }
+    }
+
+    /**
+     * Decodes an HTTP response body according to its Content-Encoding header(s), per RFC 9110 §8.4.
+     * Supports {@code identity} and {@code gzip}/{@code x-gzip}; any other or combined coding is
+     * rejected. JDK HttpClient and Vert.x do not auto-decompress, so callers that parse or proxy
+     * upstream bodies must decode explicitly. Unlike {@link #decompress}, a corrupt gzip stream is
+     * surfaced as an error rather than passed through.
+     *
+     * @param contentEncodings raw Content-Encoding header values (each may be a comma-separated list)
+     * @param body             raw response bytes (may be null or empty)
+     * @return decoded bytes, or the input unchanged when no decoding applies
+     * @throws IllegalArgumentException when the coding is unsupported; callers map it to a status
+     */
+    @SneakyThrows
+    public byte[] decodeHttpBody(List<String> contentEncodings, byte[] body) {
+        if (body == null || body.length == 0) {
+            return body;
+        }
+        List<String> codings = contentEncodings.stream()
+                .flatMap(value -> Arrays.stream(value.split(",")))
+                .map(String::trim)
+                .filter(coding -> !coding.isEmpty())
+                .toList();
+        if (codings.isEmpty() || (codings.size() == 1 && codings.getFirst().equalsIgnoreCase("identity"))) {
+            return body;
+        }
+        if (codings.size() == 1 && (codings.getFirst().equalsIgnoreCase("gzip")
+                || codings.getFirst().equalsIgnoreCase("x-gzip"))) {
+            try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(body))) {
+                return gzip.readAllBytes();
+            }
+        }
+        throw new IllegalArgumentException("Unsupported Content-Encoding '%s'".formatted(String.join(", ", codings)));
     }
 }

--- a/storage/src/test/java/com/epam/aidial/core/storage/util/CompressionTest.java
+++ b/storage/src/test/java/com/epam/aidial/core/storage/util/CompressionTest.java
@@ -2,9 +2,12 @@ package com.epam.aidial.core.storage.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,5 +37,28 @@ public class CompressionTest {
         byte[] actual = Compression.decompress("gzip", content);
 
         assertEquals(content, actual);
+    }
+
+    @Test
+    public void testDecodeHttpBody() {
+        byte[] content = "Hello world!".getBytes();
+        byte[] gzipped = Compression.compress("gzip", content);
+
+        // gzip and x-gzip are decoded, case-insensitively
+        assertArrayEquals(content, Compression.decodeHttpBody(List.of("gzip"), gzipped));
+        assertArrayEquals(content, Compression.decodeHttpBody(List.of("x-gzip"), gzipped));
+        assertArrayEquals(content, Compression.decodeHttpBody(List.of("GZIP"), gzipped));
+
+        // identity or no coding is passed through unchanged
+        assertArrayEquals(content, Compression.decodeHttpBody(List.of("identity"), content));
+        assertArrayEquals(content, Compression.decodeHttpBody(List.of(), content));
+
+        // empty/null bodies are returned as-is
+        assertArrayEquals(new byte[0], Compression.decodeHttpBody(List.of("gzip"), new byte[0]));
+        assertNull(Compression.decodeHttpBody(List.of("gzip"), null));
+
+        // unsupported or combined codings are rejected
+        assertThrows(IllegalArgumentException.class, () -> Compression.decodeHttpBody(List.of("br"), content));
+        assertThrows(IllegalArgumentException.class, () -> Compression.decodeHttpBody(List.of("gzip, identity"), gzipped));
     }
 }


### PR DESCRIPTION
The MCP toolset proxy parsed the raw upstream body when filtering `tools/list`, so a gzip-compressed response (e.g. from CDN-fronted MCP servers like Cloudflare-fronted `mcp.epam.com`) failed JSON parsing and returned `400 "Invalid response body from MCP server"`. This decodes the body by its `Content-Encoding` before parsing.

### Applicable issues

- fixes #1586

### Description of changes

- `McpProxyController.handleResponse`: decode the upstream response by `Content-Encoding` before `readTree`, and strip the now-stale `Content-Encoding` header from the re-serialized (plain JSON) client response.
- Extract gzip/identity decoding into a shared `Compression.decodeHttpBody` helper (RFC 9110 §8.4: `identity`/`gzip`/`x-gzip`, comma-split, unsupported → `IllegalArgumentException`); reuse it from `ResourceAuthorizationClient` (dedupes the existing OAuth-discovery gzip handling from #1493).
- Tests: unit coverage of `Compression.decodeHttpBody` branches + an integration test for gzip `tools/list` through the proxy.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.