### PR TITLE
fix: expose applications and toolsets via admin file-config API

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/FileConfigController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/FileConfigController.java
@@ -191,9 +191,11 @@ public class FileConfigController implements Controller {
             case PROJECT_KEY -> config.getKeys();
             case ROUTE -> config.getRoutes();
             case APP_TYPE_SCHEMA -> config.getApplicationTypeSchemas();
+            case APPLICATION -> config.getApplications();
+            case TOOL_SET -> config.getToolsets();
             // GLOBAL_SETTINGS has no per-entity map — handled by handleSettings before this helper.
-            // Other types (APPLICATION, TOOL_SET, FILE, PROMPT, CONVERSATION) are not part of the
-            // file-config surface; the route regex restricts {type} to the closed set above.
+            // Other types (FILE, PROMPT, CONVERSATION) are not part of the file-config surface;
+            // the route regex restricts {type} to the closed set above.
             default -> null;
         };
     }

--- a/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
@@ -86,7 +86,7 @@ public enum RouteTemplate {
     ),
 
     ADMIN_FILE_CONFIG(
-            "^/v1/admin/config/file/(?<type>models|interceptors|roles|keys|routes|schemas|settings)(?:/(?<name>.+))?$",
+            "^/v1/admin/config/file/(?<type>models|interceptors|roles|keys|routes|schemas|settings|applications|toolsets)(?:/(?<name>.+))?$",
             "/v1/admin/config/file/{type}/{name}"
     ),
 


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

`GET /v1/admin/config/file/{type}` is the read-only admin surface for inspecting file-sourced config entries. The `Config` POJO populates `applications` and `toolsets` maps from `aidial.config.json` at startup, but neither type was reachable through this API — the `ADMIN_FILE_CONFIG` route regex only matched `models|interceptors|roles|keys|routes|schemas|settings`.

**Changes:**
- `RouteTemplate.ADMIN_FILE_CONFIG` — added `applications` and `toolsets` to the `{type}` alternation
- `FileConfigController.entitySource()` — added `APPLICATION → config.getApplications()` and `TOOL_SET → config.getToolsets()` switch cases

Operators can now call:
- `GET /v1/admin/config/file/applications` — list file-sourced applications
- `GET /v1/admin/config/file/applications/{name}` — get a single file-sourced application
- `GET /v1/admin/config/file/toolsets` — list file-sourced toolsets
- `GET /v1/admin/config/file/toolsets/{name}` — get a single file-sourced toolset

Authorization is unchanged: existing `isAdmin` gate applies to both new types.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.