### PR TITLE
feat: add typed `interfaces` config alongside legacy `endpoint`/`resp…

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Application.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Application.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Data
 @Accessors(chain = true)
@@ -150,17 +149,6 @@ public class Application extends Deployment {
 
     public enum McpConfigDelivery {
         HEADER, META;
-    }
-
-    private static final Set<String> SUPPORTED_INTERFACE_KEYS = Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
-
-    /**
-     * Applications are routable only for the OpenAI chat completions interface; the Responses API
-     * (and other interfaces) are not supported through a config-declared {@code interfaces} entry.
-     */
-    @Override
-    public Set<String> supportedInterfaceKeys() {
-        return SUPPORTED_INTERFACE_KEYS;
     }
 
     public Application() {

--- a/config/src/main/java/com/epam/aidial/core/config/Application.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Application.java
@@ -148,13 +148,15 @@ public class Application extends Deployment {
         HEADER, META;
     }
 
+    private static final Set<String> SUPPORTED_INTERFACE_KEYS = Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
+
     /**
      * Applications are routable only for the OpenAI chat completions interface; the Responses API
      * (and other interfaces) are not supported through a config-declared {@code interfaces} entry.
      */
     @Override
     public Set<String> supportedInterfaceKeys() {
-        return Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
+        return SUPPORTED_INTERFACE_KEYS;
     }
 
     public Application() {

--- a/config/src/main/java/com/epam/aidial/core/config/Application.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Application.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Data
 @Accessors(chain = true)
@@ -147,6 +148,15 @@ public class Application extends Deployment {
         HEADER, META;
     }
 
+    /**
+     * Applications are routable only for the OpenAI chat completions interface; the Responses API
+     * (and other interfaces) are not supported through a config-declared {@code interfaces} entry.
+     */
+    @Override
+    public Set<String> supportedInterfaceKeys() {
+        return Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
+    }
+
     public Application() {
         super();
     }
@@ -156,6 +166,7 @@ public class Application extends Deployment {
         this.setInvalid(source.getInvalid());
         this.setName(source.getName());
         this.setEndpoint(source.getEndpoint());
+        this.setInterfaces(source.getInterfaces());
         this.setDisplayName(source.getDisplayName());
         this.setDisplayVersion(source.getDisplayVersion());
         this.setIconUrl(source.getIconUrl());

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -1,17 +1,25 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public abstract class Deployment extends RoleBasedEntity {
     private String endpoint;
     private String responsesEndpoint;
+    /**
+     * Supported LLM API interfaces keyed by interface-type value. Peer of endpoint/responsesEndpoint.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, DeploymentInterface> interfaces = Map.of();
     @JsonAlias({"displayName", "display_name"})
     private String displayName;
     @JsonAlias({"displayVersion", "display_version"})
@@ -70,4 +78,56 @@ public abstract class Deployment extends RoleBasedEntity {
      * Dependent deployments
      */
     private List<String> dependencies = List.of();
+
+    /**
+     * New-flow base URL for the type (trailing slash stripped), or null when not declared.
+     */
+    public String getInterfaceBaseUrl(InterfaceType type) {
+        DeploymentInterface i = interfaces == null ? null : interfaces.get(type.getValue());
+        if (i == null || i.getBaseUrl() == null) {
+            return null;
+        }
+        String url = i.getBaseUrl();
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /**
+     * Legacy fully-qualified endpoint configured for the type, or null.
+     */
+    public String getLegacyEndpoint(InterfaceType type) {
+        if (type == InterfaceType.OPENAI_CHAT_COMPLETIONS) {
+            return endpoint;
+        }
+        if (type == InterfaceType.OPENAI_RESPONSES) {
+            return responsesEndpoint;
+        }
+        return null;
+    }
+
+    /**
+     * Routing identifier for the type: interfaces base_url when declared (new flow), else the legacy
+     * endpoint (verbatim flow). Used as the synthetic upstream id when a deployment has no upstreams.
+     */
+    public String resolveEndpoint(InterfaceType type) {
+        String baseUrl = getInterfaceBaseUrl(type);
+        return baseUrl != null ? baseUrl : getLegacyEndpoint(type);
+    }
+
+    /**
+     * True when the deployment can serve the type via the new interfaces map OR a legacy endpoint.
+     * This restores the legacy {@code getEndpoint() != null} semantics while also honouring interfaces.
+     */
+    public boolean supportsInterface(InterfaceType type) {
+        return getInterfaceBaseUrl(type) != null || getLegacyEndpoint(type) != null;
+    }
+
+    /**
+     * Interface-type keys accepted in this deployment's {@link #interfaces} map at config read time.
+     * {@code null} means no restriction — any key is tolerated, including forward-compatible unknown
+     * types (used by {@link Model}). Subclasses narrow this so unsupported keys are dropped on load.
+     */
+    @JsonIgnore
+    public Set<String> supportedInterfaceKeys() {
+        return null;
+    }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -84,10 +84,10 @@ public abstract class Deployment extends RoleBasedEntity {
      */
     public String getInterfaceBaseUrl(InterfaceType type) {
         DeploymentInterface deploymentInterface = interfaces == null ? null : interfaces.get(type.getValue());
-        String url = deploymentInterface == null ? null : deploymentInterface.getBaseUrl();
-        if (url == null || url.isBlank()) {
+        if (deploymentInterface == null) {
             return null;
         }
+        String url = deploymentInterface.getBaseUrl();
         return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -83,11 +83,13 @@ public abstract class Deployment extends RoleBasedEntity {
      * New-flow base URL for the type (trailing slash stripped), or null when not declared.
      */
     public String getInterfaceBaseUrl(InterfaceType type) {
-        DeploymentInterface i = interfaces == null ? null : interfaces.get(type.getValue());
-        if (i == null || i.getBaseUrl() == null) {
+        DeploymentInterface deploymentInterface = interfaces == null ? null : interfaces.get(type.getValue());
+        if (deploymentInterface == null) {
             return null;
         }
-        String url = i.getBaseUrl();
+        // base_url is required and non-null (enforced by DeploymentInterface's constructor),
+        // so a declared interface always carries one.
+        String url = deploymentInterface.getBaseUrl();
         return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -84,12 +84,10 @@ public abstract class Deployment extends RoleBasedEntity {
      */
     public String getInterfaceBaseUrl(InterfaceType type) {
         DeploymentInterface deploymentInterface = interfaces == null ? null : interfaces.get(type.getValue());
-        if (deploymentInterface == null) {
+        String url = deploymentInterface == null ? null : deploymentInterface.getBaseUrl();
+        if (url == null || url.isBlank()) {
             return null;
         }
-        // base_url is required and non-null (enforced by DeploymentInterface's constructor),
-        // so a declared interface always carries one.
-        String url = deploymentInterface.getBaseUrl();
         return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -1,14 +1,12 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -119,15 +117,5 @@ public abstract class Deployment extends RoleBasedEntity {
      */
     public boolean supportsInterface(InterfaceType type) {
         return getInterfaceBaseUrl(type) != null || getLegacyEndpoint(type) != null;
-    }
-
-    /**
-     * Interface-type keys accepted in this deployment's {@link #interfaces} map at config read time.
-     * {@code null} means no restriction — any key is tolerated, including forward-compatible unknown
-     * types (used by {@link Model}). Subclasses narrow this so unsupported keys are dropped on load.
-     */
-    @JsonIgnore
-    public Set<String> supportedInterfaceKeys() {
-        return null;
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -1,39 +1,26 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Per-interface routing configuration for a {@link Deployment}. Intentionally minimal;
  * future per-interface options (auth mode, defaults, ...) go here.
  */
-@Getter
-@ToString
-@EqualsAndHashCode
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DeploymentInterface {
 
     /**
-     * Required, non-null. Source (adapter) root the matching ingress path is appended to at request time.
-     * A deployment interface cannot be created without a {@code base_url}; config that declares one without it
-     * is rejected at load time.
+     * Source (adapter) root the matching ingress path is appended to at request time.
      */
     @JsonProperty("base_url")
-    private final String baseUrl;
-
-    @JsonCreator
-    public DeploymentInterface(
-            @NotBlank
-            @JsonProperty(value = "base_url", required = true)
-            @JsonAlias({"baseUrl", "base_url"})
-            String baseUrl
-    ) {
-        this.baseUrl = baseUrl;
-    }
+    @JsonAlias({"baseUrl", "base_url"})
+    private String baseUrl;
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * Per-interface routing configuration for a {@link Deployment}. Intentionally minimal;
@@ -20,7 +18,6 @@ public class DeploymentInterface {
      * Source (adapter) root the matching ingress path is appended to at request time.
      */
     @JsonProperty("base_url")
-    @JsonAlias({"baseUrl", "base_url"})
     private String baseUrl;
 
     @JsonCreator

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -12,8 +13,6 @@ import lombok.NoArgsConstructor;
  * future per-interface options (auth mode, defaults, ...) go here.
  */
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DeploymentInterface {
 
@@ -23,4 +22,16 @@ public class DeploymentInterface {
     @JsonProperty("base_url")
     @JsonAlias({"baseUrl", "base_url"})
     private String baseUrl;
+
+    @JsonCreator
+    public DeploymentInterface(
+            @JsonProperty(value = "base_url", required = true)
+            @JsonAlias({"baseUrl", "base_url"})
+            String baseUrl
+    ) {
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            throw new IllegalArgumentException("baseUrl cannot be null or empty");
+        }
+        this.baseUrl = baseUrl;
+    }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -1,0 +1,26 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Per-interface routing configuration for a {@link Deployment}. Intentionally minimal;
+ * future per-interface options (auth mode, defaults, ...) go here.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeploymentInterface {
+
+    /**
+     * Source (adapter) root the matching ingress path is appended to at request time.
+     */
+    @JsonProperty("base_url")
+    @JsonAlias({"baseUrl", "base_url"})
+    private String baseUrl;
+}

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -28,13 +29,11 @@ public class DeploymentInterface {
 
     @JsonCreator
     public DeploymentInterface(
+            @NotBlank
             @JsonProperty(value = "base_url", required = true)
             @JsonAlias({"baseUrl", "base_url"})
             String baseUrl
     ) {
-        if (baseUrl == null || baseUrl.isBlank()) {
-            throw new IllegalArgumentException("'base_url' is required and cannot be blank for a deployment interface");
-        }
         this.baseUrl = baseUrl;
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -1,26 +1,40 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Per-interface routing configuration for a {@link Deployment}. Intentionally minimal;
  * future per-interface options (auth mode, defaults, ...) go here.
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DeploymentInterface {
 
     /**
-     * Source (adapter) root the matching ingress path is appended to at request time.
+     * Required, non-null. Source (adapter) root the matching ingress path is appended to at request time.
+     * A deployment interface cannot be created without a {@code base_url}; config that declares one without it
+     * is rejected at load time.
      */
     @JsonProperty("base_url")
-    @JsonAlias({"baseUrl", "base_url"})
-    private String baseUrl;
+    private final String baseUrl;
+
+    @JsonCreator
+    public DeploymentInterface(
+            @JsonProperty(value = "base_url", required = true)
+            @JsonAlias({"baseUrl", "base_url"})
+            String baseUrl
+    ) {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalArgumentException("'base_url' is required and cannot be blank for a deployment interface");
+        }
+        this.baseUrl = baseUrl;
+    }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/Interceptor.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Interceptor.java
@@ -4,12 +4,14 @@ import java.util.Set;
 
 public class Interceptor extends Deployment {
 
+    private static final Set<String> SUPPORTED_INTERFACE_KEYS = Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
+
     /**
      * Interceptors operate only on the OpenAI chat completions interface; the Responses API
      * (and other interfaces) are not supported through a config-declared {@code interfaces} entry.
      */
     @Override
     public Set<String> supportedInterfaceKeys() {
-        return Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
+        return SUPPORTED_INTERFACE_KEYS;
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/Interceptor.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Interceptor.java
@@ -1,17 +1,4 @@
 package com.epam.aidial.core.config;
 
-import java.util.Set;
-
 public class Interceptor extends Deployment {
-
-    private static final Set<String> SUPPORTED_INTERFACE_KEYS = Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
-
-    /**
-     * Interceptors operate only on the OpenAI chat completions interface; the Responses API
-     * (and other interfaces) are not supported through a config-declared {@code interfaces} entry.
-     */
-    @Override
-    public Set<String> supportedInterfaceKeys() {
-        return SUPPORTED_INTERFACE_KEYS;
-    }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/Interceptor.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Interceptor.java
@@ -1,4 +1,15 @@
 package com.epam.aidial.core.config;
 
+import java.util.Set;
+
 public class Interceptor extends Deployment {
+
+    /**
+     * Interceptors operate only on the OpenAI chat completions interface; the Responses API
+     * (and other interfaces) are not supported through a config-declared {@code interfaces} entry.
+     */
+    @Override
+    public Set<String> supportedInterfaceKeys() {
+        return Set.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue());
+    }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/InterfaceType.java
+++ b/config/src/main/java/com/epam/aidial/core/config/InterfaceType.java
@@ -1,0 +1,39 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+/**
+ * Extensible set of LLM API interface types a deployment may expose.
+ * The string {@link #value} is the key used in {@link Deployment#getInterfaces()}.
+ */
+@Getter
+public enum InterfaceType {
+
+    @JsonAlias({"openai_chat_completions"})
+    OPENAI_CHAT_COMPLETIONS("openaiChatCompletions"),
+    @JsonAlias({"openai_responses"})
+    OPENAI_RESPONSES("openaiResponses");
+
+    @JsonValue
+    private final String value;
+
+    InterfaceType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Resolves an interface type from its string value.
+     *
+     * @throws IllegalArgumentException if the value does not match any known interface type.
+     */
+    public static InterfaceType fromValue(String value) {
+        for (InterfaceType type : values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown interface type: " + value);
+    }
+}

--- a/config/src/main/java/com/epam/aidial/core/config/Model.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Model.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.util.List;
+import java.util.Set;
 
 @Data
 @Accessors(chain = true)
@@ -23,7 +24,17 @@ public class Model extends Deployment {
     @JsonAlias({"embeddingDimensions", "embedding_dimensions"})
     private Integer embeddingDimensions;
 
+    private static final Set<String> SUPPORTED_INTERFACE_KEYS = Set.of(
+            InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(),
+            InterfaceType.OPENAI_RESPONSES.getValue()
+    );
+
     public Model() {
         setMaxRetryAttempts(5);
+    }
+
+    @Override
+    public Set<String> supportedInterfaceKeys() {
+        return SUPPORTED_INTERFACE_KEYS;
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/Model.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Model.java
@@ -6,7 +6,6 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
 import java.util.List;
-import java.util.Set;
 
 @Data
 @Accessors(chain = true)
@@ -24,17 +23,7 @@ public class Model extends Deployment {
     @JsonAlias({"embeddingDimensions", "embedding_dimensions"})
     private Integer embeddingDimensions;
 
-    private static final Set<String> SUPPORTED_INTERFACE_KEYS = Set.of(
-            InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(),
-            InterfaceType.OPENAI_RESPONSES.getValue()
-    );
-
     public Model() {
         setMaxRetryAttempts(5);
-    }
-
-    @Override
-    public Set<String> supportedInterfaceKeys() {
-        return SUPPORTED_INTERFACE_KEYS;
     }
 }

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -1,0 +1,151 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeploymentTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void legacyOnlyChatCompletions() {
+        Model model = new Model();
+        model.setEndpoint("http://host/chat/completions");
+
+        assertTrue(model.supportsInterface(OPENAI_CHAT_COMPLETIONS));
+        assertNull(model.getInterfaceBaseUrl(OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://host/chat/completions", model.getLegacyEndpoint(OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://host/chat/completions", model.resolveEndpoint(OPENAI_CHAT_COMPLETIONS));
+
+        assertFalse(model.supportsInterface(OPENAI_RESPONSES));
+        assertNull(model.resolveEndpoint(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void legacyOnlyResponses() {
+        Model model = new Model();
+        model.setResponsesEndpoint("http://host/openai/v1/responses");
+
+        assertTrue(model.supportsInterface(OPENAI_RESPONSES));
+        assertNull(model.getInterfaceBaseUrl(OPENAI_RESPONSES));
+        assertEquals("http://host/openai/v1/responses", model.getLegacyEndpoint(OPENAI_RESPONSES));
+        assertEquals("http://host/openai/v1/responses", model.resolveEndpoint(OPENAI_RESPONSES));
+
+        assertFalse(model.supportsInterface(OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void interfacesOnlyStripsTrailingSlash() {
+        Model model = new Model();
+        model.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface("http://adapter:5000/")));
+
+        assertTrue(model.supportsInterface(OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://adapter:5000", model.getInterfaceBaseUrl(OPENAI_CHAT_COMPLETIONS));
+        assertNull(model.getLegacyEndpoint(OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://adapter:5000", model.resolveEndpoint(OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void interfacesWinWhenBothDeclared() {
+        Model model = new Model();
+        model.setResponsesEndpoint("http://legacy/openai/v1/responses");
+        model.setInterfaces(Map.of(
+                OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
+
+        assertTrue(model.supportsInterface(OPENAI_RESPONSES));
+        assertEquals("http://adapter", model.resolveEndpoint(OPENAI_RESPONSES));
+        // legacy field is left untouched in config
+        assertEquals("http://legacy/openai/v1/responses", model.getLegacyEndpoint(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void neitherDeclared() {
+        Model model = new Model();
+        assertFalse(model.supportsInterface(OPENAI_CHAT_COMPLETIONS));
+        assertFalse(model.supportsInterface(OPENAI_RESPONSES));
+        assertNull(model.resolveEndpoint(OPENAI_CHAT_COMPLETIONS));
+        assertNull(model.resolveEndpoint(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void unknownInterfaceKeysAreTolerated() throws Exception {
+        String json = """
+                {
+                    "endpoint": "http://host/chat/completions",
+                    "interfaces": {
+                        "anthropicMessages": {"base_url": "http://anthropic"},
+                        "geminiGenerateContent": {"base_url": "http://gemini"}
+                    }
+                }
+                """;
+        Model model = MAPPER.readValue(json, Model.class);
+
+        assertTrue(model.supportsInterface(OPENAI_CHAT_COMPLETIONS));
+        assertEquals(2, model.getInterfaces().size());
+        // unknown keys parse but never resolve to a routed interface type
+        assertNull(model.getInterfaceBaseUrl(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void applicationCopyConstructorPreservesInterfaces() {
+        Application source = new Application();
+        source.setName("app1");
+        source.setEndpoint("http://host/chat/completions");
+        source.setInterfaces(Map.of(
+                OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
+
+        Application copy = new Application(source);
+
+        assertEquals(source.getInterfaces(), copy.getInterfaces());
+        assertEquals("http://adapter", copy.resolveEndpoint(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void supportedInterfaceKeysByDeploymentKind() {
+        // models: no restriction (forward-compatible, tolerate unknown keys)
+        assertNull(new Model().supportedInterfaceKeys());
+        // applications and interceptors: only the chat completions interface
+        assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
+                new Application().supportedInterfaceKeys());
+        assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
+                new Interceptor().supportedInterfaceKeys());
+    }
+
+    @Test
+    void roundTripLegacy() throws Exception {
+        Model model = new Model();
+        model.setEndpoint("http://host/chat/completions");
+        model.setResponsesEndpoint("http://host/openai/v1/responses");
+
+        Model restored = MAPPER.readValue(MAPPER.writeValueAsString(model), Model.class);
+
+        assertEquals("http://host/chat/completions", restored.getEndpoint());
+        assertEquals("http://host/openai/v1/responses", restored.getResponsesEndpoint());
+        assertTrue(restored.getInterfaces().isEmpty());
+    }
+
+    @Test
+    void roundTripInterfaces() throws Exception {
+        Model model = new Model();
+        model.setEndpoint("http://host/chat/completions");
+        model.setInterfaces(Map.of(
+                OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
+
+        String json = MAPPER.writeValueAsString(model);
+        Model restored = MAPPER.readValue(json, Model.class);
+
+        // legacy field is not stripped, interfaces survive
+        assertEquals("http://host/chat/completions", restored.getEndpoint());
+        assertEquals("http://adapter", restored.getInterfaceBaseUrl(OPENAI_RESPONSES));
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -124,12 +124,6 @@ public class DeploymentTest {
     }
 
     @Test
-    void interfaceCannotBeCreatedWithoutBaseUrl() {
-        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface(null));
-        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface("   "));
-    }
-
-    @Test
     void interfaceWithoutBaseUrlIsRejectedOnDeserialization() {
         String json = """
                 {

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -112,8 +112,9 @@ public class DeploymentTest {
 
     @Test
     void supportedInterfaceKeysByDeploymentKind() {
-        // models: no restriction (forward-compatible, tolerate unknown keys)
-        assertNull(new Model().supportedInterfaceKeys());
+        // models: chat completions and responses interfaces
+        assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue(), OPENAI_RESPONSES.getValue()),
+                new Model().supportedInterfaceKeys());
         // applications and interceptors: only the chat completions interface
         assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
                 new Application().supportedInterfaceKeys());

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.config;
 
+import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,7 @@ import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentTest {
@@ -119,6 +121,25 @@ public class DeploymentTest {
                 new Application().supportedInterfaceKeys());
         assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
                 new Interceptor().supportedInterfaceKeys());
+    }
+
+    @Test
+    void interfaceCannotBeCreatedWithoutBaseUrl() {
+        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface(null));
+        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface("   "));
+    }
+
+    @Test
+    void interfaceWithoutBaseUrlIsRejectedOnDeserialization() {
+        String json = """
+                {
+                    "endpoint": "http://host/chat/completions",
+                    "interfaces": {
+                        "openaiResponses": {}
+                    }
+                }
+                """;
+        assertThrows(DatabindException.class, () -> MAPPER.readValue(json, Model.class));
     }
 
     @Test

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.core.config;
 
-import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +10,6 @@ import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentTest {
@@ -121,19 +119,6 @@ public class DeploymentTest {
                 new Application().supportedInterfaceKeys());
         assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
                 new Interceptor().supportedInterfaceKeys());
-    }
-
-    @Test
-    void interfaceWithoutBaseUrlIsRejectedOnDeserialization() {
-        String json = """
-                {
-                    "endpoint": "http://host/chat/completions",
-                    "interfaces": {
-                        "openaiResponses": {}
-                    }
-                }
-                """;
-        assertThrows(DatabindException.class, () -> MAPPER.readValue(json, Model.class));
     }
 
     @Test

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -10,6 +10,7 @@ import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentTest {
@@ -78,6 +79,12 @@ public class DeploymentTest {
     }
 
     @Test
+    void baseUrlIsRequired() {
+        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface(null));
+        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface(""));
+    }
+
+    @Test
     void unknownInterfaceKeysAreTolerated() throws Exception {
         String json = """
                 {
@@ -108,18 +115,6 @@ public class DeploymentTest {
 
         assertEquals(source.getInterfaces(), copy.getInterfaces());
         assertEquals("http://adapter", copy.resolveEndpoint(OPENAI_RESPONSES));
-    }
-
-    @Test
-    void supportedInterfaceKeysByDeploymentKind() {
-        // models: chat completions and responses interfaces
-        assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue(), OPENAI_RESPONSES.getValue()),
-                new Model().supportedInterfaceKeys());
-        // applications and interceptors: only the chat completions interface
-        assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
-                new Application().supportedInterfaceKeys());
-        assertEquals(java.util.Set.of(OPENAI_CHAT_COMPLETIONS.getValue()),
-                new Interceptor().supportedInterfaceKeys());
     }
 
     @Test

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -28,6 +28,7 @@ An object containing parameters for each [application](#applications).
 * `applications.<application_name>.applicationTypeSchemaId`: The identifier of a JSON schema that application is based upon. The shema ID must exist in the DIAL Core config property `applicationTypeSchemas`. Refer to [DIAL Documentation](https://docs.dialx.ai/platform/core/apps#application-types) to learn more about schema-rich apps.
 * `applications.<application_name>.applicationProperties`: Properties of a schema-rich application. Specified properties must conform to the JSON schema referenced by `applicationTypeSchemaId`. Refer to [DIAL Documentation](https://docs.dialx.ai/platform/core/apps#application-types) to learn more about schema-rich apps.
 * `endpoint`: The application's API endpoint for chat completion requests.
+* `interfaces`: A typed alternative to the flat `endpoint` field for declaring the routing target. For applications, only the `openaiChatCompletions` interface is supported; the Responses API and other interfaces are not. Refer to [applications.<application_name>.interfaces](#applicationsapplication_nameinterfaces).
 * `iconUrl`: A string with URL of the icon to display for the app in the UI.
 * `description`: A string with a brief description of the application.
 * `displayName`: A string with the app's name. Display name is shown in all DIAL client UI dropdowns, tables, and logs for identification purposes.
@@ -133,6 +134,34 @@ An object containing parameters for each [application](#applications).
             }
         }
     },
+```
+
+#### applications.<application_name>.interfaces
+
+An optional, typed alternative to the flat `endpoint` field. Both shapes are first-class — choose whichever you prefer per application; there is no migration between them.
+
+Unlike `endpoint`, which is forwarded **verbatim**, an `interfaces` entry declares a `base_url` and DIAL Core forwards each request to `base_url` + **the exact ingress path it was received on**. A trailing slash on `base_url` is normalized. If both `interfaces` and `endpoint` are declared for the chat completions interface, `interfaces` takes precedence.
+
+Applications support only one interface type:
+
+* `openaiChatCompletions`: the OpenAI chat completions interface. Peer of `endpoint`.
+
+> The Responses API (`openaiResponses`) and any other interface types are **not** supported for applications. If declared, they are dropped on config read with a warning.
+
+Each value is an object with a single field:
+
+* `base_url`: The application adapter root that the matching ingress path is appended to.
+
+**Example**
+
+```json
+"applications": {
+    "app-via-interfaces": {
+        "interfaces": {
+            "openaiChatCompletions": { "base_url": "http://localhost:7005" }
+        }
+    }
+}
 ```
 
 #### applications.<application_name>.features

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -150,7 +150,7 @@ Applications support only one interface type:
 
 Each value is an object with a single field:
 
-* `base_url`: **Required.** The application adapter root that the matching ingress path is appended to. An interface entry declared without a `base_url` is rejected when the configuration is loaded.
+* `base_url`: The application adapter root that the matching ingress path is appended to.
 
 **Example**
 

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -150,7 +150,7 @@ Applications support only one interface type:
 
 Each value is an object with a single field:
 
-* `base_url`: The application adapter root that the matching ingress path is appended to.
+* `base_url`: **Required.** The application adapter root that the matching ingress path is appended to. An interface entry declared without a `base_url` is rejected when the configuration is loaded.
 
 **Example**
 

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -60,7 +60,7 @@ Interceptors support only one interface type:
 
 Each value is an object with a single field:
 
-* `base_url`: The interceptor service root that the matching ingress path is appended to.
+* `base_url`: **Required.** The interceptor service root that the matching ingress path is appended to. An interface entry declared without a `base_url` is rejected when the configuration is loaded.
 
 **Example**
 

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -60,7 +60,7 @@ Interceptors support only one interface type:
 
 Each value is an object with a single field:
 
-* `base_url`: **Required.** The interceptor service root that the matching ingress path is appended to. An interface entry declared without a `base_url` is rejected when the configuration is loaded.
+* `base_url`: The interceptor service root that the matching ingress path is appended to.
 
 **Example**
 

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -33,7 +33,8 @@ An object containing deployed DIAL Interceptors and their [parameters](#intercep
 
 An object containing parameters for each [interceptor](#interceptors).
 
-* `endpoint`: The URL of the interceptor service. This URL is used to handle requests and responses for the interceptor. **Required**.
+* `endpoint`: The URL of the interceptor service. This URL is used to handle requests and responses for the interceptor. **Required** unless `interfaces` is used instead.
+* `interfaces`: A typed alternative to the flat `endpoint` field for declaring the interceptor service target. For interceptors, only the `openaiChatCompletions` interface is supported; the Responses API and other interfaces are not. Refer to [interceptors.<interceptor_name>.interfaces](#interceptorsinterceptor_nameinterfaces).
 * `iconUrl`: A string with the URL with the icon location to display for the interceptor on UI.
 * `description`: A brief summary of what this interceptor does and any parameters it uses (e.g. BLACKLIST=bar or Logs request/response payloads).
 * `displayName`: A string with the interceptor's name. Display name is shown in all DIAL client UI dropdowns, tables, and logs so operators can quickly identify the interceptor.
@@ -44,6 +45,34 @@ An object containing parameters for each [interceptor](#interceptors).
 * `features`: Features supported by the interceptors.
 *  `configurationEndpoint`: The URL that exposes the configuration of the interceptor.
 *  `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.
+
+### interceptors.<interceptor_name>.interfaces
+
+An optional, typed alternative to the flat `endpoint` field. Both shapes are first-class — choose whichever you prefer per interceptor; there is no migration between them.
+
+Unlike `endpoint`, which is forwarded **verbatim**, an `interfaces` entry declares a `base_url` and DIAL Core forwards each request to `base_url` + **the ingress path**, with the `{deployment-id}` segment rewritten to the interceptor's own name (e.g. `/openai/deployments/<model>/chat/completions` is routed to `<base_url>/openai/deployments/<interceptor-name>/chat/completions`). A trailing slash on `base_url` is normalized. If both `interfaces` and `endpoint` are declared, `interfaces` takes precedence.
+
+Interceptors support only one interface type:
+
+* `openaiChatCompletions`: the OpenAI chat completions interface. Peer of `endpoint`.
+
+> The Responses API (`openaiResponses`) and any other interface types are **not** supported for interceptors. If declared, they are dropped on config read with a warning.
+
+Each value is an object with a single field:
+
+* `base_url`: The interceptor service root that the matching ingress path is appended to.
+
+**Example**
+
+```json
+"interceptors": {
+    "interceptor-via-interfaces": {
+        "interfaces": {
+            "openaiChatCompletions": { "base_url": "http://localhost:4088" }
+        }
+    }
+}
+```
 
 ## Categories of Interceptors
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -154,7 +154,7 @@ Supported interface types for models:
 
 Each value is an object with a single field:
 
-* `base_url`: **Required.** The model adapter root that the matching ingress path is appended to. An interface entry declared without a `base_url` is rejected when the configuration is loaded.
+* `base_url`: The model adapter root that the matching ingress path is appended to.
 
 **Example**
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -48,6 +48,7 @@ An object containing parameters for each [model](#models).
 
   DIAL Core rewrites upstream response IDs to stable `resp_dial_*` identifiers and uses sticky routing to ensure follow-up requests are forwarded to the same upstream instance that handled the original request. `previous_response_id`, conversations, prompts, and files are not supported.
 * `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API.
+* `interfaces`: An alternative to the flat `endpoint`/`responsesEndpoint` fields for declaring routing targets, keyed by interface type. Both shapes are first-class — pick whichever you prefer per model. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interceptors`: A list of interceptors to be triggered for the given model. Refer to [Interceptors](https://github.com/epam/ai-dial/blob/main/docs/platform/3.core/6.interceptors.md) to learn more.
 * `fieldsHashingOrder`: A list of chat completion request components that defines an order in which they are used to compute a hash of the request. The components of the request are identified by strings `prefix.body.tools` and `prefix.body.messages`. The default value of the parameter is ["prefix.body.tools", "prefix.body.messages"], meaning the hash is first computed for the tools definitions, then extended with the hash of the messages. It reflects the relative order of tools and messages components when they are converted to tokens and fed into a typical LLM. The hash is used uniquely identify prefixes of the request that are marked by [cache breakpoints](https://docs.dialx.ai/tutorials/developers/prompt-caching). It enables DIAL Core to redirect independent requests that are sharing the same prefix to the same upstream endpoint. This is essential to enable context caching feature of LLM since their caching scope is limited to a simple upstream endpoint.
 * `features`: An object with the model features that define optional capabilities of the model. Refer to [models.<model_name>.features](#modelsmodel_namefeatures).
@@ -133,6 +134,40 @@ An object containing parameters for each [model](#models).
             "userRoles": ["role3"]
         }
     },
+```
+
+#### models.<model_name>.interfaces
+
+An optional, typed alternative to the flat `endpoint`/`responsesEndpoint` fields. Both shapes are first-class and fully supported — choose whichever you prefer per model. There is no migration between them in either direction, and declaring `interfaces` never rewrites or removes the legacy fields.
+
+The two shapes route differently:
+
+* `endpoint`/`responsesEndpoint` are forwarded **verbatim** — the configured URL is used as-is and the ingress path is not appended.
+* An `interfaces` entry declares a `base_url`, and DIAL Core forwards each request to `base_url` + **the exact ingress path it was received on** (e.g. `POST /openai/v1/responses` is routed to `<base_url>/openai/v1/responses`). A trailing slash on `base_url` is normalized.
+
+If both `interfaces` and a legacy field are declared for the same interface type, `interfaces` takes precedence; the legacy field is left untouched in config and ignored for routing.
+
+Supported interface types for models:
+
+* `openaiChatCompletions`: the OpenAI deployments POST family (`chat/completions`, `completions`, `embeddings`). Peer of `endpoint`.
+* `openaiResponses`: the OpenAI Responses API. Peer of `responsesEndpoint`.
+
+Each value is an object with a single field:
+
+* `base_url`: The model adapter root that the matching ingress path is appended to.
+
+**Example**
+
+```json
+"models": {
+    "gpt-4-via-interfaces": {
+        "type": "chat",
+        "interfaces": {
+            "openaiChatCompletions": { "base_url": "http://localhost:7005" },
+            "openaiResponses": { "base_url": "http://localhost:7005" }
+        }
+    }
+}
 ```
 
 #### models.<model_name>.limits

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -154,7 +154,7 @@ Supported interface types for models:
 
 Each value is an object with a single field:
 
-* `base_url`: The model adapter root that the matching ingress path is appended to.
+* `base_url`: **Required.** The model adapter root that the matching ingress path is appended to. An interface entry declared without a `base_url` is rejected when the configuration is loaded.
 
 **Example**
 

--- a/sample/aidial.config.json
+++ b/sample/aidial.config.json
@@ -177,6 +177,19 @@
                 }
             ],
             "userRoles": ["role3"]
+        },
+        "gpt-4-via-interfaces": {
+            "type": "chat",
+            "displayName": "GPT-4 (interfaces)",
+            "interfaces": {
+                "openaiChatCompletions": {
+                    "base_url": "http://localhost:7005"
+                },
+                "openaiResponses": {
+                    "base_url": "http://localhost:7005"
+                }
+            },
+            "userRoles": ["role1"]
         }
     },
     "toolsets": {

--- a/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
@@ -2,8 +2,6 @@ package com.epam.aidial.core.server.config;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
-import com.epam.aidial.core.config.Deployment;
-import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.ExternalService;
 import com.epam.aidial.core.config.Interceptor;
 import com.epam.aidial.core.config.Key;
@@ -147,7 +145,6 @@ public final class ConfigPostProcessor {
         Interceptor interceptor = config.getInterceptors().get(canonicalId);
         if (interceptor != null) {
             interceptor.setName(canonicalId);
-            stripUnsupportedInterfaces(interceptor, canonicalId, ResourceTypes.INTERCEPTOR);
         }
     }
 
@@ -274,36 +271,7 @@ public final class ConfigPostProcessor {
             Application application = entry.getValue();
             application.setName(name);
             validateExternalServices(application);
-            stripUnsupportedInterfaces(application, name, ResourceTypes.APPLICATION);
             log.debug("Loading {}", application);
-        }
-    }
-
-    /**
-     * Drops {@code interfaces} entries whose key is not supported by the deployment kind
-     * (see {@link Deployment#supportedInterfaceKeys()}). Applications and interceptors only
-     * accept {@code openaiChatCompletions}; any other key (e.g. {@code openaiResponses}) is
-     * removed with a warning so the deployment still serves the interfaces it does support.
-     */
-    private static void stripUnsupportedInterfaces(Deployment deployment, String name, ResourceTypes type) {
-        Set<String> allowed = deployment.supportedInterfaceKeys();
-        Map<String, DeploymentInterface> interfaces = deployment.getInterfaces();
-        if (allowed == null || interfaces == null || interfaces.isEmpty()) {
-            return;
-        }
-        Map<String, DeploymentInterface> filtered = new LinkedHashMap<>(interfaces);
-        boolean changed = false;
-        Iterator<Map.Entry<String, DeploymentInterface>> iter = filtered.entrySet().iterator();
-        while (iter.hasNext()) {
-            String key = iter.next().getKey();
-            if (!allowed.contains(key)) {
-                log.warn("{} '{}' does not support interface type '{}'; ignoring it", type, name, key);
-                iter.remove();
-                changed = true;
-            }
-        }
-        if (changed) {
-            deployment.setInterfaces(filtered);
         }
     }
 
@@ -375,7 +343,6 @@ public final class ConfigPostProcessor {
             }
             Interceptor interceptor = entry.getValue();
             interceptor.setName(name);
-            stripUnsupportedInterfaces(interceptor, name, ResourceTypes.INTERCEPTOR);
             log.debug("Loading {}", interceptor);
         }
     }

--- a/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
@@ -2,6 +2,8 @@ package com.epam.aidial.core.server.config;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Interceptor;
 import com.epam.aidial.core.config.Key;
 import com.epam.aidial.core.config.Limit;
@@ -139,6 +141,7 @@ public final class ConfigPostProcessor {
         Interceptor interceptor = config.getInterceptors().get(canonicalId);
         if (interceptor != null) {
             interceptor.setName(canonicalId);
+            stripUnsupportedInterfaces(interceptor, canonicalId, ResourceTypes.INTERCEPTOR);
         }
     }
 
@@ -264,7 +267,36 @@ public final class ConfigPostProcessor {
             }
             Application application = entry.getValue();
             application.setName(name);
+            stripUnsupportedInterfaces(application, name, ResourceTypes.APPLICATION);
             log.debug("Loading {}", application);
+        }
+    }
+
+    /**
+     * Drops {@code interfaces} entries whose key is not supported by the deployment kind
+     * (see {@link Deployment#supportedInterfaceKeys()}). Applications and interceptors only
+     * accept {@code openaiChatCompletions}; any other key (e.g. {@code openaiResponses}) is
+     * removed with a warning so the deployment still serves the interfaces it does support.
+     */
+    private static void stripUnsupportedInterfaces(Deployment deployment, String name, ResourceTypes type) {
+        Set<String> allowed = deployment.supportedInterfaceKeys();
+        Map<String, DeploymentInterface> interfaces = deployment.getInterfaces();
+        if (allowed == null || interfaces == null || interfaces.isEmpty()) {
+            return;
+        }
+        Map<String, DeploymentInterface> filtered = new LinkedHashMap<>(interfaces);
+        boolean changed = false;
+        Iterator<Map.Entry<String, DeploymentInterface>> iter = filtered.entrySet().iterator();
+        while (iter.hasNext()) {
+            String key = iter.next().getKey();
+            if (!allowed.contains(key)) {
+                log.warn("{} '{}' does not support interface type '{}'; ignoring it", type, name, key);
+                iter.remove();
+                changed = true;
+            }
+        }
+        if (changed) {
+            deployment.setInterfaces(filtered);
         }
     }
 
@@ -292,6 +324,7 @@ public final class ConfigPostProcessor {
             }
             Interceptor interceptor = entry.getValue();
             interceptor.setName(name);
+            stripUnsupportedInterfaces(interceptor, name, ResourceTypes.INTERCEPTOR);
             log.debug("Loading {}", interceptor);
         }
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Pricing;
 import com.epam.aidial.core.config.Upstream;
@@ -164,18 +165,37 @@ public class BaseDeploymentPostController {
         return tokenUsageFuture;
     }
 
-    protected Future<HttpClientRequest> createProxyRequest(Function<Deployment, String> endpointSelector) {
+    /**
+     * Low-level: build and issue the proxy request to an already-resolved absolute URI.
+     */
+    protected Future<HttpClientRequest> createProxyRequest(String absoluteUri) {
         HttpServerRequest request = context.getRequest();
-        String uri = endpointSelector.apply(context.getDeployment())
-                + (request.query() == null ? "" : "?" + request.query());
         RequestOptions options = new RequestOptions()
-                .setAbsoluteURI(uri)
+                .setAbsoluteURI(absoluteUri)
                 .setMethod(request.method())
                 .setTraceOperation(context.getTraceOperation())
                 .setConnectTimeout(proxy.getClientOptions().getConnectTimeout())
                 .setIdleTimeout(proxy.getClientOptions().getIdleTimeout());
 
         return proxy.getClient().request(options);
+    }
+
+    /**
+     * Dual-mode: route by interface type. When the deployment declares an {@code interfaces} base URL
+     * for the type, forward to {@code base_url + <exact ingress path>}; otherwise forward the verbatim
+     * legacy endpoint (plus the original query), byte-identical to the legacy flow.
+     */
+    protected Future<HttpClientRequest> createProxyRequest(InterfaceType type) {
+        HttpServerRequest request = context.getRequest();
+        Deployment deployment = context.getDeployment();
+        String baseUrl = deployment.getInterfaceBaseUrl(type);
+        String uri = baseUrl != null
+                // New flow: base_url + exact ingress path. request.uri() already includes path + query.
+                ? baseUrl + request.uri()
+                // Legacy flow: verbatim endpoint + original query — byte-identical to today.
+                : deployment.getLegacyEndpoint(type)
+                        + (request.query() == null ? "" : "?" + request.query());
+        return createProxyRequest(uri);
     }
 
     protected Future<HttpClientResponse> sendProxyRequest(

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -249,7 +249,6 @@ public class DeploymentController {
                 } else {
                     interfaces.add(EMBEDDING_IFACE);
                 }
-                interfaces.addAll(model.getInterfaces().keySet());
                 deployment.setInterfaces(interfaces);
                 deployments.add(deployment);
             }
@@ -269,7 +268,6 @@ public class DeploymentController {
         if (app.getViewerUrl() != null) {
             interfaces.add(CUSTOM_UI_IFACE);
         }
-        interfaces.addAll(app.getInterfaces().keySet());
         applicationData.setInterfaces(interfaces);
         return applicationData;
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -249,6 +249,7 @@ public class DeploymentController {
                 } else {
                     interfaces.add(EMBEDDING_IFACE);
                 }
+                interfaces.addAll(supportedInterfaces(model));
                 deployment.setInterfaces(interfaces);
                 deployments.add(deployment);
             }
@@ -268,6 +269,7 @@ public class DeploymentController {
         if (app.getViewerUrl() != null) {
             interfaces.add(CUSTOM_UI_IFACE);
         }
+        interfaces.addAll(supportedInterfaces(app));
         applicationData.setInterfaces(interfaces);
         return applicationData;
     }
@@ -278,6 +280,21 @@ public class DeploymentController {
         toolSetData.setAuthSettings(null);
         toolSetData.setInterfaces(List.of(MCP_IFACE));
         return toolSetData;
+    }
+
+    /**
+     * Typed interface types ({@link InterfaceType}) the deployment exposes, via either the new
+     * {@code interfaces} map or a legacy endpoint. Embedding models also expose
+     * {@code openaiChatCompletions} since their endpoint is registered under that interface key.
+     */
+    private static List<String> supportedInterfaces(Deployment deployment) {
+        List<String> result = new ArrayList<>();
+        for (InterfaceType type : InterfaceType.values()) {
+            if (deployment.supportsInterface(type)) {
+                result.add(type.getValue());
+            }
+        }
+        return result;
     }
 
     private static class ExecutionPlan {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.controller;
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
 import com.epam.aidial.core.config.ToolSet;
@@ -143,7 +144,7 @@ public class DeploymentController {
                 case CHAT_IFACE: {
                     plan.useModels = true;
                     plan.useApplications = true;
-                    plan.appFilters.add(app -> app.getEndpoint() != null);
+                    plan.appFilters.add(app -> app.supportsInterface(InterfaceType.OPENAI_CHAT_COMPLETIONS));
                     plan.modelFilters.add(model -> model.getType() == ModelType.CHAT);
                     break;
                 }
@@ -261,7 +262,7 @@ public class DeploymentController {
         if (app.getMcp() != null) {
             interfaces.add(MCP_IFACE);
         }
-        if (app.getEndpoint() != null) {
+        if (app.supportsInterface(InterfaceType.OPENAI_CHAT_COMPLETIONS)) {
             interfaces.add(CHAT_IFACE);
         }
         if (app.getViewerUrl() != null) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -249,6 +249,7 @@ public class DeploymentController {
                 } else {
                     interfaces.add(EMBEDDING_IFACE);
                 }
+                interfaces.addAll(model.getInterfaces().keySet());
                 deployment.setInterfaces(interfaces);
                 deployments.add(deployment);
             }
@@ -268,6 +269,7 @@ public class DeploymentController {
         if (app.getViewerUrl() != null) {
             interfaces.add(CUSTOM_UI_IFACE);
         }
+        interfaces.addAll(app.getInterfaces().keySet());
         applicationData.setInterfaces(interfaces);
         return applicationData;
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -4,6 +4,7 @@ import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.Features;
 import com.epam.aidial.core.config.Interceptor;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
@@ -90,7 +91,7 @@ public class DeploymentPostController extends BaseDeploymentPostController {
                         dep = proxy.getApplicationSchemaService().modifyEndpointsForCustomApplication(app);
                     }
 
-                    if (dep.getEndpoint() == null) {
+                    if (!dep.supportsInterface(InterfaceType.OPENAI_CHAT_COMPLETIONS)) {
                         throw new HttpException(HttpStatus.SERVICE_UNAVAILABLE, "");
                     }
 
@@ -203,7 +204,7 @@ public class DeploymentPostController extends BaseDeploymentPostController {
     @SneakyThrows
     private void sendRequest() {
         if (nextUpstream()) {
-            createProxyRequest(Deployment::getEndpoint)
+            createProxyRequest(InterfaceType.OPENAI_CHAT_COMPLETIONS)
                     .onSuccess(this::handleProxyRequest)
                     .onFailure(this::handleProxyConnectionError);
         }
@@ -238,7 +239,8 @@ public class DeploymentPostController extends BaseDeploymentPostController {
         String upstreamId = context.getRequest().headers().get(Proxy.HEADER_UPSTREAM_ID);
         UpstreamRoute upstreamRoute;
         try {
-            upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, context.getCacheBreakpointContext(), upstreamId);
+            upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, context.getCacheBreakpointContext(),
+                    dep -> dep.resolveEndpoint(InterfaceType.OPENAI_CHAT_COMPLETIONS), upstreamId);
         } catch (HttpException e) {
             respond(e.getStatus(), e.getMessage());
             return;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/InterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/InterceptorController.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
@@ -15,6 +16,7 @@ import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientRequest;
@@ -22,14 +24,17 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.RequestOptions;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 public class InterceptorController extends BaseDeploymentPostController {
+
+    private static final Pattern DEPLOYMENT_PATH = Pattern.compile("(/openai/deployments/)([^/]+)(/.*)");
 
     private final List<BaseRequestFunction<RequestObject>> enhancementFunctions;
 
@@ -84,26 +89,30 @@ public class InterceptorController extends BaseDeploymentPostController {
     }
 
 
-    private static String buildUri(ProxyContext context) {
-        HttpServerRequest request = context.getRequest();
-        Deployment deployment = context.getDeployment();
-        String endpoint = deployment.getEndpoint();
-        String query = request.query();
-        return endpoint + (query == null ? "" : "?" + query);
-    }
-
     private void sendRequest() {
-        String uri = buildUri(context);
-        RequestOptions options = new RequestOptions()
-                .setAbsoluteURI(uri)
-                .setMethod(context.getRequest().method())
-                .setTraceOperation(context.getTraceOperation())
-                .setConnectTimeout(context.getProxy().getClientOptions().getConnectTimeout())
-                .setIdleTimeout(context.getProxy().getClientOptions().getIdleTimeout());
-
-        proxy.getClient().request(options)
+        createProxyRequest(interceptorUri())
                 .onSuccess(this::handleProxyRequest)
                 .onFailure(this::handleProxyConnectionError);
+    }
+
+    private String interceptorUri() {
+        Deployment deployment = context.getDeployment();
+        HttpServerRequest request = context.getRequest();
+        String query = request.query();
+        String baseUrl = deployment.getInterfaceBaseUrl(InterfaceType.OPENAI_CHAT_COMPLETIONS);
+        if (baseUrl != null) {
+            // New flow: rewrite the {id} segment to the interceptor's own name, then base_url + path.
+            String name = UrlUtil.encodePathSegment(deployment.getName());
+            String path = rewriteDeploymentSegment(request.path(), name);
+            return query == null ? baseUrl + path : baseUrl + path + "?" + query;
+        }
+        // Legacy flow: verbatim endpoint + query — identical to today's buildUri.
+        return query == null ? deployment.getEndpoint() : deployment.getEndpoint() + "?" + query;
+    }
+
+    static String rewriteDeploymentSegment(String path, String name) {
+        Matcher m = DEPLOYMENT_PATH.matcher(path);
+        return m.matches() ? m.group(1) + name + m.group(3) : path;
     }
 
 

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponseItemController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponseItemController.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -34,10 +35,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ResponseItemController implements Controller {
 
+    private static final String OPENAI_RESPONSES_BASE_PATH = "/openai/v1/responses";
+
     private final Proxy proxy;
     private final ProxyContext context;
     private final String dialResponseId;
     private final Operation operation;
+
+    /**
+     * New flow: base_url + /openai/v1/responses. Legacy flow: the verbatim responsesEndpoint.
+     */
+    private static String responsesBase(Deployment deployment) {
+        String baseUrl = deployment.getInterfaceBaseUrl(InterfaceType.OPENAI_RESPONSES);
+        return baseUrl != null ? baseUrl + OPENAI_RESPONSES_BASE_PATH : deployment.getResponsesEndpoint();
+    }
 
     @Override
     public Future<?> handle() {
@@ -64,15 +75,16 @@ public class ResponseItemController implements Controller {
 
     private Future<Void> forwardToUpstream(ResponseMapping mapping) {
         Deployment deployment = proxy.getDeploymentService().findDeployment(context, mapping.getDeploymentName());
-        if (deployment.getResponsesEndpoint() == null) {
+        if (!deployment.supportsInterface(InterfaceType.OPENAI_RESPONSES)) {
             return context.respond(HttpStatus.SERVICE_UNAVAILABLE, "Deployment for response_id does not support Responses API")
                     .mapEmpty();
         }
-        UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, null, mapping.getUpstreamKey());
+        UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, null,
+                dep -> dep.resolveEndpoint(InterfaceType.OPENAI_RESPONSES), mapping.getUpstreamKey());
         Upstream upstream = upstreamRoute.next();
 
         String query = context.getRequest().query();
-        String targetUrl = deployment.getResponsesEndpoint() + "/" + mapping.getUpstreamResponseId() + operation.suffix
+        String targetUrl = responsesBase(deployment) + "/" + mapping.getUpstreamResponseId() + operation.suffix
                 + (query != null ? "?" + query : "");
         RequestOptions options = new RequestOptions()
                 .setAbsoluteURI(targetUrl)

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponseItemController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponseItemController.java
@@ -79,8 +79,12 @@ public class ResponseItemController implements Controller {
             return context.respond(HttpStatus.SERVICE_UNAVAILABLE, "Deployment for response_id does not support Responses API")
                     .mapEmpty();
         }
-        UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider().get(deployment, null,
-                dep -> dep.resolveEndpoint(InterfaceType.OPENAI_RESPONSES), mapping.getUpstreamKey());
+        UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider()
+                .get(deployment,
+                        null,
+                        dep -> dep.resolveEndpoint(InterfaceType.OPENAI_RESPONSES),
+                        mapping.getUpstreamKey()
+                );
         Upstream upstream = upstreamRoute.next();
 
         String query = context.getRequest().query();

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.controller;
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.Features;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
@@ -94,8 +95,11 @@ public class ResponsesController extends BaseDeploymentPostController {
             deployment = proxy.getApplicationSchemaService().modifyEndpointsForCustomApplication(application);
         }
 
-        if (deployment.getResponsesEndpoint() == null) {
-            throw new HttpException(HttpStatus.SERVICE_UNAVAILABLE, "");
+        if (!deployment.supportsInterface(InterfaceType.OPENAI_RESPONSES)) {
+            throw new HttpException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "OpenAI responses not supported for this deployment type"
+            );
         }
 
         context.setTraceOperation("Send request to %s deployment".formatted(deployment.getName()));
@@ -163,7 +167,8 @@ public class ResponsesController extends BaseDeploymentPostController {
         Deployment deployment = context.getDeployment();
         String upstreamId = context.getRequest().headers().get(Proxy.HEADER_UPSTREAM_ID);
         UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider()
-                .get(deployment, context.getCacheBreakpointContext(), upstreamId);
+                .get(deployment, context.getCacheBreakpointContext(),
+                        dep -> dep.resolveEndpoint(InterfaceType.OPENAI_RESPONSES), upstreamId);
 
         context.setRequestBodyTimestamp(System.currentTimeMillis());
         context.setUpstreamRoute(upstreamRoute);
@@ -179,7 +184,7 @@ public class ResponsesController extends BaseDeploymentPostController {
                 respond(HttpStatus.SERVICE_UNAVAILABLE, "Upstream is missing required id");
                 return;
             }
-            createProxyRequest(Deployment::getResponsesEndpoint)
+            createProxyRequest(InterfaceType.OPENAI_RESPONSES)
                     .onSuccess(this::handleProxyRequest)
                     .onFailure(this::handleProxyConnectionError);
         }

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -6,7 +6,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentApiTest extends ResourceBaseTest {
 
@@ -67,5 +71,23 @@ public class DeploymentApiTest extends ResourceBaseTest {
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
         assertEquals(1, body.size());
+    }
+
+    @DialConfigLocation("dial-config/deployment-interfaces-typed.json")
+    @Test
+    public void testListDeploymentsExposesTypedInterfaces() throws JsonProcessingException {
+        Response response = send(HttpMethod.GET, "/v1/deployments", null, null);
+        verify(response, 200);
+        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
+        assertEquals(1, body.size());
+
+        JsonNode interfaces = body.get(0).get("interfaces");
+        List<String> values = new ArrayList<>();
+        interfaces.forEach(node -> values.add(node.asText()));
+
+        // legacy UI category plus the configured typed interface keys
+        assertTrue(values.contains("chat"));
+        assertTrue(values.contains("openaiChatCompletions"));
+        assertTrue(values.contains("openaiResponses"));
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -6,6 +6,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DeploymentApiTest extends ResourceBaseTest {
@@ -17,6 +22,12 @@ public class DeploymentApiTest extends ResourceBaseTest {
         verify(response, 200);
         JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
         assertEquals(4, body.size());
+
+        // typed interface types are surfaced in the `interfaces` array next to the UI categories;
+        // embedding models expose openaiChatCompletions since their endpoint lives under that key
+        Map<String, Set<String>> interfacesById = collectInterfaces(body);
+        assertEquals(Set.of("embedding", "openaiChatCompletions"), interfacesById.get("embedding-ada"));
+        assertEquals(Set.of("chat", "openaiChatCompletions"), interfacesById.get("gpt-4"));
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=all,mcp", null);
         verify(response, 200);
@@ -67,5 +78,17 @@ public class DeploymentApiTest extends ResourceBaseTest {
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
         assertEquals(1, body.size());
+    }
+
+    private static Map<String, Set<String>> collectInterfaces(JsonNode body) {
+        Map<String, Set<String>> result = new HashMap<>();
+        for (JsonNode deployment : body) {
+            Set<String> interfaces = new HashSet<>();
+            for (JsonNode iface : deployment.get("interfaces")) {
+                interfaces.add(iface.asText());
+            }
+            result.put(deployment.get("id").asText(), interfaces);
+        }
+        return result;
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -6,11 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentApiTest extends ResourceBaseTest {
 
@@ -71,23 +67,5 @@ public class DeploymentApiTest extends ResourceBaseTest {
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
         assertEquals(1, body.size());
-    }
-
-    @DialConfigLocation("dial-config/deployment-interfaces-typed.json")
-    @Test
-    public void testListDeploymentsExposesTypedInterfaces() throws JsonProcessingException {
-        Response response = send(HttpMethod.GET, "/v1/deployments", null, null);
-        verify(response, 200);
-        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(1, body.size());
-
-        JsonNode interfaces = body.get(0).get("interfaces");
-        List<String> values = new ArrayList<>();
-        interfaces.forEach(node -> values.add(node.asText()));
-
-        // legacy UI category plus the configured typed interface keys
-        assertTrue(values.contains("chat"));
-        assertTrue(values.contains("openaiChatCompletions"));
-        assertTrue(values.contains("openaiResponses"));
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.config;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Interceptor;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Role;
@@ -14,6 +15,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,6 +91,51 @@ public class ConfigPostProcessorTest {
         assertEquals("shared", capturedKey.get());
         assertTrue(config.getModels().containsKey("shared"));
         assertFalse(config.getApplications().containsKey("shared"));
+    }
+
+    @Test
+    void testStripsUnsupportedInterfacesFromApplicationsAndInterceptors() {
+        Config config = newMutableConfig();
+
+        Application app = new Application();
+        Map<String, DeploymentInterface> appInterfaces = new LinkedHashMap<>();
+        appInterfaces.put("openaiChatCompletions", new DeploymentInterface("http://app"));
+        appInterfaces.put("openaiResponses", new DeploymentInterface("http://app-responses"));
+        app.setInterfaces(appInterfaces);
+        config.getApplications().put("app", app);
+
+        Interceptor interceptor = new Interceptor();
+        Map<String, DeploymentInterface> interceptorInterfaces = new LinkedHashMap<>();
+        interceptorInterfaces.put("openaiChatCompletions", new DeploymentInterface("http://interceptor"));
+        interceptorInterfaces.put("anthropicMessages", new DeploymentInterface("http://interceptor-anthropic"));
+        interceptor.setInterfaces(interceptorInterfaces);
+        config.getInterceptors().put("interceptor", interceptor);
+
+        ConfigPostProcessor.process(config, null);
+
+        // applications and interceptors keep only the chat completions interface
+        assertEquals(Set.of("openaiChatCompletions"),
+                config.getApplications().get("app").getInterfaces().keySet());
+        assertEquals(Set.of("openaiChatCompletions"),
+                config.getInterceptors().get("interceptor").getInterfaces().keySet());
+    }
+
+    @Test
+    void testKeepsAllInterfacesForModels() {
+        Config config = newMutableConfig();
+
+        Model model = new Model();
+        Map<String, DeploymentInterface> interfaces = new LinkedHashMap<>();
+        interfaces.put("openaiChatCompletions", new DeploymentInterface("http://model"));
+        interfaces.put("openaiResponses", new DeploymentInterface("http://model-responses"));
+        // forward-compatible unknown key is tolerated for models
+        interfaces.put("anthropicMessages", new DeploymentInterface("http://model-anthropic"));
+        model.setInterfaces(interfaces);
+        config.getModels().put("model", model);
+
+        ConfigPostProcessor.process(config, null);
+
+        assertEquals(3, config.getModels().get("model").getInterfaces().size());
     }
 
     private static Config newMutableConfig() {

--- a/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,41 +93,15 @@ public class ConfigPostProcessorTest {
     }
 
     @Test
-    void testStripsUnsupportedInterfacesFromApplicationsAndInterceptors() {
+    void testPreservesAllInterfacesIncludingUnknownKeys() {
         Config config = newMutableConfig();
 
-        Application app = new Application();
-        Map<String, DeploymentInterface> appInterfaces = new LinkedHashMap<>();
-        appInterfaces.put("openaiChatCompletions", new DeploymentInterface("http://app"));
-        appInterfaces.put("openaiResponses", new DeploymentInterface("http://app-responses"));
-        app.setInterfaces(appInterfaces);
-        config.getApplications().put("app", app);
-
-        Interceptor interceptor = new Interceptor();
-        Map<String, DeploymentInterface> interceptorInterfaces = new LinkedHashMap<>();
-        interceptorInterfaces.put("openaiChatCompletions", new DeploymentInterface("http://interceptor"));
-        interceptorInterfaces.put("anthropicMessages", new DeploymentInterface("http://interceptor-anthropic"));
-        interceptor.setInterfaces(interceptorInterfaces);
-        config.getInterceptors().put("interceptor", interceptor);
-
-        ConfigPostProcessor.process(config, null);
-
-        // applications and interceptors keep only the chat completions interface
-        assertEquals(Set.of("openaiChatCompletions"),
-                config.getApplications().get("app").getInterfaces().keySet());
-        assertEquals(Set.of("openaiChatCompletions"),
-                config.getInterceptors().get("interceptor").getInterfaces().keySet());
-    }
-
-    @Test
-    void testKeepsAllInterfacesForModels() {
-        Config config = newMutableConfig();
-
+        // Models, applications and interceptors all keep their declared interfaces verbatim — config
+        // processing never strips keys (unknown/forward-compatible keys simply never resolve to a route).
         Model model = new Model();
         Map<String, DeploymentInterface> interfaces = new LinkedHashMap<>();
         interfaces.put("openaiChatCompletions", new DeploymentInterface("http://model"));
         interfaces.put("openaiResponses", new DeploymentInterface("http://model-responses"));
-        // forward-compatible unknown key is tolerated for models
         interfaces.put("anthropicMessages", new DeploymentInterface("http://model-anthropic"));
         model.setInterfaces(interfaces);
         config.getModels().put("model", model);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -3,7 +3,9 @@ package com.epam.aidial.core.server.controller;
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Features;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
@@ -34,11 +36,13 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -365,6 +369,46 @@ public class DeploymentPostControllerTest {
         controller.handleRequestBody(requestBody);
 
         verify(proxy.getClient()).request(any());
+    }
+
+    @Test
+    public void testHandleRequestBody_InterfacesBaseUrl() {
+        when(context.getRequest()).thenReturn(request);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        when(upstreamRoute.next()).thenReturn(new Upstream());
+        when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
+        HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
+        when(context.getRequest()).thenReturn(request);
+        when(request.uri()).thenReturn("/openai/deployments/name/chat/completions");
+        HttpClient httpClient = mock(HttpClient.class, RETURNS_DEEP_STUBS);
+        when(proxy.getClient()).thenReturn(httpClient);
+        when(proxy.getApiKeyStore()).thenReturn(mock(ApiKeyStore.class));
+        when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
+        ApiKeyData proxyApiKeyData = new ApiKeyData();
+        proxyApiKeyData.setInterceptorIndex(0);
+        when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
+
+        Model model = new Model();
+        model.setName("name");
+        model.setInterfaces(Map.of(
+                InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface("http://host")));
+        when(context.getDeployment()).thenReturn(model);
+        String body = """
+                {
+                    "model": "name",
+                    "messages": [],
+                    "stream": false
+                }
+                """;
+        Buffer requestBody = Buffer.buffer(body);
+
+        controller.handleRequestBody(requestBody);
+
+        ArgumentCaptor<RequestOptions> captor = ArgumentCaptor.forClass(RequestOptions.class);
+        verify(httpClient).request(captor.capture());
+        // new flow: base_url + exact ingress path (request.uri())
+        assertEquals("/openai/deployments/name/chat/completions", captor.getValue().getURI());
+        assertEquals("host", captor.getValue().getHost());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/controller/InterceptorControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/InterceptorControllerTest.java
@@ -1,0 +1,28 @@
+package com.epam.aidial.core.server.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InterceptorControllerTest {
+
+    @Test
+    void rewritesDeploymentSegmentToInterceptorName() {
+        assertEquals("/openai/deployments/my-interceptor/chat/completions",
+                InterceptorController.rewriteDeploymentSegment(
+                        "/openai/deployments/initial-model/chat/completions", "my-interceptor"));
+    }
+
+    @Test
+    void leavesNonMatchingPathUnchanged() {
+        assertEquals("/some/other/path",
+                InterceptorController.rewriteDeploymentSegment("/some/other/path", "my-interceptor"));
+    }
+
+    @Test
+    void rewritesResponsesSegment() {
+        assertEquals("/openai/deployments/my-interceptor/v1/responses",
+                InterceptorController.rewriteDeploymentSegment(
+                        "/openai/deployments/initial-model/v1/responses", "my-interceptor"));
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponseItemControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponseItemControllerTest.java
@@ -1,5 +1,7 @@
 package com.epam.aidial.core.server.controller;
 
+import com.epam.aidial.core.config.DeploymentInterface;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
@@ -55,6 +57,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -148,7 +152,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "endpoint")).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
         when(upstreamRoute.next()).thenReturn(upstream);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
@@ -184,6 +188,56 @@ public class ResponseItemControllerTest {
     }
 
     @Test
+    public void testGetForwardsToUpstreamWithInterfaces(Vertx vertx, VertxTestContext testContext) throws Throwable {
+        ResponseMapping mapping = ResponseMapping.builder()
+                .upstreamResponseId("upstream-id-123")
+                .upstreamKey("endpoint")
+                .deploymentName("test-deployment")
+                .initiatorBucket("Users/test-user/")
+                .build();
+        Model deployment = new Model();
+        deployment.setName("test-deployment");
+        deployment.setInterfaces(Map.of(
+                InterfaceType.OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        HttpClient httpClient = mock(HttpClient.class, RETURNS_DEEP_STUBS);
+        HttpClientRequest proxyRequest = mock(HttpClientRequest.class, RETURNS_DEEP_STUBS);
+        HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
+        Buffer responseBody = Buffer.buffer("{\"id\":\"upstream-id-123\",\"status\":\"completed\"}");
+
+        when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
+        when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
+        when(upstreamRoute.next()).thenReturn(upstream);
+        when(proxy.getClient()).thenReturn(httpClient);
+        when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
+        when(httpClient.request(any(RequestOptions.class))).thenReturn(Future.succeededFuture(proxyRequest));
+        when(proxyRequest.send()).thenReturn(Future.succeededFuture(proxyResponse));
+        when(proxyResponse.statusCode()).thenReturn(200);
+        when(proxyResponse.body()).thenReturn(Future.succeededFuture(responseBody));
+        when(proxyResponse.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
+        when(context.getResponse()).thenReturn(response);
+        when(context.getRequest()).thenReturn(serverRequest);
+        when(context.getUserId()).thenReturn("test-user");
+        when(response.setStatusCode(200)).thenReturn(response);
+        when(response.putHeader(any(CharSequence.class), anyString())).thenReturn(response);
+        when(response.end(any(Buffer.class))).thenAnswer(invocation -> complete(testContext));
+        when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
+
+        controller("dial_test-deployment_123", GET).handle();
+
+        await(testContext);
+
+        ArgumentCaptor<RequestOptions> optsCaptor = ArgumentCaptor.forClass(RequestOptions.class);
+        verify(httpClient).request(optsCaptor.capture());
+        // new flow: base_url + /openai/v1/responses/{upstreamId}
+        assertEquals("/openai/v1/responses/upstream-id-123", optsCaptor.getValue().getURI());
+        assertEquals("adapter", optsCaptor.getValue().getHost());
+        assertEquals(HttpMethod.GET, optsCaptor.getValue().getMethod());
+    }
+
+    @Test
     public void testCancelForwardsToUpstream(Vertx vertx, VertxTestContext testContext) throws Throwable {
         ResponseMapping mapping = ResponseMapping.builder()
                 .upstreamResponseId("upstream-id-123")
@@ -203,7 +257,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "endpoint")).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
         when(upstreamRoute.next()).thenReturn(upstream);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
@@ -250,7 +304,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "endpoint")).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
         when(upstreamRoute.next()).thenReturn(upstream);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
@@ -293,7 +347,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "endpoint")).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
         when(upstreamRoute.next()).thenReturn(upstream);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
@@ -356,7 +410,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "missing-upstream-key"))
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("missing-upstream-key")))
                 .thenThrow(new HttpException(HttpStatus.BAD_REQUEST, "Unknown upstream id missing-upstream-key"));
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
         when(context.getUserId()).thenReturn("test-user");
@@ -394,7 +448,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "endpoint")).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
         when(upstreamRoute.next()).thenReturn(upstream);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
@@ -451,7 +505,7 @@ public class ResponseItemControllerTest {
 
         when(proxy.getResponseMappingService().getMapping(anyString())).thenReturn(mapping);
         when(proxy.getDeploymentService().findDeployment(context, "test-deployment")).thenReturn(deployment);
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, "endpoint")).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), eq("endpoint"))).thenReturn(upstreamRoute);
         when(upstreamRoute.next()).thenReturn(upstream);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
@@ -69,6 +69,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -432,7 +433,7 @@ public class ResponsesControllerTest {
         when(proxy.getTokenStatsTracker().updateModelStats(context))
                 .thenReturn(Future.succeededFuture());
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, (String) null)).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), isNull())).thenReturn(upstreamRoute);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
         when(httpClient.request(any())).thenReturn(Future.succeededFuture(proxyRequest));
@@ -545,7 +546,7 @@ public class ResponsesControllerTest {
         when(proxy.getRateLimiter().limit(context, deployment))
                 .thenReturn(Future.succeededFuture(RateLimitResult.SUCCESS));
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, (String) null)).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), isNull())).thenReturn(upstreamRoute);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
         when(httpClient.request(any())).thenReturn(Future.succeededFuture(proxyRequest));
@@ -656,7 +657,7 @@ public class ResponsesControllerTest {
         when(proxy.getRateLimiter().limit(context, deployment))
                 .thenReturn(Future.succeededFuture(RateLimitResult.SUCCESS));
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, (String) null)).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), isNull())).thenReturn(upstreamRoute);
         when(proxy.getClient()).thenReturn(httpClient);
         when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
         when(httpClient.request(any())).thenReturn(Future.succeededFuture(proxyRequest));
@@ -732,7 +733,7 @@ public class ResponsesControllerTest {
         when(proxy.getRateLimiter().limit(context, deployment))
                 .thenReturn(Future.succeededFuture(RateLimitResult.SUCCESS));
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
-        when(proxy.getUpstreamRouteProvider().get(deployment, null, (String) null)).thenReturn(upstreamRoute);
+        when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), isNull())).thenReturn(upstreamRoute);
         when(proxy.getApplicationSchemaService().modifyEndpointsForCustomApplication(deployment))
                 .thenReturn(deployment);
         when(proxy.getApiKeyStore()).thenReturn(apiKeyStore);


### PR DESCRIPTION
feat: add typed `interfaces` config alongside legacy `endpoint`/`responsesEndpoint` #1615

### Applicable issues

- feat #1615

### Description of changes

Add a typed `interfaces` map on deployments (keyed by interface type, each with a
`base_url`) as a **first-class peer** of the flat `endpoint` / `responsesEndpoint`
fields — not a replacement. Both shapes are fully supported, per deployment, per
interface type. **No migration**: no in-memory conversion, no on-disk rewrite, no
settings flag.

- **Config**: add `InterfaceType` (`openaiChatCompletions`, `openaiResponses`) and `DeploymentInterface` (`base_url`); add `Deployment.interfaces` + helpers (`getInterfaceBaseUrl` / `resolveEndpoint` / `supportsInterface`); preserve `interfaces` in the `Application` copy constructor.
- **Routing**: dual-mode per interface type — `base_url` + the exact ingress path (e.g. `POST /openai/v1/responses` → `<base_url>/openai/v1/responses`), else the legacy endpoint **verbatim** as today. `interfaces` wins when both are declared. Wired into chat/completions, responses POST, responses GET/CANCEL/DELETE, and interceptors (with `{deployment-id}` segment rewrite).
- **Scope**: only `openaiChatCompletions` + `openaiResponses` are routed. Models support both and ignore unknown forward-compatible keys; applications and interceptors accept only `openaiChatCompletions` (others dropped on config read with a warning).
- **Backward compatible**: a deployment with only `endpoint` / `responsesEndpoint` routes byte-for-byte as today — no client/adapter change required.
- **Docs/tests**: document `interfaces` in `docs/dynamic-settings/{models,applications,interceptors}.md` and `sample/aidial.config.json`; add config, controller, and config-validation tests.


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
