### PR TITLE
fix: unable to get list of tools for notion mcp toolset #1561

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -31,18 +31,27 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.List;
@@ -55,6 +64,8 @@ public class ToolSetToolsController implements Controller {
     private static final JsonSchemaValidator NOOP_SCHEMA_VALIDATOR =
             (Map<String, Object> schema, Object content) ->
                     JsonSchemaValidator.ValidationResponse.asValid(null);
+
+    private static final McpJsonMapper MCP_JSON_MAPPER = createLenientMcpJsonMapper();
 
     private final String toolSetId;
     private final boolean filterAllowed;
@@ -152,6 +163,7 @@ public class ToolSetToolsController implements Controller {
 
         HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
                 .builder(upstream.getEndpoint())
+                .jsonMapper(MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, endpoint, body, transportContext) ->
                         customizeRequest(builder, deployment))
                 .build();
@@ -256,6 +268,26 @@ public class ToolSetToolsController implements Controller {
         ApiKeyData.initFromContext(proxyApiKeyData, context);
         apiKeyStore.assignPerRequestApiKey(proxyApiKeyData);
         return proxyApiKeyData.getPerRequestKey();
+    }
+
+    private static McpJsonMapper createLenientMcpJsonMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // JSON Schema allows `additionalProperties` to be a boolean OR a schema object,
+        // but the MCP SDK models it as Boolean. Coerce object/array values to null so a
+        // single non-conforming field does not fail the whole tools/list response (#1561).
+        mapper.addHandler(new DeserializationProblemHandler() {
+            @Override
+            public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType,
+                    JsonToken t, JsonParser p, String failureMsg) throws IOException {
+                if (targetType.hasRawClass(Boolean.class)
+                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)) {
+                    p.skipChildren();
+                    return null;
+                }
+                return super.handleUnexpectedToken(ctxt, targetType, t, p, failureMsg);
+            }
+        });
+        return new JacksonMcpJsonMapper(mapper);
     }
 
     private void handleError(Throwable error) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -270,6 +270,8 @@ public class ToolSetToolsController implements Controller {
         return proxyApiKeyData.getPerRequestKey();
     }
 
+    private static final String ADDITIONAL_PROPERTIES_FIELD = "additionalProperties";
+
     private static McpJsonMapper createLenientMcpJsonMapper() {
         ObjectMapper mapper = new ObjectMapper();
         // JSON Schema allows `additionalProperties` to be a boolean OR a schema object,
@@ -280,7 +282,8 @@ public class ToolSetToolsController implements Controller {
             public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType,
                     JsonToken t, JsonParser p, String failureMsg) throws IOException {
                 if (targetType.hasRawClass(Boolean.class)
-                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)) {
+                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)
+                        && ADDITIONAL_PROPERTIES_FIELD.equals(p.currentName())) {
                     p.skipChildren();
                     return null;
                 }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -2289,6 +2289,45 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testGetAllTools_ObjectAdditionalProperties() throws JsonProcessingException {
+        // JSON Schema allows `additionalProperties` to be a schema object (e.g. Notion MCP server);
+        // the MCP SDK models it as Boolean. Such tools must not fail the whole tools/list (#1561).
+        String mcpToolsListResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 2,
+                   "result": {
+                     "tools": [
+                       {"name": "search", "description": "Search",
+                        "inputSchema": {"type": "object",
+                          "properties": {"q": {"type": "string"}},
+                          "additionalProperties": {"type": "string"}}},
+                       {"name": "lookup", "description": "Lookup",
+                        "inputSchema": {"type": "object",
+                          "properties": {"id": {"type": "string"}},
+                          "additionalProperties": true}}
+                     ]
+                   }
+                 }
+                """;
+        try (TestWebServer ignore = new TestWebServer(9876, mcpToolsHandler(mcpToolsListResponse))) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/git/tools",
+                    null, null, "authorization", "admin");
+
+            assertEquals(200, resp.status());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            assertEquals(2, tools.size());
+            assertEquals("search", tools.get(0).get("name").asText());
+            assertEquals("lookup", tools.get(1).get("name").asText());
+            // object-valued additionalProperties is coerced to null (omitted); boolean is preserved
+            assertTrue(tools.get(1).get("inputSchema").get("additionalProperties").asBoolean());
+        }
+    }
+
+    @Test
     void testGetAllTools_RegularUserForbidden() {
         try (TestWebServer ignore = new TestWebServer(9876, mcpToolsHandler("{}"))) {
             Response resp = send(HttpMethod.GET, "/v1/toolset/git/tools");


### PR DESCRIPTION
Listing tools for an MCP toolset whose server returns an object-valued `inputSchema.additionalProperties` (e.g. Notion's `https://mcp.notion.com/mcp`) failed with HTTP 502. The MCP Java SDK models that JSON Schema field as `Boolean`, but the spec allows it to be a boolean *or* a schema object, so Jackson threw a deserialization error and the whole `tools/list` failed. This is an unfixed [upstream SDK bug](https://github.com/modelcontextprotocol/java-sdk/issues/445), worked around on the DIAL side.

### Applicable issues

- fixes #1561

### Description of changes

- Inject a lenient `McpJsonMapper` into the MCP transport in `ToolSetToolsController`. It wraps a Jackson `ObjectMapper` with a `DeserializationProblemHandler` that coerces an object/array value to `null` when a `Boolean` is expected, instead of throwing — so a single non-conforming field no longer fails the entire `tools/list`.
- Because the SDK record types `additionalProperties` as `Boolean`, object-valued schemas are dropped (omitted) rather than carried through; boolean values pass through unchanged. Full fidelity requires the upstream fix.
- Added regression test `testGetAllTools_ObjectAdditionalProperties` covering both object-valued and boolean `additionalProperties`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.