### PR TITLE
fix: send client_id in token request body for OAuth toolsets #1608

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenEndpointAuthMethod.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenEndpointAuthMethod.java
@@ -4,16 +4,9 @@ package com.epam.aidial.core.credentials.data.credentials;
  * Client authentication methods at the OAuth 2.0 token endpoint
  * (RFC 6749 §2.3 and RFC 8414 §2 — {@code token_endpoint_auth_methods_supported}).
  *
- * <p>A null/blank value resolves to {@link #CLIENT_SECRET_BASIC} per RFC 6749 §2.3.1
- * (BASIC is {@code MUST} for compliant authorization servers; POST is {@code MAY} and
- * {@code NOT RECOMMENDED}). OAuth 2.1, which MCP references, deprecates POST entirely.
- *
- * <p>DIAL historically sent {@code client_secret_post} unconditionally. Operators whose AS
- * only accepts POST must set this field explicitly — those servers are non-compliant with
- * RFC 6749 §2.3.1 and would be unable to interop with most OAuth 2.1 clients anyway.
- *
- * <p>TODO: require the field at creation time so the default applies only to pre-PR
- * persisted data and can eventually be removed.
+ * <p>When the method is unspecified it is inferred from the client type (see
+ * {@link #resolve(String, String)}): a client with no secret is public and uses {@link #NONE};
+ * a client with a secret falls back to {@link #CLIENT_SECRET_BASIC} (RFC 7591 §2 default).
  */
 public enum TokenEndpointAuthMethod {
 
@@ -25,11 +18,23 @@ public enum TokenEndpointAuthMethod {
         return name().toLowerCase();
     }
 
-    public static TokenEndpointAuthMethod resolveOrDefault(String value) {
-        if (value == null || value.isBlank()) {
-            return CLIENT_SECRET_BASIC;
+    /**
+     * Resolves the token-endpoint auth method for a client. An explicit {@code value} always wins.
+     * When it is null/blank the method is inferred from the client type: a client with <b>no</b>
+     * secret is public and uses {@link #NONE} (it cannot perform a {@code client_secret_*} method);
+     * a client <b>with</b> a secret falls back to {@link #CLIENT_SECRET_BASIC} (RFC 7591 §2 default).
+     *
+     * <p>Defaulting a secretless client to {@code client_secret_basic} would put {@code client_id}
+     * in the Authorization header instead of the request body, which public/PKCE DCR servers
+     * (e.g. FastMCP's OAuth Proxy) reject — they read {@code client_id} from the body. For a
+     * secretless client {@code none} and {@code client_secret_post} are wire-identical, so
+     * {@code none} (the RFC-correct public-client value) is used.
+     */
+    public static TokenEndpointAuthMethod resolve(String value, String clientSecret) {
+        if (value != null && !value.isBlank()) {
+            return parse(value);
         }
-        return parse(value);
+        return (clientSecret == null || clientSecret.isBlank()) ? NONE : CLIENT_SECRET_BASIC;
     }
 
     /**

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
@@ -28,7 +28,8 @@ public class TokenService {
                                   ResourceSignInRequest resourceSignInRequest) {
         log.debug("Start Resource {} token retrieval", resourceId);
         String redirectUri = resolveRedirectUri(resourceAuthSettings, resourceSignInRequest);
-        TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolveOrDefault(resourceAuthSettings.getTokenEndpointAuthMethod());
+        TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolve(
+                resourceAuthSettings.getTokenEndpointAuthMethod(), resourceAuthSettings.getClientSecret());
 
         TokenRequest.TokenRequestBuilder builder = TokenRequest.builder()
                 .code(resourceSignInRequest.getCode())
@@ -50,7 +51,8 @@ public class TokenService {
                                   ResourceAuthSettings resourceAuthSettings,
                                   String refreshToken) {
         log.debug("Start Resource {} refresh token retrieval", resourceId);
-        TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolveOrDefault(resourceAuthSettings.getTokenEndpointAuthMethod());
+        TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolve(
+                resourceAuthSettings.getTokenEndpointAuthMethod(), resourceAuthSettings.getClientSecret());
 
         RefreshTokenRequest.RefreshTokenRequestBuilder builder = RefreshTokenRequest.builder()
                 .grantType("refresh_token")
@@ -100,7 +102,13 @@ public class TokenService {
                                                                  Consumer<String> setClientId,
                                                                  Consumer<String> setClientSecret) {
         return switch (authMethod) {
-            case CLIENT_SECRET_BASIC -> Map.of("Authorization", buildBasicAuthHeader(clientId, clientSecret));
+            case CLIENT_SECRET_BASIC -> {
+                // Include client_id in the body too (RFC 6749 §3.2.1 permits it). Some token endpoints
+                // — e.g. FastMCP's OAuth Proxy — look up the client by the BODY client_id even when the
+                // secret is supplied via the Basic header; omitting it yields "Missing client_id".
+                setClientId.accept(clientId);
+                yield Map.of("Authorization", buildBasicAuthHeader(clientId, clientSecret));
+            }
             case NONE -> {
                 setClientId.accept(clientId);
                 yield Map.of();

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/registration/DynamicResourceRegistrationStrategy.java
@@ -85,11 +85,13 @@ public class DynamicResourceRegistrationStrategy implements ResourceRegistration
                 ClientRegistrationResponse.class);
 
         // Reject methods DIAL can't honor (e.g. private_key_jwt) at registration time so the
-        // operator gets a clear error before any end-user sign-in attempt. Null falls back to
-        // client_secret_basic per RFC 6749 §2.3.1; the persisted value always reflects what
-        // DIAL will use.
-        String tokenEndpointAuthMethod = TokenEndpointAuthMethod.resolveOrDefault(
-                clientRegistrationResponse.getTokenEndpointAuthMethod()).value();
+        // operator gets a clear error before any end-user sign-in attempt. Honor the method the AS
+        // advertises; when it omits it, infer from the issued client type — a client registered
+        // without a secret is public (none), otherwise client_secret_basic (RFC 7591 §2). The
+        // persisted value always reflects what DIAL will use.
+        String tokenEndpointAuthMethod = TokenEndpointAuthMethod.resolve(
+                clientRegistrationResponse.getTokenEndpointAuthMethod(),
+                clientRegistrationResponse.getClientSecret()).value();
 
         ClientRegistration clientRegistration = ClientRegistration.builder()
                 .resourceId(clientRegistrationResponse.getClientName())

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
@@ -212,12 +212,12 @@ class TokenServiceTest {
         assertEquals(expected, headersCaptor.getValue().get("Authorization"));
 
         String formData = formDataCaptor.getValue();
-        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
+        assertTrue(formData.contains("client_id="), "client_id must be in body: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
     }
 
     @Test
-    void testGetToken_clientSecretBasic_sendsAuthorizationHeaderAndOmitsBodyCreds() {
+    void testGetToken_clientSecretBasic_sendsBasicHeaderWithClientIdInBody() {
         TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
 
         ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
@@ -244,8 +244,11 @@ class TokenServiceTest {
                 eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
-        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
-        assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
+        // client_id is sent in the body even under Basic (RFC 6749 §3.2.1 MAY) so servers that look up
+        // the client by the body client_id (e.g. FastMCP's OAuth Proxy) work; the SECRET stays only in
+        // the Basic header — no second authentication method per RFC 6749 §2.3.1.
+        assertTrue(formData.contains("client_id="), "client_id must be in body: " + formData);
+        assertFalse(formData.contains("client_secret="), "client_secret must NOT be in body for basic: " + formData);
 
         // Plain RFC 7617 Basic: client_id and client_secret are concatenated as-is and base64'd
         // without URL-encoding. This is what Snowflake and most real-world authorization servers
@@ -332,8 +335,8 @@ class TokenServiceTest {
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("grant_type=refresh_token"));
         assertTrue(formData.contains("refresh_token=old-refresh-token"));
-        assertFalse(formData.contains("client_id="), "client_id must not be in body for basic: " + formData);
-        assertFalse(formData.contains("client_secret="), "client_secret must not be in body for basic: " + formData);
+        assertTrue(formData.contains("client_id="), "client_id must be in body for basic: " + formData);
+        assertFalse(formData.contains("client_secret="), "client_secret must NOT be in body for basic: " + formData);
 
         String expected = "Basic " + Base64.getEncoder().encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
         assertEquals(expected, headersCaptor.getValue().get("Authorization"));
@@ -365,7 +368,7 @@ class TokenServiceTest {
         assertEquals(expected, headersCaptor.getValue().get("Authorization"));
 
         String formData = formDataCaptor.getValue();
-        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
+        assertTrue(formData.contains("client_id="), "client_id must be in body: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1869,10 +1869,10 @@ public class ToolSetApiTest extends ResourceBaseTest {
                     "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
             assertEquals(expectedHeader, authHeaderRef.get(),
                     "client_secret_basic must produce an Authorization: Basic header per RFC 6749 §2.3.1");
-            assertFalse(bodyRef.get().contains("client_id="),
-                    "client_id must not appear in body for client_secret_basic, got: " + bodyRef.get());
+            assertTrue(bodyRef.get().contains("client_id="),
+                    "client_id must appear in body for client_secret_basic (RFC 6749 §3.2.1), got: " + bodyRef.get());
             assertFalse(bodyRef.get().contains("client_secret="),
-                    "client_secret must not appear in body for client_secret_basic, got: " + bodyRef.get());
+                    "client_secret must NOT appear in body for client_secret_basic (secret stays in the header), got: " + bodyRef.get());
 
             // Persisted setting is readable via GET (round-trip)
             response = send(HttpMethod.GET, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-basic@",
@@ -1940,10 +1940,103 @@ public class ToolSetApiTest extends ResourceBaseTest {
                     "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
             assertEquals(expectedAuth, authHeaderRef.get(),
                     "null token_endpoint_auth_method must default to client_secret_basic");
-            assertFalse(bodyRef.get().contains("client_id="),
-                    "client_id must not be in body when defaulting to basic, got: " + bodyRef.get());
+            assertTrue(bodyRef.get().contains("client_id="),
+                    "client_id must be in body when defaulting to basic (RFC 6749 §3.2.1), got: " + bodyRef.get());
             assertFalse(bodyRef.get().contains("client_secret="),
-                    "client_secret must not be in body when defaulting to basic, got: " + bodyRef.get());
+                    "client_secret must NOT be in body when defaulting to basic, got: " + bodyRef.get());
+        }
+    }
+
+    @Test
+    void testOauthDcrPublicClient_sendsClientIdInBodyNotBasicHeader() {
+        // Reproduces the FastMCP "OAuth Proxy" regression. A dynamically-registered PUBLIC client
+        // (DCR response carries NO client_secret) must authenticate at the token endpoint with
+        // token_endpoint_auth_method=none — i.e. client_id in the BODY, no Authorization header.
+        // DIAL defaulted a secretless client to client_secret_basic, which moves client_id into a
+        // Basic header and drops it from the body; FastMCP then rejects the token exchange with
+        // invalid_grant "Client ID does not match the one used in the initial request."
+        // EXPECTED (post-fix): a secretless DCR client uses 'none' -> client_id in body, no header.
+        String protectedResourceMetadata = """
+                {
+                    "resource": "http://localhost:9876/mcp",
+                    "authorization_servers": ["http://localhost:9876"],
+                    "scopes_supported": ["read"]
+                }
+                """;
+        String authServerMetadata = """
+                {
+                    "issuer": "http://localhost:9876",
+                    "authorization_endpoint": "http://localhost:9876/authorize",
+                    "token_endpoint": "http://localhost:9876/token",
+                    "registration_endpoint": "http://localhost:9876/register",
+                    "code_challenge_methods_supported": ["S256"]
+                }
+                """;
+        // FastMCP-style DCR response: a client_id, NO client_secret, and (like FastMCP) no explicit
+        // token_endpoint_auth_method — the registered client is public.
+        String registrationResponse = """
+                {
+                    "client_id": "dcr-public-client",
+                    "client_name": "toolset-dcr-public",
+                    "redirect_uris": ["http://admin/callback"]
+                }
+                """;
+        String tokenResponse = """
+                {
+                    "access_token": "test-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "expires_in": 3600
+                }
+                """;
+        java.util.concurrent.atomic.AtomicReference<String> authHeaderRef = new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<String> bodyRef = new java.util.concurrent.atomic.AtomicReference<>();
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+            server.map(HttpMethod.GET, "/.well-known/oauth-protected-resource/mcp",
+                    200, protectedResourceMetadata, "Content-Type", "application/json");
+            server.map(HttpMethod.GET, "/.well-known/oauth-authorization-server",
+                    200, authServerMetadata, "Content-Type", "application/json");
+            server.map(HttpMethod.POST, "/register",
+                    200, registrationResponse, "Content-Type", "application/json");
+            server.map(HttpMethod.POST, "/token", request -> {
+                authHeaderRef.set(request.getHeader("Authorization"));
+                bodyRef.set(request.getBody().readUtf8());
+                return new MockResponse().setBody(tokenResponse).setHeader("Content-Type", "application/json");
+            });
+
+            // Dynamic client registration: no client_id/client_secret supplied.
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-dcr-public@", null, """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "redirect_uri": "http://admin/callback"
+                        }
+                    }
+                    """, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "toolsets/4X25dj1mja51jykqxsXnCH/toolset-dcr-public@",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+
+            // Public client (no secret) => token_endpoint_auth_method=none: client_id in the BODY,
+            // no Authorization header. Pre-fix DIAL sent a Basic header and omitted body client_id.
+            assertNull(authHeaderRef.get(),
+                    "public DCR client (no secret) must NOT send an Authorization header, got: " + authHeaderRef.get());
+            assertTrue(bodyRef.get().contains("client_id=dcr-public-client"),
+                    "public client must send client_id in the body, got: " + bodyRef.get());
+            assertFalse(bodyRef.get().contains("client_secret="),
+                    "no client_secret should be sent for a public client, got: " + bodyRef.get());
         }
     }
 


### PR DESCRIPTION
## Summary

OAuth toolsets whose token endpoint is fronted by a **FastMCP OAuth Proxy** (or any MCP server built on the MCP Python SDK) fail sign-in with:

```
invalid_grant: Client ID does not match the one used in the initial request
```

Root cause: in `client_secret_basic` mode DIAL sent `client_id` **only** in the `Authorization: Basic` header and omitted it from the request body. The MCP SDK's token endpoint reads `client_id` from the form body unconditionally (`form_data.get("client_id")`) and matches the client by that value; with no body `client_id` it cannot bind the code to the client → `invalid_grant`. (Worked on 0.42.3, regressed in 0.44.)

## Fix

`TokenService.applyClientAuthentication` now also sets `client_id` in the body for the `CLIENT_SECRET_BASIC` branch (RFC 6749 §3.2.1 permits `client_id` in the body alongside the Basic header). The Basic header is unchanged, so servers that authenticate via the header (e.g. Snowflake) are unaffected.

Additionally, `TokenEndpointAuthMethod.resolve(value, clientSecret)` infers the method when the server omits it: no secret → `none` (public/PKCE client), secret → `client_secret_basic` (RFC 7591 §2 default). A secretless client defaulting to `none` keeps `client_id` in the body with no header — which public/PKCE DCR servers like FastMCP require.

## Verification

- Updated unit tests (`TokenServiceTest`) and integration tests (`ToolSetApiTest`) assert `client_id` is present in the body for both `client_secret_basic` and `none` modes.
- Reproduced end-to-end against a local FastMCP OAuth Proxy: prior behavior → `invalid_grant`; with the fix → `/token` returns 200 and credentials are stored.
- Empirically confirmed the proxy validates on body `client_id` + PKCE and ignores the secret/header — matching the client's failure signature.

Fixes #1608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
