### PR TITLE
feat: upload large files into a temporary folder #1604

### DIFF
--- a/server/src/test/java/com/epam/aidial/core/server/FileApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/FileApiTest.java
@@ -659,6 +659,62 @@ public class FileApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testSmallThenBigFileUploadSameKey(Vertx vertx, VertxTestContext context) {
+        // Regression test for issue #1594/#1604: overwriting a small file with a large (multipart) file
+        // at the same key must return the large file, not the stale small one.
+        Checkpoint checkpoint = context.checkpoint(3);
+        WebClient client = WebClient.create(vertx);
+
+        byte[] smallContent = new byte[1024];
+        IntStream.range(0, smallContent.length).forEach(i -> smallContent[i] = (byte) i);
+        byte[] bigContent = new byte[(int) (BlobWriteStream.MIN_PART_SIZE_BYTES * 1.5)];
+        IntStream.range(0, bigContent.length).forEach(i -> bigContent[i] = (byte) (2 * i));
+
+        String path = "/v1/files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/overwrite.bin";
+
+        Future.succeededFuture().compose((mapper) -> {
+            Promise<Void> promise = Promise.promise();
+            // upload small file (stored as a single blob, body cached in Redis)
+            client.put(serverPort, "localhost", path)
+                    .putHeader("Api-key", "proxyKey2")
+                    .as(BodyCodec.string())
+                    .sendMultipartForm(generateMultipartForm("overwrite.bin", smallContent, "application/x-binary"),
+                            context.succeeding(response -> context.verify(() -> {
+                                assertEquals(200, response.statusCode());
+                                checkpoint.flag();
+                                promise.complete();
+                            })));
+
+            return promise.future();
+        }).compose((mapper) -> {
+            Promise<Void> promise = Promise.promise();
+            // overwrite with a large file (multipart upload)
+            client.put(serverPort, "localhost", path)
+                    .putHeader("Api-key", "proxyKey2")
+                    .as(BodyCodec.string())
+                    .sendMultipartForm(generateMultipartForm("overwrite.bin", bigContent, "application/x-binary"),
+                            context.succeeding(response -> context.verify(() -> {
+                                assertEquals(200, response.statusCode());
+                                Assertions.assertNotNull(response.getHeader(HttpHeaders.ETAG));
+                                checkpoint.flag();
+                                promise.complete();
+                            })));
+
+            return promise.future();
+        }).andThen((result) -> {
+            // read the file back - must be the large content, not the stale small one
+            client.get(serverPort, "localhost", path)
+                    .putHeader("Api-key", "proxyKey2")
+                    .as(BodyCodec.buffer())
+                    .send(context.succeeding(response -> context.verify(() -> {
+                        assertEquals(200, response.statusCode());
+                        assertArrayEquals(bigContent, response.body().getBytes());
+                        checkpoint.flag();
+                    })));
+        });
+    }
+
+    @Test
     public void testBigFileEvents(Vertx vertx, VertxTestContext context) {
         Checkpoint checkpoint = context.checkpoint(4);
         WebClient client = WebClient.create(vertx);

--- a/storage/src/main/java/com/epam/aidial/core/storage/data/ResourceUpload.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/data/ResourceUpload.java
@@ -21,15 +21,23 @@ public class ResourceUpload {
     private final String contentType;
     private final long updatedAt;
     private final long createdAt;
+    private final String author;
+    /**
+     * Temporary blob path the multipart upload is assembled at before being moved to the target resource.
+     */
+    private final String tempPath;
     private long contentLength;
     private int chunkNumber = 0;
 
-    public ResourceUpload(BlobStorage blobStorage, MultipartUpload mpu, String contentType, long createdAt, long updatedAt) {
+    public ResourceUpload(BlobStorage blobStorage, MultipartUpload mpu, String contentType,
+                          long createdAt, long updatedAt, String author, String tempPath) {
         this.multipartUpload = mpu;
         this.blobStorage = blobStorage;
         this.contentType = contentType;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.author = author;
+        this.tempPath = tempPath;
     }
 
     public void addChunk(ByteBuf chunk) throws IOException {

--- a/storage/src/main/java/com/epam/aidial/core/storage/data/ResourceUpload.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/data/ResourceUpload.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.storage.data;
 
 import com.epam.aidial.core.storage.blobstore.BlobStorage;
+import com.epam.aidial.core.storage.util.EtagBuilder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import lombok.Data;
@@ -12,6 +13,7 @@ import org.jclouds.io.payloads.InputStreamPayload;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ResourceUpload {
@@ -19,25 +21,24 @@ public class ResourceUpload {
     private final BlobStorage blobStorage;
     private final List<MultipartPart> parts = new ArrayList<>();
     private final String contentType;
-    private final long updatedAt;
-    private final long createdAt;
-    private final String author;
+    private final Map<String, String> userMetadata;
+    private final EtagBuilder etagBuilder;
     /**
      * Temporary blob path the multipart upload is assembled at before being moved to the target resource.
      */
     private final String tempPath;
     private long contentLength;
     private int chunkNumber = 0;
+    private String etag;
 
     public ResourceUpload(BlobStorage blobStorage, MultipartUpload mpu, String contentType,
-                          long createdAt, long updatedAt, String author, String tempPath) {
+                          Map<String, String> userMetadata, String tempPath) {
         this.multipartUpload = mpu;
         this.blobStorage = blobStorage;
         this.contentType = contentType;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.author = author;
+        this.userMetadata = userMetadata;
         this.tempPath = tempPath;
+        this.etagBuilder = new EtagBuilder();
     }
 
     public void addChunk(ByteBuf chunk) throws IOException {
@@ -46,6 +47,7 @@ public class ResourceUpload {
             parts.add(part);
         }
         contentLength += chunk.readableBytes();
+        etagBuilder.append(chunk.nioBuffer());
     }
 
     public void abort() {
@@ -58,5 +60,12 @@ public class ResourceUpload {
         payload.getContentMetadata().setContentLength((long) buffer.readableBytes());
 
         return payload;
+    }
+
+    public String calculateEtag() {
+        if (etag == null) {
+            etag = etagBuilder.build();
+        }
+        return etag;
     }
 }

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -53,6 +53,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -91,6 +96,22 @@ public class ResourceService implements AutoCloseable {
      * System folder large files are uploaded to before being moved to the target resource, see issue #1604.
      */
     public static final String TEMP_FOLDER = ".dial-tmp";
+    /**
+     * Files uploaded to the {@link #TEMP_FOLDER} are grouped into sub-folders named after the hour they were uploaded
+     * in, e.g. {@code .dial-tmp/2024-01-31 13/<uuid>}.
+     */
+    private static final DateTimeFormatter TEMP_FOLDER_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH")
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .toFormatter();
+    /**
+     * How frequently the scheduled job scans the {@link #TEMP_FOLDER} for expired files.
+     */
+    private static final long TEMP_CLEANUP_PERIOD = Duration.ofHours(24).toMillis();
+    /**
+     * A temp file is considered expired and removed once its upload hour ended more than this duration ago.
+     */
+    private static final Duration TEMP_FILE_TTL = Duration.ofHours(1);
     private static final String COMPRESS_ATTRIBUTE = "compress";
     private static final String AUTHOR_ATTRIBUTE = "author";
 
@@ -129,6 +150,7 @@ public class ResourceService implements AutoCloseable {
     private final int maxSize;
     private final int maxSizeToCache;
     private final TimerService.Timer syncTimer;
+    private final TimerService.Timer tempCleanupTimer;
     private final long syncDelay;
     private final int syncBatch;
     private final Duration cacheExpiration;
@@ -169,12 +191,14 @@ public class ResourceService implements AutoCloseable {
         this.resourceTypeExpiration = Objects.requireNonNullElseGet(settings.resourceTypesExpiration, Map::of);
         this.senderPodIdSupplier = senderPodIdSupplier;
         this.syncTimer = timerService.scheduleWithFixedDelay(settings.syncPeriod, settings.syncPeriod, this::sync);
+        this.tempCleanupTimer = timerService.scheduleWithFixedDelay(TEMP_CLEANUP_PERIOD, TEMP_CLEANUP_PERIOD, this::cleanupTempFolder);
     }
 
     @SneakyThrows
     @Override
     public void close() {
         syncTimer.close();
+        tempCleanupTimer.close();
     }
 
     public ResourceTopic.Subscription subscribeResources(Collection<ResourceDescriptor> resources,
@@ -663,23 +687,77 @@ public class ResourceService implements AutoCloseable {
             Map<String, String> userMetadata = toUserMetadata(null, createdAt, updatedAt, resource.getType().name(), author);
             // Assemble the upload in an isolated temporary location to avoid concurrent modifications of the
             // target key while the multipart upload is in progress (see issue #1604).
-            String tempPath = tempBlobPath(resource);
+            String tempPath = tempBlobPath();
             MultipartUpload mpu = blobStore.initMultipartUpload(tempPath, contentType, userMetadata);
-            return new ResourceUpload(blobStore, mpu, contentType, createdAt, updatedAt, author, tempPath);
+            return new ResourceUpload(blobStore, mpu, contentType, userMetadata, tempPath);
         }
     }
 
-    private static String tempBlobPath(ResourceDescriptor resource) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(resource.getBucketLocation())
-                .append(TEMP_FOLDER).append(ResourceDescriptor.PATH_SEPARATOR)
-                .append(resource.getType().group()).append(ResourceDescriptor.PATH_SEPARATOR);
-        String parentPath = resource.getParentPath();
-        if (parentPath != null) {
-            builder.append(parentPath).append(ResourceDescriptor.PATH_SEPARATOR);
+    private static String tempBlobPath() {
+        String separator = ResourceDescriptor.PATH_SEPARATOR;
+        String folder = LocalDateTime.now().format(TEMP_FOLDER_FORMATTER);
+        return TEMP_FOLDER + separator + folder + separator + UUID.randomUUID();
+    }
+
+    /**
+     * Scans the {@link #TEMP_FOLDER} and removes expired files. A file is expired when the hour denoted by its parent
+     * folder name (see {@link #TEMP_FOLDER_FORMATTER}) ended more than {@link #TEMP_FILE_TTL} ago. The job runs every
+     * {@link #TEMP_CLEANUP_PERIOD} to clean up leftovers from interrupted or abandoned uploads, see issue #1604.
+     */
+    @VisibleForTesting
+    Void cleanupTempFolder() {
+        log.debug("Cleaning up temp folder");
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            String token = null;
+            do {
+                PageSet<? extends StorageMetadata> set = blobStore.list(TEMP_FOLDER, token, PAGE_SIZE, true);
+                for (StorageMetadata meta : set) {
+                    if (meta.getType() != StorageType.BLOB) {
+                        continue;
+                    }
+                    String path = meta.getName();
+                    if (isExpiredTempFile(path, now)) {
+                        try {
+                            blobStore.delete(path);
+                        } catch (Throwable e) {
+                            log.warn("Failed to delete expired temp file: {}", path, e);
+                        }
+                    }
+                }
+                token = set.getNextMarker();
+            } while (token != null);
+        } catch (Throwable e) {
+            log.warn("Failed to clean up temp folder", e);
         }
-        builder.append(UUID.randomUUID());
-        return builder.toString();
+
+        return null;
+    }
+
+    private static boolean isExpiredTempFile(String path, LocalDateTime now) {
+        String prefix = TEMP_FOLDER + ResourceDescriptor.PATH_SEPARATOR;
+        if (!path.startsWith(prefix)) {
+            return false;
+        }
+
+        int folderStart = prefix.length();
+        int folderEnd = path.indexOf(ResourceDescriptor.PATH_SEPARATOR, folderStart);
+        if (folderEnd < 0) {
+            return false;
+        }
+
+        String folder = path.substring(folderStart, folderEnd);
+        LocalDateTime uploadHour;
+        try {
+            uploadHour = LocalDateTime.parse(folder, TEMP_FOLDER_FORMATTER);
+        } catch (DateTimeParseException e) {
+            log.warn("Unexpected folder name in temp folder: {}", folder);
+            return false;
+        }
+
+        // the folder covers a whole hour, so a file is guaranteed to be older than the TTL only once the next hour
+        // plus the TTL has passed
+        return uploadHour.plusHours(1).plus(TEMP_FILE_TTL).isBefore(now);
     }
 
     public FileMetadata finishFileUpload(ResourceDescriptor descriptor, ResourceUpload resourceUpload, EtagHeader etagHeader) {
@@ -694,20 +772,21 @@ public class ResourceService implements AutoCloseable {
             MultipartUpload multipartUpload = resourceUpload.getMultipartUpload();
             List<MultipartPart> parts = resourceUpload.getParts();
 
-            long updatedAt = resourceUpload.getUpdatedAt();
-            Long createdAt = resourceUpload.getCreatedAt();
-
-            String etag = blobStore.completeMultipartUpload(multipartUpload, parts);
+            blobStore.completeMultipartUpload(multipartUpload, parts);
             // Move the assembled blob from the temporary location to the target resource. Pass the user metadata
             // explicitly so the author/timestamps survive the copy regardless of the blob storage provider.
             String tempPath = resourceUpload.getTempPath();
+            String etag = resourceUpload.calculateEtag();
+            Map<String, String> userMetadata = resourceUpload.getUserMetadata();
+            userMetadata.put(ETAG_ATTRIBUTE, etag);
             try {
-                Map<String, String> userMetadata = toUserMetadata(
-                        null, createdAt, updatedAt, descriptor.getType().name(), resourceUpload.getAuthor());
                 blobStore.copy(tempPath, descriptor.getAbsoluteFilePath(), userMetadata);
             } finally {
                 blobStore.delete(tempPath);
             }
+
+            long updatedAt = Long.parseLong(userMetadata.get(UPDATED_AT_ATTRIBUTE));
+            long createdAt = Long.parseLong(userMetadata.get(CREATED_AT_ATTRIBUTE));
 
             ResourceEvent.Action action = metadata == null
                     ? ResourceEvent.Action.CREATE

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -97,12 +97,10 @@ public class ResourceService implements AutoCloseable {
      */
     public static final String TEMP_FOLDER = ".dial-tmp";
     /**
-     * Files uploaded to the {@link #TEMP_FOLDER} are grouped into sub-folders named after the hour they were uploaded
-     * in, e.g. {@code .dial-tmp/2024-01-31 13/<uuid>}.
+     * Files uploaded to the {@link #TEMP_FOLDER} are grouped into sub-folders, e.g. {@code .dial-tmp/2024-01-31 13:34:10/<uuid>}.
      */
     private static final DateTimeFormatter TEMP_FOLDER_FORMATTER = new DateTimeFormatterBuilder()
-            .appendPattern("yyyy-MM-dd HH")
-            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
             .toFormatter();
     /**
      * How frequently the scheduled job scans the {@link #TEMP_FOLDER} for expired files.
@@ -710,7 +708,7 @@ public class ResourceService implements AutoCloseable {
         try {
             LocalDateTime now = LocalDateTime.now();
             String token = null;
-            do {
+            exit: do {
                 PageSet<? extends StorageMetadata> set = blobStore.list(TEMP_FOLDER, token, PAGE_SIZE, true);
                 for (StorageMetadata meta : set) {
                     if (meta.getType() != StorageType.BLOB) {
@@ -723,7 +721,10 @@ public class ResourceService implements AutoCloseable {
                         } catch (Throwable e) {
                             log.warn("Failed to delete expired temp file: {}", path, e);
                         }
+                    } else {
+                        break exit;
                     }
+
                 }
                 token = set.getNextMarker();
             } while (token != null);
@@ -737,27 +738,29 @@ public class ResourceService implements AutoCloseable {
     private static boolean isExpiredTempFile(String path, LocalDateTime now) {
         String prefix = TEMP_FOLDER + ResourceDescriptor.PATH_SEPARATOR;
         if (!path.startsWith(prefix)) {
-            return false;
+            throw invalidTempPathException(path);
         }
 
         int folderStart = prefix.length();
         int folderEnd = path.indexOf(ResourceDescriptor.PATH_SEPARATOR, folderStart);
         if (folderEnd < 0) {
-            return false;
+            throw invalidTempPathException(path);
         }
 
         String folder = path.substring(folderStart, folderEnd);
-        LocalDateTime uploadHour;
+        LocalDateTime uploadTs;
         try {
-            uploadHour = LocalDateTime.parse(folder, TEMP_FOLDER_FORMATTER);
+            uploadTs = LocalDateTime.parse(folder, TEMP_FOLDER_FORMATTER);
         } catch (DateTimeParseException e) {
             log.warn("Unexpected folder name in temp folder: {}", folder);
-            return false;
+            throw invalidTempPathException(path);
         }
 
-        // the folder covers a whole hour, so a file is guaranteed to be older than the TTL only once the next hour
-        // plus the TTL has passed
-        return uploadHour.plusHours(1).plus(TEMP_FILE_TTL).isBefore(now);
+        return uploadTs.plus(TEMP_FILE_TTL).isBefore(now);
+    }
+
+    private static IllegalArgumentException invalidTempPathException(String path) {
+        return new IllegalArgumentException("Invalid path to temp file: " + path);
     }
 
     public FileMetadata finishFileUpload(ResourceDescriptor descriptor, ResourceUpload resourceUpload, EtagHeader etagHeader) {

--- a/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/ResourceService.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
@@ -86,6 +87,10 @@ public class ResourceService implements AutoCloseable {
     public static final String UPDATED_AT_ATTRIBUTE = "updated_at";
     public static final String CREATED_AT_ATTRIBUTE = "created_at";
     public static final String ETAG_ATTRIBUTE = "etag";
+    /**
+     * System folder large files are uploaded to before being moved to the target resource, see issue #1604.
+     */
+    public static final String TEMP_FOLDER = ".dial-tmp";
     private static final String COMPRESS_ATTRIBUTE = "compress";
     private static final String AUTHOR_ATTRIBUTE = "author";
 
@@ -656,9 +661,25 @@ public class ResourceService implements AutoCloseable {
             long updatedAt = time();
             long createdAt = metadata == null ? updatedAt : metadata.getCreatedAt();
             Map<String, String> userMetadata = toUserMetadata(null, createdAt, updatedAt, resource.getType().name(), author);
-            MultipartUpload mpu = blobStore.initMultipartUpload(resource.getAbsoluteFilePath(), contentType, userMetadata);
-            return new ResourceUpload(blobStore, mpu, contentType, createdAt, updatedAt);
+            // Assemble the upload in an isolated temporary location to avoid concurrent modifications of the
+            // target key while the multipart upload is in progress (see issue #1604).
+            String tempPath = tempBlobPath(resource);
+            MultipartUpload mpu = blobStore.initMultipartUpload(tempPath, contentType, userMetadata);
+            return new ResourceUpload(blobStore, mpu, contentType, createdAt, updatedAt, author, tempPath);
         }
+    }
+
+    private static String tempBlobPath(ResourceDescriptor resource) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(resource.getBucketLocation())
+                .append(TEMP_FOLDER).append(ResourceDescriptor.PATH_SEPARATOR)
+                .append(resource.getType().group()).append(ResourceDescriptor.PATH_SEPARATOR);
+        String parentPath = resource.getParentPath();
+        if (parentPath != null) {
+            builder.append(parentPath).append(ResourceDescriptor.PATH_SEPARATOR);
+        }
+        builder.append(UUID.randomUUID());
+        return builder.toString();
     }
 
     public FileMetadata finishFileUpload(ResourceDescriptor descriptor, ResourceUpload resourceUpload, EtagHeader etagHeader) {
@@ -677,6 +698,16 @@ public class ResourceService implements AutoCloseable {
             Long createdAt = resourceUpload.getCreatedAt();
 
             String etag = blobStore.completeMultipartUpload(multipartUpload, parts);
+            // Move the assembled blob from the temporary location to the target resource. Pass the user metadata
+            // explicitly so the author/timestamps survive the copy regardless of the blob storage provider.
+            String tempPath = resourceUpload.getTempPath();
+            try {
+                Map<String, String> userMetadata = toUserMetadata(
+                        null, createdAt, updatedAt, descriptor.getType().name(), resourceUpload.getAuthor());
+                blobStore.copy(tempPath, descriptor.getAbsoluteFilePath(), userMetadata);
+            } finally {
+                blobStore.delete(tempPath);
+            }
 
             ResourceEvent.Action action = metadata == null
                     ? ResourceEvent.Action.CREATE

--- a/storage/src/test/java/com/epam/aidial/core/storage/service/ResourceServiceTest.java
+++ b/storage/src/test/java/com/epam/aidial/core/storage/service/ResourceServiceTest.java
@@ -178,7 +178,7 @@ public class ResourceServiceTest {
     @Test
     public void testCleanupTempFolder() {
         byte[] body = "1234567890".getBytes();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         LocalDateTime now = LocalDateTime.now();
 
         String expiredFolder = now.minusHours(3).format(formatter);

--- a/storage/src/test/java/com/epam/aidial/core/storage/service/ResourceServiceTest.java
+++ b/storage/src/test/java/com/epam/aidial/core/storage/service/ResourceServiceTest.java
@@ -19,13 +19,17 @@ import redis.embedded.RedisServer;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourceServiceTest {
 
@@ -169,5 +173,31 @@ public class ResourceServiceTest {
         assertEquals("", ResourceService.decode(""));
         assertEquals("{abc}", ResourceService.decode("{abc}"));
         assertEquals("{abñ}", ResourceService.decode("base58_24SWdWXor"));
+    }
+
+    @Test
+    public void testCleanupTempFolder() {
+        byte[] body = "1234567890".getBytes();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH");
+        LocalDateTime now = LocalDateTime.now();
+
+        String expiredFolder = now.minusHours(3).format(formatter);
+        String recentFolder = now.minusMinutes(30).format(formatter);
+        String currentFolder = now.format(formatter);
+
+        String expiredFile = ResourceService.TEMP_FOLDER + "/" + expiredFolder + "/expired";
+        String recentFile = ResourceService.TEMP_FOLDER + "/" + recentFolder + "/recent";
+        String currentFile = ResourceService.TEMP_FOLDER + "/" + currentFolder + "/current";
+
+        storage.store(expiredFile, "application/octet-stream", null, Map.of(), body);
+        storage.store(recentFile, "application/octet-stream", null, Map.of(), body);
+        storage.store(currentFile, "application/octet-stream", null, Map.of(), body);
+
+        service.cleanupTempFolder();
+
+        assertFalse(storage.exists(expiredFile));
+        // a file uploaded within the last hour is kept because its folder hour may still be in progress
+        assertTrue(storage.exists(recentFile));
+        assertTrue(storage.exists(currentFile));
     }
 }


### PR DESCRIPTION
Multipart uploads of large files now assemble the file in an isolated `.dial-tmp` system folder and move it to the target location only on completion. This prevents concurrent writes (e.g. a Redis→blob flush of a previously cached small file) from corrupting an in-flight multipart upload, which on S3 returned the stale file and on Azure failed with `400 The specified block list is invalid`.

### Applicable issues

- fixes #1604

### Description of changes

- `ResourceService.initFileUpload` now initiates the multipart upload against a unique temporary path `<bucket>/.dial-tmp/<type>/<folder>/<uuid>` instead of the target key.
- `ResourceService.finishFileUpload` completes the multipart upload at the temp path, copies the assembled blob to the target (in a `try`/`finally` that always deletes the temp blob), and publishes the resource event.
- User metadata (author/timestamps/resource type) is passed explicitly to the copy so it survives on every blob storage provider; the response etag keeps the value returned by `completeMultipartUpload`.
- `ResourceUpload` carries the temp path and resolved author through the upload lifecycle.
- Added `FileApiTest.testSmallThenBigFileUploadSameKey` reproducing #1594: a small file overwritten by a large (multipart) file at the same key must read back as the large file.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.