### PR TITLE
chore: patch p11-kit CVE-2026-2100 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --chown=appuser:appuser docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # upgrade/install packages
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat binutils gpgv gnutls libpng zlib musl musl-utils
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat binutils gpgv gnutls libpng zlib musl musl-utils p11-kit p11-kit-trust
 RUN apk add --no-cache su-exec
 
 HEALTHCHECK --start-period=30s --interval=1m --timeout=3s \


### PR DESCRIPTION
## Summary
Patches the HIGH-severity **CVE-2026-2100** (NULL dereference via `C_DeriveKey` with specific NULL parameters) reported by Trivy against the runtime Docker image.

The vulnerable `p11-kit` / `p11-kit-trust` packages (`0.25.5-r2`) ship in the `eclipse-temurin:21-jdk-alpine` base image. This change adds them to the existing `apk upgrade --no-cache` allowlist so the build picks up the fixed `0.26.2-r0` packages — consistent with how other base-image CVEs are already patched in the Dockerfile.

## Changes
- Add `p11-kit p11-kit-trust` to the `apk upgrade` package list in `Dockerfile`.

## Testing
- No code changes; image-level package upgrade. Verified via Trivy scan output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)