### PR TITLE
fix: handle URL-encoding asymmetry in AutoShareDeploymentFn #1632

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
@@ -14,6 +14,7 @@ import com.epam.aidial.core.server.validation.ApplicationTypeResourceException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.util.UrlUtil;
 
 import javax.annotation.Nullable;
 
@@ -64,7 +65,7 @@ public class AutoShareDeploymentFn extends BaseRequestFunction<RequestObject> {
             return null;
         }
         try {
-            return ResourceDescriptorFactory.fromAnyUrl(id, proxy.getEncryptionService());
+            return ResourceDescriptorFactory.fromAnyUrl(UrlUtil.encodePath(id), proxy.getEncryptionService());
         } catch (Exception e) {
             return null;
         }

--- a/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
@@ -85,6 +85,22 @@ public class AutoShareDeploymentFnTest {
     }
 
     @Test
+    public void testApply_WhenInitialDeploymentIdContainsSpace() {
+        when(encryptionService.decrypt(anyString())).thenReturn("/Users/user/");
+        when(proxy.getEncryptionService()).thenReturn(encryptionService);
+        when(proxy.getAccessService()).thenReturn(accessService);
+        when(context.getInitialDeployment()).thenReturn("applications/123/demo a_0.0.1");
+        when(accessService.hasReadAccess(any(ResourceDescriptor.class), eq(context))).thenReturn(true);
+        when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
+        when(proxy.getDeploymentService()).thenReturn(deploymentService);
+
+        assertFalse(fn.apply(EMPTY_OBJECT));
+        assertFalse(proxyApiKeyData.getAttachedDeployments().isEmpty());
+        assertEquals(ResourceAccessType.READ_ONLY,
+                proxyApiKeyData.getAttachedDeployments().get("applications/123/demo%20a_0.0.1").accessTypes());
+    }
+
+    @Test
     public void testApply_WhenInitialDeploymentIsApp() {
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/user/");
         when(proxy.getEncryptionService()).thenReturn(encryptionService);


### PR DESCRIPTION
Fixes a `403 Forbidden deployment` error that occurred when a global interceptor was active and a deployment id contained a character requiring percent-encoding (e.g. a space). The interceptor auto-share path (`AutoShareDeploymentFn`) built the resource descriptor from the raw, percent-decoded id, which caused `UrlUtil.decodePath` to throw `URISyntaxException`; the swallowed exception meant the per-request API key never received the READ grant, so the subsequent interceptor callback was rejected with 403.

### Applicable issues

- fixes #1632

### Description of changes

- `AutoShareDeploymentFn#toResourceDescriptor` now percent-encodes the id via `UrlUtil.encodePath(id)` before calling `ResourceDescriptorFactory.fromAnyUrl`, making it consistent with `DeploymentService#toResourceDescriptor`. This is a no-op for ids without special characters.
- Added regression test `testApply_WhenInitialDeploymentIdContainsSpace` verifying the auto-share grant is registered for a deployment id containing a space.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.