### PR TITLE
feat: expose reasoning efforts as string array in features listing

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Features.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Features.java
@@ -72,6 +72,7 @@ public class Features {
     @JsonAlias({"customTemperatureSupported", "custom_temperature_supported"})
     private Boolean customTemperatureSupported;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonAlias({"reasoningEfforts", "reasoning_efforts"})
-    private List<String> reasoningEfforts = List.of();
+    private List<String> reasoningEfforts;
 }

--- a/config/src/main/java/com/epam/aidial/core/config/Features.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Features.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -70,6 +72,6 @@ public class Features {
     @JsonAlias({"customTemperatureSupported", "custom_temperature_supported"})
     private Boolean customTemperatureSupported;
 
-    @JsonAlias({"reasoningEffortsSupported", "reasoning_efforts_supported"})
-    private Boolean reasoningEffortsSupported;
+    @JsonAlias({"reasoningEfforts", "reasoning_efforts"})
+    private List<String> reasoningEfforts = List.of();
 }

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -156,7 +156,7 @@ The following features are supported:
 * `contentPartsSupported`: A boolean parameter that indicates whether the deployment supports requests with content parts or not.Default is `false`.
 * `consentRequired`: A boolean parameter that indicates whether the application requires user consent before use.
 * `supportCommentInRateResponse`: A boolean parameters that indicates whether the application supports the field `comment` in rate response payload.
-* `reasoningEffortsSupported`: A boolean parameter that indicates whether the deployment supports the `effort` parameter in chat completions requests. When enabled, clients can specify the reasoning effort level (e.g., `low`, `medium`, `high`) for reasoning models. Default is `false`.
+* `reasoningEfforts`: A list of supported `effort` values for chat completions requests (e.g., `low`, `medium`, `high`). An empty list means the deployment does not support the `effort` parameter. Default is `[]`.
 
 **Example**:
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -205,7 +205,7 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
 * `parallelToolCallsSupported`: A boolean parameter that indicates whether the deployment supports `parallel_tool_calls` parameter in a chat completion request. Default is `true`.
 * `assistantAttachmentsInRequestSupported`: A boolean parameter that indicates whether the deployment supports DIAL attachments in the assistant messages. Default is `false`. When set to `true`, DIAL Chat must preserve attachments in the assistant messages, instead of removing them. The feature is especially useful for models that can generate attachments as well as take attachments in its input. A typical example of such a model is an image-editing model.
 * `supportCommentInRateResponse`: A boolean parameters that indicates whether the application supports the field `comment` in rate response payload.
-* `reasoningEffortsSupported`: A boolean parameter that indicates whether the deployment supports the `effort` parameter in chat completions requests. When enabled, clients can specify the reasoning effort level (e.g., `low`, `medium`, `high`) for reasoning models. Default is `false`.
+* `reasoningEfforts`: A list of supported `effort` values for chat completions requests (e.g., `low`, `medium`, `high`). An empty list means the deployment does not support the `effort` parameter. Default is `[]`.
 
 **Example**
 
@@ -228,7 +228,7 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
                 "accessibleByPerRequestKey": true,
                 "contentPartsSupported": false,
                 "assistantAttachmentsInRequestSupported": false,
-                "reasoningEffortsSupported": false
+                "reasoningEfforts": []
             },
         }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
@@ -114,7 +114,7 @@ public class FeaturesData {
             data.setCustomTemperatureSupported(features.getCustomTemperatureSupported());
         }
 
-        if (features.getReasoningEfforts() != null) {
+        if (features.getReasoningEfforts() != null && !features.getReasoningEfforts().isEmpty()) {
             data.setReasoningEfforts(List.copyOf(features.getReasoningEfforts()));
         }
 

--- a/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -33,7 +35,7 @@ public class FeaturesData {
     private boolean maxTokensSupported = true;
     private boolean maxCompletionTokensSupported = false;
     private boolean customTemperatureSupported = true;
-    private boolean reasoningEffortsSupported = false;
+    private List<String> reasoningEfforts = List.of();
 
     @JsonIgnore
     public static FeaturesData createFeatures(Features features) {
@@ -112,8 +114,8 @@ public class FeaturesData {
             data.setCustomTemperatureSupported(features.getCustomTemperatureSupported());
         }
 
-        if (features.getReasoningEffortsSupported() != null) {
-            data.setReasoningEffortsSupported(features.getReasoningEffortsSupported());
+        if (features.getReasoningEfforts() != null) {
+            data.setReasoningEfforts(List.copyOf(features.getReasoningEfforts()));
         }
 
         return data;

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
@@ -950,7 +950,7 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
                       "custom_temperature_supported": true,
-                      "reasoning_efforts_supported": false
+                      "reasoning_efforts": []
                     },
                     "defaults" : { },
                     "responses_defaults" : { },
@@ -1014,7 +1014,7 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
                       "custom_temperature_supported": true,
-                      "reasoning_efforts_supported": false
+                      "reasoning_efforts": []
                     },
                     "defaults" : { },
                     "responses_defaults" : { },
@@ -1058,7 +1058,7 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
                       "custom_temperature_supported": true,
-                      "reasoning_efforts_supported": false
+                      "reasoning_efforts": []
                       },
                       "defaults" : { },
                       "responses_defaults" : { },
@@ -1111,7 +1111,7 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                       "max_tokens_supported": true,
                       "max_completion_tokens_supported": false,
                       "custom_temperature_supported": true,
-                      "reasoning_efforts_supported": false
+                      "reasoning_efforts": []
                     },
                     "defaults" : { },
                     "responses_defaults" : { },

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -545,7 +545,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
                                 "custom_temperature_supported": true,
-                                "reasoning_efforts_supported": false
+                                "reasoning_efforts": []
                                 },
                             "defaults":{},
                             "responses_defaults":{},
@@ -588,7 +588,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
                                 "custom_temperature_supported": true,
-                                "reasoning_efforts_supported": false
+                                "reasoning_efforts": []
                              },
                              "defaults" : { },
                              "responses_defaults" : { },
@@ -665,7 +665,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
                                 "custom_temperature_supported": true,
-                                "reasoning_efforts_supported": false
+                                "reasoning_efforts": []
                     },
                     "defaults":{},
                     "responses_defaults":{},
@@ -717,7 +717,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
                                 "custom_temperature_supported": true,
-                                "reasoning_efforts_supported": false
+                                "reasoning_efforts": []
                                 },
                             "defaults":{},
                             "responses_defaults":{},
@@ -761,7 +761,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
                                 "custom_temperature_supported": true,
-                                "reasoning_efforts_supported": false
+                                "reasoning_efforts": []
                             },
                             "defaults" : { },
                             "responses_defaults" : { },
@@ -814,7 +814,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                                 "max_tokens_supported": true,
                                 "max_completion_tokens_supported": false,
                                 "custom_temperature_supported": true,
-                                "reasoning_efforts_supported": false
+                                "reasoning_efforts": []
                             },
                             "defaults" : { },
                             "responses_defaults" : { },
@@ -1320,7 +1320,7 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                        "max_tokens_supported": true,
                        "max_completion_tokens_supported": false,
                        "custom_temperature_supported": true,
-                       "reasoning_efforts_supported": false
+                       "reasoning_efforts": []
                      },
                      "defaults" : { },
                      "responses_defaults" : { },

--- a/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
@@ -56,7 +56,7 @@ public class ListingTest extends ResourceBaseTest {
                     "auto_caching" : false, "parallel_tool_calls": true,
                     "assistant_attachments_in_request": false, "mcp" : false,
                     "max_tokens_supported": true, "max_completion_tokens_supported": false,
-                    "custom_temperature_supported": true, "reasoning_efforts_supported": false
+                    "custom_temperature_supported": true, "reasoning_efforts": []
                     }
                 """));
     }
@@ -72,7 +72,7 @@ public class ListingTest extends ResourceBaseTest {
                     "auto_caching" : false, "parallel_tool_calls": true,
                     "assistant_attachments_in_request": false, "mcp" : false,
                     "max_tokens_supported": true, "max_completion_tokens_supported": false,
-                    "custom_temperature_supported": true, "reasoning_efforts_supported": false
+                    "custom_temperature_supported": true, "reasoning_efforts": []
                     }
                 """));
     }
@@ -88,7 +88,7 @@ public class ListingTest extends ResourceBaseTest {
                     "auto_caching" : false, "parallel_tool_calls": true,
                     "assistant_attachments_in_request": false, "mcp" : false,
                     "max_tokens_supported": true, "max_completion_tokens_supported": false,
-                    "custom_temperature_supported": true, "reasoning_efforts_supported": false
+                    "custom_temperature_supported": true, "reasoning_efforts": []
                     }
                 """));
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -156,7 +156,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                       },
                      "description_keywords" : [ ],
                      "max_retry_attempts" : 1,
@@ -200,7 +200,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                         },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,
@@ -245,7 +245,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                         },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,
@@ -299,7 +299,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                       },
                      "description_keywords" : [ ],
                      "max_retry_attempts" : 1,
@@ -437,7 +437,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                   },
                   "description_keywords": [],
                   "max_retry_attempts": 1,
@@ -490,7 +490,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                           },
                       "description_keywords" : [ ],
                       "max_retry_attempts" : 1,
@@ -536,7 +536,7 @@ public class ToolSetApiTest extends ResourceBaseTest {
                            "max_tokens_supported": true,
                            "max_completion_tokens_supported": false,
                            "custom_temperature_supported": true,
-                           "reasoning_efforts_supported": false
+                           "reasoning_efforts": []
                           },
                         "description_keywords" : [ ],
                         "max_retry_attempts" : 1,

--- a/server/src/test/java/com/epam/aidial/core/server/data/FeaturesDataTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/data/FeaturesDataTest.java
@@ -1,0 +1,29 @@
+package com.epam.aidial.core.server.data;
+
+import com.epam.aidial.core.config.Features;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FeaturesDataTest {
+
+    @Test
+    void createFeatures_defaultReasoningEffortsIsEmpty() {
+        FeaturesData data = FeaturesData.createFeatures(null);
+
+        assertTrue(data.getReasoningEfforts().isEmpty());
+    }
+
+    @Test
+    void createFeatures_mapsReasoningEfforts() {
+        Features features = new Features();
+        features.setReasoningEfforts(List.of("low", "medium", "high"));
+
+        FeaturesData data = FeaturesData.createFeatures(features);
+
+        assertEquals(List.of("low", "medium", "high"), data.getReasoningEfforts());
+    }
+}


### PR DESCRIPTION
Replace `reasoning_efforts_supported` boolean with `reasoning_efforts` list so clients can discover which effort values each deployment accepts.

### Applicable issues

- fixes #

### Description of changes

Replaces the `reasoning_efforts_supported` boolean in deployment `features` with `reasoning_efforts` — a string array of supported `effort` values for chat completions (e.g. `low`, `medium`, `high`).

- Empty array means the deployment does not support `effort`; non-empty array lists values clients may send


Breaking change vs #1584: `reasoning_efforts_supported` is removed.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
