### PR TITLE
feat: expose embedding vector dimensions in model listing

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Model.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Model.java
@@ -20,6 +20,8 @@ public class Model extends Deployment {
     private String overrideName;
     @JsonAlias({"fieldsHashingOrder", "fields_hashing_order"})
     private List<String> fieldsHashingOrder = List.of("prefix.body.tools", "prefix.body.messages");
+    @JsonAlias({"embeddingDimensions", "embedding_dimensions"})
+    private Integer embeddingDimensions;
 
     public Model() {
         setMaxRetryAttempts(5);

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -29,6 +29,7 @@ An object containing parameters for each [model](#models).
 * `displayName`: A string with the models's name. Display name is shown in all DIAL client UI dropdowns, tables, and logs so operators can quickly identify the model.
 * `displayVersion`: A string with the model's version. Use it to distinguish between "latest," "beta," or date-stamped builds.
 * `endpoint`: Model API for chat completions or embeddings.
+* `embeddingDimensions`: The size of the embedding vector returned by an embedding model (e.g. `1536` for `text-embedding-ada-002`). Omit for chat/completion models.
 * `tokenizerModel`: Identifies the specific model whose tokenization algorithm exactly matches that of the referenced model. This is typically the name of the earliest-released model in a series of models sharing an identical tokenization algorithm (e.g. gpt-3.5-turbo-0301, gpt-4-0314, or gpt-4-1106-vision-preview). This parameter is essential for DIAL clients that reimplement tokenization algorithms on their side, instead of utilizing the tokenizeEndpoint provided by the model.
 * `userRoles`: A specific claim value provided by a specific IDP in JWT or an API key role. If not defined, the language model is available to all users. Refer to [IDP Configuration](https://docs.dialx.ai/tutorials/devops/auth-and-access-control/configure-idps/overview) to view examples.
 * `descriptionKeywords`: A list of keywords describes the model, e.g. code-gen, text2image.
@@ -122,6 +123,7 @@ An object containing parameters for each [model](#models).
         "embedding-ada": {
             "type": "embedding",
             "endpoint": "http://localhost:7001/openai/deployments/ada/embeddings",
+            "embeddingDimensions": 1536,
             "upstreams": [
                 {
                     "endpoint": "http://localhost:7001",

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ModelController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ModelController.java
@@ -84,6 +84,7 @@ public class ModelController {
         }
 
         data.setTokenizerModel(model.getTokenizerModel());
+        data.setEmbeddingDimensions(model.getEmbeddingDimensions());
         data.setLimits(createLimits(model.getLimits()));
         data.setPricing(createPricing(model.getPricing()));
         data.setDefaults(model.getDefaults());

--- a/server/src/main/java/com/epam/aidial/core/server/data/ModelData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ModelData.java
@@ -15,6 +15,7 @@ public class ModelData extends DeploymentData {
     private String lifecycleStatus = "generally-available";
     private CapabilitiesData capabilities = new CapabilitiesData();
     private String tokenizerModel;
+    private Integer embeddingDimensions;
     private TokenLimitsData limits;
     private PricingData pricing;
 

--- a/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
@@ -46,6 +46,11 @@ public class ListingTest extends ResourceBaseTest {
     }
 
     @Test
+    void testEmbeddingDimensions(Vertx vertx, VertxTestContext context) {
+        checkListing(vertx, context, "/openai/models", "embedding-ada", "embedding_dimensions", 1536);
+    }
+
+    @Test
     void testFeaturesEmbedding(Vertx vertx, VertxTestContext context) {
         checkListing(vertx, context, "/openai/models", "embedding-ada", "features", new JsonObject("""
                     { "rate": false, "tokenize": false, "truncate_prompt": false

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ModelControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ModelControllerTest.java
@@ -1,0 +1,35 @@
+package com.epam.aidial.core.server.controller;
+
+import com.epam.aidial.core.config.Model;
+import com.epam.aidial.core.config.ModelType;
+import com.epam.aidial.core.server.data.ModelData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ModelControllerTest {
+
+    @Test
+    void createModel_mapsEmbeddingDimensions() {
+        Model model = new Model();
+        model.setName("embedding-ada");
+        model.setType(ModelType.EMBEDDING);
+        model.setEmbeddingDimensions(1536);
+
+        ModelData data = ModelController.createModel(model);
+
+        assertEquals(1536, data.getEmbeddingDimensions());
+    }
+
+    @Test
+    void createModel_omitsEmbeddingDimensionsWhenUnset() {
+        Model model = new Model();
+        model.setName("chat-gpt-35-turbo");
+        model.setType(ModelType.CHAT);
+
+        ModelData data = ModelController.createModel(model);
+
+        assertNull(data.getEmbeddingDimensions());
+    }
+}

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -156,6 +156,7 @@
     "embedding-ada": {
       "type": "embedding",
       "endpoint" : "http://localhost:7001/openai/deployments/ada/embeddings",
+      "embeddingDimensions": 1536,
       "upstreams": [
         {"endpoint": "http://localhost:7001", "key": "modelKey4"}
       ]


### PR DESCRIPTION
Add optional `embeddingDimensions` model config field and surface it as `embedding_dimensions` in `GET /openai/models` listing so clients can size vector accordingly.

### Applicable issues

- fixes #

### Description of changes

Adds optional `embeddingDimensions` to model config (`models.*.embedding_dimensions`) and exposes it in model listing as `embedding_dimensions`.

- Clients can discover the embedding vector size per deployment (e.g. `1536` for ada-002) without inferring it from model name
- Field is omitted in listing when not configured (chat/completion models)

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.