### PR TITLE
feat: folder-as-resource whole-resource DELETE via tombstone #1635

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -282,7 +282,8 @@ public class AiDial {
             ResponseMappingService responseMappingService = new ResponseMappingService(generator, resourceService);
             responseMappingService.init(vertx, taskExecutor);
 
-            FolderResourceService folderResourceService = new FolderResourceService(resourceService);
+            FolderResourceService folderResourceService = new FolderResourceService(
+                    resourceService, lockService, shareService, invitationService);
 
             proxy = new Proxy(vertx, clientOptions, apiKeyValidation, client, webSocketClient, configStore, logStore,
                     rateLimiter, upstreamRouteProvider, accessTokenValidator,

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
@@ -434,6 +434,11 @@ public class ControllerSelector {
             String path = context.getRequest().path();
             return () -> controller.handle(resourcePathV2(path));
         });
+        delete(RouteTemplate.SKILL_FOLDER, (proxy, context, pathMatcher) -> {
+            FolderResourceController controller = new FolderResourceController(proxy, context, true);
+            String path = context.getRequest().path();
+            return () -> controller.handle(resourcePathV2(path));
+        });
 
         // add deployment routes
         ControllerRoute.Initializer applicationRouteTemplate = ((proxy, context, pathMatcher) -> {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/FolderResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/FolderResourceController.java
@@ -57,6 +57,9 @@ public class FolderResourceController extends AccessControlBaseController {
         if (HttpMethod.GET.equals(method)) {
             return get(resource);
         }
+        if (HttpMethod.DELETE.equals(method)) {
+            return delete(resource);
+        }
         return context.respond(HttpStatus.METHOD_NOT_ALLOWED);
     }
 
@@ -109,6 +112,20 @@ public class FolderResourceController extends AccessControlBaseController {
                 .recover(error -> {
                     log.warn("Failed to download resource: {}", resource.getUrl(), error);
                     return context.respond(error, "Failed to download resource: " + resource.getUrl()).mapEmpty();
+                });
+        return Future.succeededFuture();
+    }
+
+    private Future<?> delete(ResourceDescriptor resource) {
+        EtagHeader etag = ProxyUtil.etag(context.getRequest());
+        proxy.getTaskExecutor().submit(() -> {
+            folderResourceService.deleteFolder(resource, etag);
+            return null;
+        })
+                .compose(v -> context.respond(HttpStatus.OK).mapEmpty())
+                .recover(error -> {
+                    log.warn("Failed to delete resource: {}", resource.getUrl(), error);
+                    return context.respond(error, "Failed to delete resource: " + resource.getUrl()).mapEmpty();
                 });
         return Future.succeededFuture();
     }

--- a/server/src/main/java/com/epam/aidial/core/server/data/folder/FolderResourceMarker.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/folder/FolderResourceMarker.java
@@ -41,6 +41,7 @@ public class FolderResourceMarker {
     private String etag;
     private Long createdAt;
     private Long updatedAt;
+    private Long deletedAt;
     private String author;
     /**
      * Type-specific metadata extracted by the per-type handler (e.g. skill name/description/version).

--- a/server/src/main/java/com/epam/aidial/core/server/service/folder/FolderResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/folder/FolderResourceService.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.core.server.service.folder;
 
 import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
+import com.epam.aidial.core.server.service.InvitationService;
+import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
 import com.epam.aidial.core.storage.data.MetadataBase;
@@ -16,6 +18,7 @@ import io.vertx.core.buffer.Buffer;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -30,6 +33,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javax.annotation.Nullable;
 
 /**
  * Generic engine for whole-resource (folder-as-resource) operations. A resource is materialized as a
@@ -51,14 +55,22 @@ public class FolderResourceService {
     private static final String VERSION_PREFIX = "v";
     private static final int SCHEMA_VERSION = 1;
     private static final String STATE_ACTIVE = "active";
+    private static final String STATE_DELETING = "deleting";
     private static final int PAGE_SIZE = 1000;
     // A folder or a file must not be named after a structural token.
     private static final Set<String> RESERVED_SEGMENTS = Set.of(VERSION_PREFIX, MARKER_NAME);
 
     private final ResourceService resourceService;
+    private final LockService lockService;
+    private final ShareService shareService;
+    private final InvitationService invitationService;
 
-    public FolderResourceService(ResourceService resourceService) {
+    public FolderResourceService(ResourceService resourceService, LockService lockService,
+                                 ShareService shareService, InvitationService invitationService) {
         this.resourceService = resourceService;
+        this.lockService = lockService;
+        this.shareService = shareService;
+        this.invitationService = invitationService;
     }
 
     /**
@@ -132,10 +144,61 @@ public class FolderResourceService {
     }
 
     /**
-     * Returns the {@code .dial-resource} marker of the resource, or {@code null} if it does not exist.
+     * Returns the {@code .dial-resource} marker of the resource, or {@code null} if it does not exist
+     * or is in the {@code deleting} state (treated as absent).
      */
     public FolderResourceMarker getMarker(ResourceDescriptor resource) {
-        return readMarker(markerDescriptor(resource), true);
+        FolderResourceMarker marker = readMarker(markerDescriptor(resource), true);
+        if (!isActive(marker)) {
+            return null;
+        }
+        return marker;
+    }
+
+    /**
+     * Tombstones the resource by flipping the {@code .dial-resource} marker to {@code state: deleting},
+     * then best-effort removes the version tree and marker. If the marker does not exist the method
+     * returns without doing anything (idempotent).
+     *
+     * <p>The tombstone write (via {@link ResourceService#computeResource}) is the linearization point:
+     * once committed, all read paths return 404 even if the version tree still physically exists.
+     *
+     * @throws HttpException PRECONDITION_FAILED if the {@code If-Match} header does not match
+     */
+    public void deleteFolder(ResourceDescriptor resource, EtagHeader etag) {
+        ResourceDescriptor marker = markerDescriptor(resource);
+
+        MutableObject<String> capturedVersion = new MutableObject<>();
+        resourceService.computeResource(marker, json -> {
+            if (json == null) {
+                throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
+            }
+            FolderResourceMarker current = ProxyUtil.convertToObject(json, FolderResourceMarker.class);
+            if (!isActive(current)) {
+                throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
+            }
+            etag.validate(current.getEtag());
+            capturedVersion.setValue(current.getCurrentVersion());
+            current.setState(STATE_DELETING);
+            current.setDeletedAt(System.currentTimeMillis());
+            return Objects.requireNonNull(ProxyUtil.convertToString(current));
+        });
+
+        if (resource.isPrivate()) {
+            String bucketName = resource.getBucketName();
+            String bucketLocation = resource.getBucketLocation();
+            lockService.underBucketLock(bucketLocation, () -> {
+                invitationService.cleanUpResourceLink(bucketName, bucketLocation, resource);
+                shareService.revokeSharedResource(bucketName, bucketLocation, resource);
+                return null;
+            });
+        }
+
+        if (capturedVersion.get() != null) {
+            ResourceDescriptor folderVersion = versionFolder(resource, capturedVersion.get());
+            deleteVersion(folderVersion);
+            resourceService.deleteResource(marker, EtagHeader.ANY);
+        }
     }
 
     @SneakyThrows
@@ -243,5 +306,9 @@ public class FolderResourceService {
             throw new HttpException(HttpStatus.BAD_REQUEST, "Reserved path segment: " + segments[0]);
         }
         return filename;
+    }
+
+    private static boolean isActive(@Nullable FolderResourceMarker marker) {
+        return marker != null && STATE_ACTIVE.equals(marker.getState());
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
@@ -142,6 +142,37 @@ public class SkillResourceApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testDelete() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+
+        verify(uploadSkill("/to-delete", files), 200);
+        verify(deleteSkill("/to-delete"), 200);
+        assertEquals(404, downloadSkill("/to-delete").status());
+    }
+
+    @Test
+    void testDeleteIfMatch() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+
+        Response put = uploadSkill("/delete-etag", files);
+        verify(put, 200);
+        String etag = put.headers().get("etag");
+
+        // wrong If-Match -> 412, resource still live
+        verify(deleteSkill("/delete-etag", "if-match", "\"wrong\""), 412);
+        assertEquals(200, downloadSkill("/delete-etag").status());
+
+        // correct If-Match -> 200, resource gone
+        verify(deleteSkill("/delete-etag", "if-match", etag), 200);
+        assertEquals(404, downloadSkill("/delete-etag").status());
+    }
+
+    @Test
+    void testDeleteNonExistent() {
+        verify(deleteSkill("/never-existed"), 404);
+    }
+
+    @Test
     void testInvisibleToV1FilesApi() {
         Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
         verify(uploadSkill("/hidden", files), 200);
@@ -170,6 +201,21 @@ public class SkillResourceApiTest extends ResourceBaseTest {
             builder.addBinaryBody(entry.getKey(), entry.getValue(), ContentType.DEFAULT_BINARY, entry.getKey());
         }
         request.setEntity(builder.build());
+
+        return client.execute(request, ResourceBaseTest::toResponse);
+    }
+
+    @SneakyThrows
+    private Response deleteSkill(String skillPath, String... headers) {
+        String uri = "http://127.0.0.1:" + serverPort + "/v2/skills/" + bucket + skillPath;
+        HttpUriRequest request = new HttpUriRequestBase(HttpMethod.DELETE.name(), URI.create(uri));
+
+        for (int i = 0; i < headers.length; i += 2) {
+            request.setHeader(headers[i], headers[i + 1]);
+        }
+        if (!request.containsHeader("authorization") && !request.containsHeader("api-key")) {
+            request.setHeader("api-key", "proxyKey1");
+        }
 
         return client.execute(request, ResourceBaseTest::toResponse);
     }


### PR DESCRIPTION
Implements atomic whole-resource DELETE for skills (folder-as-resource) via a tombstone marker state. The `.dial-resource` marker is flipped to `state: deleting` as the linearization point — all read paths immediately return 404, even if the version tree still physically exists.

### Applicable issues

- fixes #1635

### Description of changes

- `FolderResourceMarker`: added `deletedAt` field alongside existing `createdAt`/`updatedAt`
- `FolderResourceService`: added `STATE_DELETING` constant and `isActive()` helper; `getMarker()` returns `null` for deleting resources (treats them as absent); new `deleteFolder()` method uses `computeResource` for an atomic tombstone write (per-resource lock), then best-effort cleans up the version tree and marker; access-control metadata (`invitationService`, `shareService`) is revoked under the bucket lock only for private resources
- `FolderResourceController`: added `DELETE` branch delegating to `deleteFolder()` on the worker thread, following the same async pattern as `PUT`
- `ControllerSelector`: registered `DELETE /v2/skills/{bucket}/{path}` route
- `AiDial`: updated `FolderResourceService` constructor call with the three new injected services
- `SkillResourceApiTest`: added `testDelete`, `testDeleteIfMatch`, and `testDeleteNonExistent` integration tests

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.