### PR TITLE
fix: process compressed responses in streaming mode #1643

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -172,6 +172,8 @@ public class AiDial {
 
             vertx = Vertx.vertx(vertxOptions);
             HttpClientOptions clientOptions = new HttpClientOptions(settings("client"));
+            // upstream bodies (including SSE streams) are parsed/proxied, so they must be decoded
+            clientOptions.setDecompressionSupported(true);
             HttpProxySelector httpProxySelector = createHttpProxySelector(clientOptions);
             client = vertx.createHttpClient(clientOptions);
             WebSocketClientOptions webSocketClientOptions = new WebSocketClientOptions(settings("webSocketClient"));

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
@@ -5,6 +5,7 @@ import com.epam.aidial.core.server.data.LimitStats;
 import com.epam.aidial.core.server.service.ApplicationService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
+import com.epam.aidial.core.storage.util.Compression;
 import com.epam.aidial.core.storage.util.EtagHeader;
 import com.sun.net.httpserver.HttpServer;
 import io.vertx.core.http.HttpMethod;
@@ -26,6 +27,8 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("checkstyle:LineLength")
 public class DeploymentPostApiTest extends ResourceBaseTest {
@@ -121,6 +124,44 @@ public class DeploymentPostApiTest extends ResourceBaseTest {
             if (adapterRef.getValue() != null) {
                 adapterRef.getValue().stop(0);
             }
+        }
+    }
+
+    @Test
+    public void testStreaming_DecompressesGzipResponse() {
+        String responseBody = """
+                data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1687780896,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"this is a"}}],"usage":null}\r
+                data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1687780896,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":"stop","delta":{}}],"usage":{"completion_tokens":20,"prompt_tokens":20,"total_tokens":40}}\r
+                data: [DONE]\r
+                """;
+        byte[] gzipped = Compression.compress("gzip", responseBody.getBytes(StandardCharsets.UTF_8));
+
+        try (TestWebServer server = new TestWebServer(4848)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                okio.Buffer buffer = new okio.Buffer();
+                buffer.write(gzipped);
+                return new MockResponse()
+                        .setResponseCode(200)
+                        .setHeader("Content-Type", "text/event-stream")
+                        .setHeader("Content-Encoding", "gzip")
+                        .setChunkedBody(buffer, 16);
+            });
+
+            Response response = send(HttpMethod.POST,
+                    "/openai/deployments/gpt-3-turbo/chat/completions", null,
+                    """
+                    {"model":"gpt-3-turbo","stream":true,"messages":[{"role":"user","content":"how are you?"}]}
+                    """,
+                    "content-type", "application/json");
+
+            verify(response, 200);
+            // Without decompression the SSE parser would receive gzip binary and emit nothing;
+            // the decoded event proves the upstream gzip stream was inflated before parsing.
+            assertTrue(response.body().contains("\"content\":\"this is a\""),
+                    "Expected decoded SSE content, but got: " + response.body());
+            // The body delivered to the client is plaintext re-serialized SSE,
+            // so the upstream gzip Content-Encoding header must not leak to the client.
+            assertNull(response.headers().get("Content-Encoding"));
         }
     }
 


### PR DESCRIPTION
Enable response decompression on the proxy HttpClient so gzip-encoded upstream responses (including SSE streams) are inflated before DIAL parses, re-serializes, and proxies them. Previously a compressed streaming response was fed as gzip binary into the SSE parser, which emitted nothing and closed the connection without output.

### Applicable issues

- fixes #1643

### Description of changes

- Set `setDecompressionSupported(true)` on the shared proxy `HttpClient` in `AiDial.java`. Vert.x/Netty's `HttpContentDecompressor` decompresses `gzip`/`deflate` bodies incrementally (streaming stays streaming) and strips the `Content-Encoding` header, so the header copied to the client is correct and the SSE parser receives plaintext.
- This covers every consumer of the proxy client (chat completions, responses API, interceptors, MCP) instead of patching the streaming machinery per controller.
- Added `testStreaming_DecompressesGzipResponse` in `DeploymentPostApiTest`: the upstream returns a gzip-compressed chunked `text/event-stream` body; the test asserts the client receives decoded SSE content and that no `Content-Encoding` header leaks through.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.