### PR TITLE
fix: correct MODEL/Schema bucket in entityId and canonical helpers

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/AdminApplyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/AdminApplyController.java
@@ -554,15 +554,13 @@ public class AdminApplyController {
         String segment = KIND_URL_SEGMENT.getOrDefault(entry.kind(), entry.kind().toLowerCase());
         String name = entry.name() != null ? entry.name()
                 : ("Settings".equals(entry.kind()) ? SETTINGS_SINGLETON_NAME : "");
-        String bucket = "Model".equals(entry.kind()) || "Application".equals(entry.kind())
-                || "ToolSet".equals(entry.kind()) || "Schema".equals(entry.kind())
+        String bucket = "Application".equals(entry.kind()) || "ToolSet".equals(entry.kind())
                 ? ResourceDescriptor.PUBLIC_BUCKET : ResourceDescriptor.PLATFORM_BUCKET;
         return segment + "/" + bucket + "/" + name;
     }
 
     private static String canonical(String segment, String name) {
-        String bucket = "models".equals(segment) || "applications".equals(segment)
-                || "toolsets".equals(segment) || "schemas".equals(segment)
+        String bucket = "applications".equals(segment) || "toolsets".equals(segment)
                 ? ResourceDescriptor.PUBLIC_BUCKET : ResourceDescriptor.PLATFORM_BUCKET;
         return segment + "/" + bucket + "/" + name;
     }


### PR DESCRIPTION
### Applicable issues

- follow-up to #1651

### Description of changes

Commit `b9057120` moved `MODEL` and `APP_TYPE_SCHEMA` from `PUBLIC_BUCKET` to `PLATFORM_BUCKET`, but two helper methods in `AdminApplyController` were not updated:

- **`entityId()`** — still included `"Model"` and `"Schema"` kinds in the `PUBLIC_BUCKET` condition, producing wrong bucket names in API response `entityId` fields and error messages.
- **`canonical()`** — still included `"models"` and `"schemas"` segments in the `PUBLIC_BUCKET` condition, causing `mutateScratch()` to store models and schemas under incorrect keys in the scratch `Config`, which broke cross-reference validation during multi-entity precheck batches.

The fix removes `Model`/`Schema` from the public-bucket conditions in both methods, leaving only `Application` and `ToolSet` there.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.