### PR TITLE
fix: re-register OAuth client when toolset endpoint URL changes

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -227,8 +228,9 @@ public class ResourceAuthSettingsService {
      *
      * <p>Client registration is required in the following cases:
      * <ul>
-     *     <li>If the authentication type is `OAUTH` and no SecuredResource exists</li>
+     *     <li>If the authentication type is {@code OAUTH} and no SecuredResource exists</li>
      *     <li>If the authentication type changes from non-OAUTH to OAUTH</li>
+     *     <li>If the endpoint URL changes while the authentication type remains OAUTH</li>
      * </ul>
      *
      * @param securedResource The new `SecuredResource` configuration being saved
@@ -236,10 +238,8 @@ public class ResourceAuthSettingsService {
      * @return true if client registration is required, false otherwise
      */
     private boolean requiresClientRegistration(SecuredResource securedResource, SecuredResource existing) {
-        ResourceAuthSettings newResourceAuthSettings = securedResource.getAuthSettings();
-
         // Do not register client for non-OAUTH auth types
-        if (!AuthenticationType.OAUTH.equals(newResourceAuthSettings.getAuthenticationType())) {
+        if (!AuthenticationType.OAUTH.equals(securedResource.getAuthSettings().getAuthenticationType())) {
             return false;
         }
 
@@ -248,10 +248,13 @@ public class ResourceAuthSettingsService {
             return true;
         }
 
-        ResourceAuthSettings existingResourceAuthSettings = existing.getAuthSettings();
+        // Auth type changed to OAUTH
+        if (!AuthenticationType.OAUTH.equals(existing.getAuthSettings().getAuthenticationType())) {
+            return true;
+        }
 
-        // Ensure client registration applies only if the auth type was changed to OAUTH
-        return !AuthenticationType.OAUTH.equals(existingResourceAuthSettings.getAuthenticationType());
+        // Endpoint changed — re-discover OAuth metadata for the new server
+        return !Objects.equals(securedResource.getEndpoint(), existing.getEndpoint());
     }
 
     /**

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
@@ -498,11 +498,67 @@ class ResourceAuthSettingsServiceTest {
         assertEquals(expectedNullCodeVerifier, updatedToolSet.getAuthSettings().getCodeVerifier() == null);
     }
 
+    @Test
+    void testProcessResourceAuthSettings_OauthEndpointChanged_DynamicReRegistration() {
+        // Given
+        String newEndpoint = "https://new-example.com";
+        ToolSet updatedToolSet = createOauthToolSetWithEndpoint(newEndpoint, null, null);
+        ToolSet existingToolSet = createOauthToolSet("oldClientId", "oldClientSecret");
+        ClientRegistration mockRegistration = createClientRegistration();
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+        when(resourceRegistrationService.register(eq(RESOURCE_NAME), eq(newEndpoint), any(), eq(true)))
+                .thenReturn(mockRegistration);
+
+        // When
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        // Then
+        verify(oauthAuthSettingsValidator, times(1)).validate(
+                any(ResourceAuthSettings.class), eq(ResourceAuthSettingsChangeMode.CREATE_DYNAMIC_CLIENT));
+        verify(resourceRegistrationService, times(1)).register(
+                eq(RESOURCE_NAME), eq(newEndpoint), any(ResourceAuthSettings.class), eq(true));
+    }
+
+    @Test
+    void testProcessResourceAuthSettings_OauthEndpointChanged_StaticReRegistration() {
+        // Given
+        String newEndpoint = "https://new-example.com";
+        ToolSet updatedToolSet = createOauthToolSetWithEndpoint(newEndpoint, "clientId", "clientSecret");
+        ToolSet existingToolSet = createOauthToolSet("clientId", "clientSecret");
+        ClientRegistration mockRegistration = createClientRegistration();
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+        when(resourceRegistrationService.register(eq(RESOURCE_NAME), eq(newEndpoint), any(), eq(false)))
+                .thenReturn(mockRegistration);
+
+        // When
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        // Then
+        verify(oauthAuthSettingsValidator, times(1)).validate(
+                any(ResourceAuthSettings.class), eq(ResourceAuthSettingsChangeMode.CREATE_STATIC_CLIENT));
+        verify(resourceRegistrationService, times(1)).register(
+                eq(RESOURCE_NAME), eq(newEndpoint), any(ResourceAuthSettings.class), eq(false));
+    }
+
     // Helper methods
 
     private static ToolSet createOauthToolSet(String clientId,
                                               String clientSecret) {
         return createOauthToolSet(clientId, clientSecret, null);
+    }
+
+    private static ToolSet createOauthToolSetWithEndpoint(String endpoint, String clientId, String clientSecret) {
+        ResourceAuthSettings authSettings = new ResourceAuthSettings();
+        authSettings.setAuthenticationType(AuthenticationType.OAUTH);
+        authSettings.setClientId(clientId);
+        authSettings.setClientSecret(clientSecret);
+        ToolSet toolSet = new ToolSet();
+        toolSet.setName(RESOURCE_NAME);
+        toolSet.setEndpoint(endpoint);
+        toolSet.setAuthSettings(authSettings);
+        return toolSet;
     }
 
     private ToolSet createOauthToolSet() {

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
@@ -549,18 +549,6 @@ class ResourceAuthSettingsServiceTest {
         return createOauthToolSet(clientId, clientSecret, null);
     }
 
-    private static ToolSet createOauthToolSetWithEndpoint(String endpoint, String clientId, String clientSecret) {
-        ResourceAuthSettings authSettings = new ResourceAuthSettings();
-        authSettings.setAuthenticationType(AuthenticationType.OAUTH);
-        authSettings.setClientId(clientId);
-        authSettings.setClientSecret(clientSecret);
-        ToolSet toolSet = new ToolSet();
-        toolSet.setName(RESOURCE_NAME);
-        toolSet.setEndpoint(endpoint);
-        toolSet.setAuthSettings(authSettings);
-        return toolSet;
-    }
-
     private ToolSet createOauthToolSet() {
         ResourceAuthSettings authSettings = new ResourceAuthSettings();
         ToolSet toolSet = Mockito.mock(ToolSet.class);
@@ -577,6 +565,18 @@ class ResourceAuthSettingsServiceTest {
         authSettings.setClientSecret(clientSecret);
         authSettings.setCodeVerifier(codeVerifier);
         return createToolSet(authSettings);
+    }
+
+    private static ToolSet createOauthToolSetWithEndpoint(String endpoint, String clientId, String clientSecret) {
+        ResourceAuthSettings authSettings = new ResourceAuthSettings();
+        authSettings.setAuthenticationType(AuthenticationType.OAUTH);
+        authSettings.setClientId(clientId);
+        authSettings.setClientSecret(clientSecret);
+        ToolSet toolSet = new ToolSet();
+        toolSet.setName(RESOURCE_NAME);
+        toolSet.setEndpoint(endpoint);
+        toolSet.setAuthSettings(authSettings);
+        return toolSet;
     }
 
     private static ToolSet createOauthToolSetWithTokenEndpointAuthMethod(String clientId,


### PR DESCRIPTION
## Summary

Fixes #1581.

When a toolset's `endpoint` URL was updated while the auth type stayed `OAUTH`, `requiresClientRegistration()` returned `false` — leaving stale `tokenEndpoint` and `authorizationEndpoint` in `ResourceAuthSettings`. Subsequent token requests hit the old auth server path and failed with authentication errors.

**Root cause:** `requiresClientRegistration()` only triggered re-discovery for two cases — new resource or auth type change to OAUTH. Endpoint URL change was not checked.

**Fix:** Added an endpoint equality check as a third trigger for OAuth re-registration, so `AuthorizationServerMetadataService` reruns discovery against the new server.

## Changes

- `ResourceAuthSettingsService.requiresClientRegistration()` — added `!Objects.equals(securedResource.getEndpoint(), existing.getEndpoint())` check
- `ResourceAuthSettingsServiceTest` — added two new tests covering endpoint-change with dynamic and static client registration

## Test plan

- [ ] `ResourceAuthSettingsServiceTest#testProcessResourceAuthSettings_OauthEndpointChanged_DynamicReRegistration` passes
- [ ] `ResourceAuthSettingsServiceTest#testProcessResourceAuthSettings_OauthEndpointChanged_StaticReRegistration` passes
- [ ] Existing `ResourceAuthSettingsServiceTest` cases unaffected
- [ ] Manual: update a toolset's endpoint URL → verify OAuth re-discovery runs and tokens are obtained from the new auth server

🤖 Generated with [Claude Code](https://claude.com/claude-code)