### PR TITLE
feat: support anthropic api (`v1/messages`, `v1/messages/count_tokens…

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/InterfaceType.java
+++ b/config/src/main/java/com/epam/aidial/core/config/InterfaceType.java
@@ -14,7 +14,9 @@ public enum InterfaceType {
     @JsonAlias({"openai_chat_completions"})
     OPENAI_CHAT_COMPLETIONS("openaiChatCompletions"),
     @JsonAlias({"openai_responses"})
-    OPENAI_RESPONSES("openaiResponses");
+    OPENAI_RESPONSES("openaiResponses"),
+    @JsonAlias({"anthropic_messages"})
+    ANTHROPIC_MESSAGES("anthropicMessages");
 
     @JsonValue
     private final String value;

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -76,6 +76,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 @Slf4j
 @Getter
@@ -93,6 +94,12 @@ public class Proxy implements Handler<HttpServerRequest> {
     // All new headers should start with X-DIAL- while existing may stay untouched
 
     public static final String HEADER_API_KEY = "API-KEY";
+    /**
+     * Authentication header of the <a href="https://platform.claude.com/docs/en/api/overview#authentication">Anthropic API</a>.
+     * Native Anthropic SDK clients pointed at {@code /anthropic/v1/messages} send the DIAL API key in this header
+     * and cannot set {@link #HEADER_API_KEY} or {@code Authorization}. It is accepted as the DIAL key only when
+     * neither of those headers is present (see {@link #extractApiKey}) and is stripped before forwarding upstream.
+     */
     public static final String HEADER_X_API_KEY = "x-api-key";
     public static final String HEADER_JOB_TITLE = "X-JOB-TITLE";
     public static final String HEADER_CONVERSATION_ID = "X-CONVERSATION-ID";
@@ -293,11 +300,8 @@ public class Proxy implements Handler<HttpServerRequest> {
      * @return the future of {@link AuthorizationResult}
      */
     private Future<AuthorizationResult> authorizeRequest(HttpServerRequest request) {
-        String apiKeyHeader = request.headers().get(HEADER_API_KEY);
+        String apiKey = extractApiKey(request);
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-        String apiKey = apiKeyHeader == null && authorization == null
-                ? request.headers().get(HEADER_X_API_KEY)
-                : apiKeyHeader;
         log.debug("Authorization header: {}", authorization);
 
         String clientIpAddress = ProxyUtil.getClientIpAddress(request, apiKeyValidation.getProxyCount());
@@ -358,6 +362,23 @@ public class Proxy implements Handler<HttpServerRequest> {
                     }
                 });
 
+    }
+
+    /**
+     * Extracts the DIAL API key from the request. The key is taken from the {@link #HEADER_API_KEY} header;
+     * when neither it nor {@code Authorization} is present, falls back to {@link #HEADER_X_API_KEY} — the header
+     * native Anthropic SDK clients send their credentials in — so existing authentication flows are unaffected.
+     *
+     * @param request HTTP request
+     * @return the API key or {@code null} if the request carries none
+     */
+    @Nullable
+    private static String extractApiKey(HttpServerRequest request) {
+        String apiKey = request.headers().get(HEADER_API_KEY);
+        if (apiKey == null && request.getHeader(HttpHeaders.AUTHORIZATION) == null) {
+            return request.headers().get(HEADER_X_API_KEY);
+        }
+        return apiKey;
     }
 
     private static void enableCors(HttpServerRequest request) {

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -93,6 +93,7 @@ public class Proxy implements Handler<HttpServerRequest> {
     // All new headers should start with X-DIAL- while existing may stay untouched
 
     public static final String HEADER_API_KEY = "API-KEY";
+    public static final String HEADER_X_API_KEY = "x-api-key";
     public static final String HEADER_JOB_TITLE = "X-JOB-TITLE";
     public static final String HEADER_CONVERSATION_ID = "X-CONVERSATION-ID";
     public static final String HEADER_UPSTREAM_ID = "X-UPSTREAM-ID";
@@ -292,8 +293,11 @@ public class Proxy implements Handler<HttpServerRequest> {
      * @return the future of {@link AuthorizationResult}
      */
     private Future<AuthorizationResult> authorizeRequest(HttpServerRequest request) {
-        String apiKey = request.headers().get(HEADER_API_KEY);
+        String apiKeyHeader = request.headers().get(HEADER_API_KEY);
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String apiKey = apiKeyHeader == null && authorization == null
+                ? request.headers().get(HEADER_X_API_KEY)
+                : apiKeyHeader;
         log.debug("Authorization header: {}", authorization);
 
         String clientIpAddress = ProxyUtil.getClientIpAddress(request, apiKeyValidation.getProxyCount());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -132,6 +132,31 @@ public class BaseDeploymentPostController {
         log.warn("Failed to receive client body. Error: {}", error.getMessage());
     }
 
+    /**
+     * Called when proxy failed to send response to the client.
+     */
+    protected void handleResponseError(Throwable error, BufferingReadStream responseStream) {
+        context.getResponse().reset();     // drop connection, so that partial client response won't seem complete
+        log.warn("Can't send response to client. Error:", error);
+        Deployment deployment = context.getDeployment();
+        if (deployment instanceof Model) {
+            // make sure we collect token usage in case if client accidentally closed the connection
+            responseStream.endStreamFuture()
+                    .onFailure(ignore -> context.getProxyRequest().reset()) // drop connection to stop origin response
+                    .compose(ignore -> {
+                        Buffer responseBody = responseStream.getContent();
+                        context.setResponseBody(responseBody);
+                        context.setResponseBodyTimestamp(System.currentTimeMillis());
+                        return collectTokenUsage(responseBody);
+                    })
+                    .onSuccess(ignored -> proxy.getLogStore().save(context))
+                    .onComplete(ignored -> finalizeRequest());
+        } else {
+            // drop connection to stop application responding
+            context.getProxyRequest().reset();
+        }
+    }
+
     protected Future<TokenUsage> collectTokenUsage(Buffer responseBody) {
         Future<TokenUsage> tokenUsageFuture = Future.succeededFuture();
         if (context.getDeployment() instanceof Model model) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -136,7 +136,7 @@ public class BaseDeploymentPostController {
         Future<TokenUsage> tokenUsageFuture = Future.succeededFuture();
         if (context.getDeployment() instanceof Model model) {
             if (context.getResponse().getStatusCode() == HttpStatus.OK.getCode()) {
-                TokenUsage tokenUsage = TokenUsageParser.parse(responseBody);
+                TokenUsage tokenUsage = parseTokenUsage(responseBody);
                 if (tokenUsage == null) {
                     Pricing pricing = model.getPricing();
                     if (pricing == null || "token".equals(pricing.getUnit())) {
@@ -163,6 +163,14 @@ public class BaseDeploymentPostController {
             tokenUsageFuture = proxy.getTokenStatsTracker().getTokenStats(context).andThen(result -> context.setTokenUsage(result.result()));
         }
         return tokenUsageFuture;
+    }
+
+    /**
+     * Parses token usage from the fully buffered response body. Overridable so provider-specific
+     * controllers can supply their own accounting (e.g. the Anthropic Messages API).
+     */
+    protected TokenUsage parseTokenUsage(Buffer responseBody) {
+        return TokenUsageParser.parse(responseBody);
     }
 
     /**

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
@@ -5,6 +5,8 @@ import com.epam.aidial.core.config.Features;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.config.MergedConfigStore;
+import com.epam.aidial.core.server.controller.anthropic.MessagesController;
+import com.epam.aidial.core.server.controller.anthropic.MessagesCountTokensController;
 import com.epam.aidial.core.server.controller.route.ApplicationRouteController;
 import com.epam.aidial.core.server.controller.route.GlobalRouteController;
 import com.epam.aidial.core.server.data.RouteTemplate;
@@ -231,6 +233,16 @@ public class ControllerSelector {
         });
         post(RouteTemplate.LLM_RESPONSES_API, (proxy, context, pathMatcher) -> {
             ResponsesController controller = new ResponsesController(proxy, context);
+            return controller::handle;
+        });
+        // count_tokens first: matching is first-registered-wins, so the more specific path must not
+        // be swallowed if a greedy /messages/(?<id>...) route is ever added.
+        post(RouteTemplate.LLM_MESSAGES_API_COUNT_TOKENS, (proxy, context, pathMatcher) -> {
+            MessagesCountTokensController controller = new MessagesCountTokensController(proxy, context);
+            return controller::handle;
+        });
+        post(RouteTemplate.LLM_MESSAGES_API, (proxy, context, pathMatcher) -> {
+            MessagesController controller = new MessagesController(proxy, context);
             return controller::handle;
         });
         post(RouteTemplate.LLM_RESPONSES_API_CANCEL, (proxy, context, pathMatcher) -> {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -370,33 +370,6 @@ public class DeploymentPostController extends BaseDeploymentPostController {
         sendRequest(); // try next
     }
 
-    /**
-     * Called when proxy failed to send response to the client.
-     */
-    private void handleResponseError(Throwable error, BufferingReadStream responseStream) {
-        context.getResponse().reset();     // drop connection, so that partial client response won't seem complete
-        log.warn("Can't send response to client. Error:", error);
-        Deployment deployment = context.getDeployment();
-        if (deployment instanceof Model) {
-            // make sure we collect token usage in case if client accidentally closed the connection
-            responseStream.endStreamFuture()
-                    .onFailure(ignore -> {
-                        context.getProxyRequest().reset(); // drop connection to stop origin response
-                    })
-                    .compose(ignore -> {
-                        Buffer responseBody = responseStream.getContent();
-                        context.setResponseBody(responseBody);
-                        context.setResponseBodyTimestamp(System.currentTimeMillis());
-                        return collectTokenUsage(responseBody);
-                    })
-                    .onSuccess(ignored -> proxy.getLogStore().save(context))
-                    .onComplete(ignored -> finalizeRequest());
-        } else {
-            // drop connection to stop application responding
-            context.getProxyRequest().reset();
-        }
-    }
-
     public static class ChatCompletionSseListener extends BufferingReadStream.BaseEventListener {
 
         public static final String CHAT_COMPLETION_FINAL_MESSAGE = "[DONE]";

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -4,7 +4,6 @@ import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.Features;
 import com.epam.aidial.core.config.InterfaceType;
-import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -21,7 +20,6 @@ import com.epam.aidial.core.server.function.enhancement.EnhanceModelRequestFn;
 import com.epam.aidial.core.server.function.request.RequestObject;
 import com.epam.aidial.core.server.function.request.ResponsesApiRequest;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
-import com.epam.aidial.core.server.token.TokenUsage;
 import com.epam.aidial.core.server.upstream.UpstreamRoute;
 import com.epam.aidial.core.server.util.BucketBuilder;
 import com.epam.aidial.core.server.util.JsonUtil;
@@ -261,26 +259,24 @@ public class ResponsesController extends BaseDeploymentPostController {
                     context.setResponseBody(rewritten);
                     context.setResponseBodyTimestamp(System.currentTimeMillis());
                     HttpServerResponse response = context.getResponse();
-                    ProxyUtil.handleChunkedResponse(response, proxyResponse);
-                    response.setChunked(false);
+                    ProxyUtil.copyResponse(response, proxyResponse);
                     response.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(rewritten.length()));
                     response.putHeader(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(context.getUpstreamRoute().getAttemptCount()));
-                    return response.end(rewritten);
-                })
-                .compose(ignore -> collectTokenUsage(context.getResponseBody()))
-                .transform(result -> {
-                    if (result.failed()) {
-                        log.warn("Failed to collect token usage", result.cause());
-                    }
-                    return collectResponseAttachments(context.getResponseBody(), new CollectResponsesApiOutputAttachmentsFn(proxy, context));
-                })
-                .onComplete(future -> {
-                    if (future.failed()) {
-                        log.warn("Failed to collect attachments from response", future.cause());
-                    }
-                    completeProxyResponse();
-                })
-                .mapEmpty();
+                    return collectTokenUsage(rewritten)
+                            .transform(result -> {
+                                if (result.failed()) {
+                                    log.warn("Failed to collect token usage", result.cause());
+                                }
+                                return collectResponseAttachments(rewritten, new CollectResponsesApiOutputAttachmentsFn(proxy, context));
+                            })
+                            .transform(result -> {
+                                if (result.failed()) {
+                                    log.warn("Failed to collect attachments from response", result.cause());
+                                }
+                                completeProxyResponse(() -> response.end(rewritten));
+                                return Future.<Void>succeededFuture();
+                            });
+                });
     }
 
     private Future<Buffer> rewriteResponseId(HttpClientResponse proxyResponse, Buffer body) {
@@ -319,19 +315,16 @@ public class ResponsesController extends BaseDeploymentPostController {
         Buffer responseBody = responseStream.getContent();
         context.setResponseBody(responseBody);
         context.setResponseBodyTimestamp(System.currentTimeMillis());
-        Future<TokenUsage> tokenUsageFuture = collectTokenUsage(responseBody);
-
-        tokenUsageFuture.onComplete(result -> {
+        collectTokenUsage(responseBody).onComplete(result -> {
             if (result.failed()) {
-                log.warn("Failed to collect attachments from response", result.cause());
+                log.warn("Failed to collect token usage", result.cause());
             }
-            HttpServerResponse response = context.getResponse();
-            responseStream.end(response);
-            completeProxyResponse();
+            completeProxyResponse(() -> responseStream.end(context.getResponse()));
         });
     }
 
-    private void completeProxyResponse() {
+    private void completeProxyResponse(Runnable endResponse) {
+        endResponse.run();
         proxy.getLogStore().save(context);
         Upstream currentUpstream = context.getUpstreamRoute().get();
         log.info("Sent response to client. Deployment: {}. Endpoint: {}. Upstream: {}. Length: {}."
@@ -361,30 +354,6 @@ public class ResponsesController extends BaseDeploymentPostController {
                 error);
 
         sendRequest(); // try next
-    }
-
-    private void handleResponseError(Throwable error, BufferingReadStream responseStream) {
-        context.getResponse().reset();     // drop connection, so that partial client response won't seem complete
-        log.warn("Can't send response to client. Error:", error);
-        Deployment deployment = context.getDeployment();
-        if (deployment instanceof Model) {
-            // make sure we collect token usage in case if client accidentally closed the connection
-            responseStream.endStreamFuture()
-                    .onFailure(ignore -> {
-                        context.getProxyRequest().reset(); // drop connection to stop origin response
-                    })
-                    .compose(ignore -> {
-                        Buffer responseBody = responseStream.getContent();
-                        context.setResponseBody(responseBody);
-                        context.setResponseBodyTimestamp(System.currentTimeMillis());
-                        return collectTokenUsage(responseBody);
-                    })
-                    .onSuccess(ignored -> proxy.getLogStore().save(context))
-                    .onComplete(ignored -> finalizeRequest());
-        } else {
-            // drop connection to stop application responding
-            context.getProxyRequest().reset();
-        }
     }
 
     private static Future<String> rewriteId(Proxy proxy, ProxyContext context, ResponseMapping mapping) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -1,0 +1,201 @@
+package com.epam.aidial.core.server.controller.anthropic;
+
+import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.Features;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.controller.BaseDeploymentPostController;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.function.BaseRequestFunction;
+import com.epam.aidial.core.server.function.CollectDeploymentsFn;
+import com.epam.aidial.core.server.function.CollectRequestApplicationFilesFn;
+import com.epam.aidial.core.server.function.CollectRequestChatCompletionAttachmentsFn;
+import com.epam.aidial.core.server.function.enhancement.ApplyDefaultDeploymentSettingsFn;
+import com.epam.aidial.core.server.function.enhancement.EnhanceModelRequestFn;
+import com.epam.aidial.core.server.function.request.MessagesApiRequest;
+import com.epam.aidial.core.server.function.request.RequestObject;
+import com.epam.aidial.core.server.service.PermissionDeniedException;
+import com.epam.aidial.core.server.upstream.UpstreamRoute;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Shared plumbing for the Anthropic Messages API controllers ({@link MessagesController} and
+ * {@link MessagesCountTokensController}): body parsing, deployment resolution + the
+ * {@code anthropicMessages} 503 gate, the enhancement chain, upstream-route preparation, and the
+ * send/retry loop. Subclasses only implement {@link #processResponse(HttpClientResponse)}.
+ */
+@Slf4j
+abstract class MessagesBaseController extends BaseDeploymentPostController {
+
+    protected final List<BaseRequestFunction<RequestObject>> enhancementFunctions;
+
+    protected MessagesBaseController(Proxy proxy, ProxyContext context) {
+        super(proxy, context);
+        this.enhancementFunctions = List.of(
+                new CollectRequestChatCompletionAttachmentsFn(proxy, context),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context),
+                new EnhanceModelRequestFn(proxy, context),
+                new CollectRequestApplicationFilesFn(proxy, context),
+                new CollectDeploymentsFn(proxy, context));
+    }
+
+    protected static MessagesApiRequest parseBody(Buffer body) {
+        log.info("Received body from client. Length: {}", body.length());
+        try {
+            ObjectNode tree = ProxyUtil.parseObject(body);
+            return new MessagesApiRequest(tree);
+        } catch (IOException e) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    protected Void setupDeployment(String model) {
+        Deployment deployment = proxy.getDeploymentService().findDeployment(context, model);
+        proxy.getConsentService().verifyUserConsent(context, deployment);
+
+        Features features = deployment.getFeatures();
+        boolean isPerRequestKey = context.getApiKeyData().getPerRequestKey() != null;
+        if (features != null && Boolean.FALSE.equals(features.getAccessibleByPerRequestKey()) && isPerRequestKey) {
+            throw new PermissionDeniedException(String.format("Deployment %s is not accessible by %s", model, context.getApiKeyData().getSourceDeployment()));
+        }
+
+        if (deployment instanceof Application application) {
+            deployment = proxy.getApplicationSchemaService().modifyEndpointsForCustomApplication(application);
+        }
+
+        if (!deployment.supportsInterface(InterfaceType.ANTHROPIC_MESSAGES)) {
+            throw new HttpException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "Anthropic messages not supported for this deployment type"
+            );
+        }
+
+        context.setTraceOperation("Send request to %s deployment".formatted(deployment.getName()));
+        context.setDeployment(deployment);
+
+        return null;
+    }
+
+    /**
+     * Runs the enhancement chain, assigns a per-request key, serializes the (possibly model-overridden)
+     * body and resolves the upstream route via the {@code anthropicMessages} base_url.
+     */
+    @SneakyThrows
+    protected void prepareUpstreamRoute(RequestObject request) {
+        ApiKeyData proxyApiKeyData = new ApiKeyData();
+        context.setProxyApiKeyData(proxyApiKeyData);
+        ApiKeyData.initFromContext(proxyApiKeyData, context);
+
+        ProxyUtil.processChain(request, enhancementFunctions);
+        // Enhancement functions update the api key, and it should be saved after that
+        proxy.getApiKeyStore().assignPerRequestApiKey(proxyApiKeyData);
+
+        context.setRequestBody(Buffer.buffer(request.serialize()));
+
+        Deployment deployment = context.getDeployment();
+        String upstreamId = context.getRequest().headers().get(Proxy.HEADER_UPSTREAM_ID);
+        UpstreamRoute upstreamRoute = proxy.getUpstreamRouteProvider()
+                .get(deployment, context.getCacheBreakpointContext(),
+                        dep -> dep.resolveEndpoint(InterfaceType.ANTHROPIC_MESSAGES), upstreamId);
+
+        context.setRequestBodyTimestamp(System.currentTimeMillis());
+        context.setUpstreamRoute(upstreamRoute);
+    }
+
+    protected void sendRequest() {
+        if (nextUpstream()) {
+            Upstream upstream = context.getUpstreamRoute().get();
+            if (upstream.getId() == null || upstream.getId().isBlank()) {
+                respond(HttpStatus.SERVICE_UNAVAILABLE, "Upstream is missing required id");
+                return;
+            }
+            createProxyRequest(InterfaceType.ANTHROPIC_MESSAGES)
+                    .onSuccess(this::handleProxyRequest)
+                    .onFailure(this::handleProxyConnectionError);
+        }
+    }
+
+    private void handleProxyRequest(HttpClientRequest proxyRequest) {
+        context.setProxyRequest(proxyRequest);
+        context.setProxyConnectTimestamp(System.currentTimeMillis());
+
+        // TODO: no per-upstream endpoint for the Messages API yet. A single endpoint can't cover
+        //  /v1/messages, /v1/messages/count_tokens and /v1/messages/batches, and the only adapter
+        //  serving this interface (bedrock) routes by interfaces.base_url + ingress path on its own.
+        //  Investigate a proper way to provide Messages API URLs to adapters before adding one.
+        sendProxyRequest(proxyRequest, upstream -> null)
+                .onSuccess(this::handleProxyResponse)
+                .onFailure(this::handleProxyResponseError);
+    }
+
+    private void handleProxyResponse(HttpClientResponse proxyResponse) {
+        UpstreamRoute upstreamRoute = context.getUpstreamRoute();
+        int responseStatusCode = proxyResponse.statusCode();
+        if (isRetriableError(responseStatusCode)) {
+            upstreamRoute.fail(proxyResponse);
+            sendRequest(); // try next
+            return;
+        }
+
+        if (responseStatusCode == 200) {
+            upstreamRoute.succeed(proxyResponse, context.getDeployment());
+        } else if (!HttpStatus.fromStatusCode(responseStatusCode).is4xx()) {
+            // mark the upstream as failed, so the next time we select another one
+            upstreamRoute.fail(proxyResponse);
+        }
+
+        context.setProxyResponse(proxyResponse);
+        context.setProxyResponseTimestamp(System.currentTimeMillis());
+
+        processResponse(proxyResponse);
+    }
+
+    private void handleProxyResponseError(Throwable error) {
+        // for 5xx errors we use exponential backoff strategy, so passing retryAfterSeconds parameter makes no sense
+        context.getUpstreamRoute().fail(HttpStatus.BAD_GATEWAY);
+        log.warn("Proxy failed to receive response header from origin. Deployment: {}. Address: {}. Error:",
+                context.getDeployment().getName(),
+                context.getProxyRequest().connection().remoteAddress(),
+                error);
+
+        sendRequest(); // try next
+    }
+
+    /**
+     * Route-specific response handling, invoked after the shared retry/succeed/fail bookkeeping.
+     */
+    protected abstract void processResponse(HttpClientResponse proxyResponse);
+
+    protected Void handleRequestError(String deploymentId, Throwable error) {
+        if (error instanceof PermissionDeniedException) {
+            respond(HttpStatus.FORBIDDEN, error.getMessage());
+            log.warn("Forbidden deployment {}", deploymentId);
+        } else if (error instanceof ResourceNotFoundException) {
+            respond(HttpStatus.NOT_FOUND, error.getMessage());
+            log.warn("Deployment not found {}", deploymentId, error);
+        } else if (error instanceof HttpException httpException) {
+            respond(httpException);
+            log.warn("Deployment error {}", deploymentId, error);
+        } else {
+            respond(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to process deployment: " + deploymentId);
+            log.error("Failed to handle deployment {}", deploymentId, error);
+        }
+
+        return null;
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -24,20 +24,24 @@ import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Strings;
 
 import java.io.IOException;
 import java.util.List;
 
 /**
  * Shared plumbing for the Anthropic Messages API controllers ({@link MessagesController} and
- * {@link MessagesCountTokensController}): body parsing, deployment resolution + the
- * {@code anthropicMessages} 503 gate, the enhancement chain, upstream-route preparation, and the
- * send/retry loop. Subclasses only implement {@link #processResponse(HttpClientResponse)}.
+ * {@link MessagesCountTokensController}): the whole {@link #handle()} flow — body parsing,
+ * deployment resolution + the {@code anthropicMessages} 503 gate, the enhancement chain,
+ * upstream-route preparation and the send/retry loop. Subclasses implement
+ * {@link #processResponse(HttpClientResponse)} and may override {@link #verifyLimit()}.
  */
 @Slf4j
 abstract class MessagesBaseController extends BaseDeploymentPostController {
@@ -52,6 +56,43 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
                 new EnhanceModelRequestFn(proxy, context),
                 new CollectRequestApplicationFilesFn(proxy, context),
                 new CollectDeploymentsFn(proxy, context));
+    }
+
+    public Future<?> handle() {
+        String contentType = context.getRequest().getHeader(HttpHeaders.CONTENT_TYPE);
+        if (!Strings.CI.contains(contentType, Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON)) {
+            return respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Only application/json is supported");
+        }
+        context.getRequest().body()
+                .map(MessagesBaseController::parseBody)
+                .compose(request -> {
+                    String model = request.getModel();
+                    return proxy.getTaskExecutor().submit(() -> setupDeployment(model))
+                            .compose(ignore -> verifyLimit())
+                            .compose(ignore -> proxy.getTokenStatsTracker().startSpan(context)
+                                    .map(ignored -> handleRequestBody(request)))
+                            .otherwise(error -> handleRequestError(model, error));
+                })
+                .onFailure(this::handleRequestBodyError);
+
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Rate-limit gate before the upstream call. No-op by default: count_tokens does not generate,
+     * so it charges no limits.
+     */
+    protected Future<Void> verifyLimit() {
+        return Future.succeededFuture();
+    }
+
+    @SneakyThrows
+    private Void handleRequestBody(RequestObject request) {
+        context.setStreamingRequest(request.isStreaming());
+        prepareUpstreamRoute(request);
+        sendRequest();
+
+        return null;
     }
 
     protected static MessagesApiRequest parseBody(Buffer body) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesController.java
@@ -1,27 +1,21 @@
 package com.epam.aidial.core.server.controller.anthropic;
 
-import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.InterfaceType;
-import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.controller.ResponsesController;
 import com.epam.aidial.core.server.function.CollectMessagesTokenUsageFn;
-import com.epam.aidial.core.server.function.request.RequestObject;
 import com.epam.aidial.core.server.token.MessagesTokenUsageParser;
 import com.epam.aidial.core.server.token.TokenUsage;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
-import com.epam.aidial.core.storage.http.HttpStatus;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.Strings;
 
 import java.util.List;
 
@@ -37,41 +31,13 @@ public class MessagesController extends MessagesBaseController {
         super(proxy, context);
     }
 
-    public Future<?> handle() {
-        String contentType = context.getRequest().getHeader(HttpHeaders.CONTENT_TYPE);
-        if (!Strings.CI.contains(contentType, Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON)) {
-            return respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Only application/json is supported");
-        }
-        context.getRequest().body()
-                .map(MessagesBaseController::parseBody)
-                .compose(request -> {
-                    String model = request.getModel();
-                    return proxy.getTaskExecutor().submit(() -> setupDeployment(model))
-                            .compose(ignore -> verifyLimit())
-                            .compose(ignore -> proxy.getTokenStatsTracker().startSpan(context)
-                                    .map(ignored -> handleRequestBody(request)))
-                            .otherwise(error -> handleRequestError(model, error));
-                })
-                .onFailure(this::handleRequestBodyError);
-
-        return Future.succeededFuture();
-    }
-
-    private Future<Void> verifyLimit() {
+    @Override
+    protected Future<Void> verifyLimit() {
         return proxy.getRateLimiter().limit(context, context.getDeployment())
                 .map(rateLimit -> {
                     rateLimit.throwIfError();
                     return null;
                 });
-    }
-
-    @SneakyThrows
-    private Void handleRequestBody(RequestObject request) {
-        context.setStreamingRequest(request.isStreaming());
-        prepareUpstreamRoute(request);
-        sendRequest();
-
-        return null;
     }
 
     @Override
@@ -102,17 +68,15 @@ public class MessagesController extends MessagesBaseController {
         context.setResponseBody(body);
         context.setResponseBodyTimestamp(System.currentTimeMillis());
         HttpServerResponse response = context.getResponse();
-        ProxyUtil.handleChunkedResponse(response, proxyResponse);
-        response.setChunked(false);
+        ProxyUtil.copyResponse(response, proxyResponse);
         response.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
         response.putHeader(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(context.getUpstreamRoute().getAttemptCount()));
-        return response.end(body)
-                .compose(ignore -> collectTokenUsage(context.getResponseBody()))
+        return collectTokenUsage(body)
                 .transform(result -> {
                     if (result.failed()) {
                         log.warn("Failed to collect token usage", result.cause());
                     }
-                    completeProxyResponse();
+                    completeProxyResponse(() -> response.end(body));
                     return Future.<Void>succeededFuture();
                 });
     }
@@ -125,13 +89,12 @@ public class MessagesController extends MessagesBaseController {
             if (result.failed()) {
                 log.warn("Failed to collect token usage", result.cause());
             }
-            HttpServerResponse response = context.getResponse();
-            responseStream.end(response);
-            completeProxyResponse();
+            completeProxyResponse(() -> responseStream.end(context.getResponse()));
         });
     }
 
-    private void completeProxyResponse() {
+    private void completeProxyResponse(Runnable endResponse) {
+        endResponse.run();
         proxy.getLogStore().save(context);
         Upstream currentUpstream = context.getUpstreamRoute().get();
         log.info("Sent response to client. Deployment: {}. Interface: {}. Upstream: {}. Length: {}. Tokens: {}.",
@@ -142,28 +105,6 @@ public class MessagesController extends MessagesBaseController {
                 context.getTokenUsage() == null ? "N/A" : context.getTokenUsage());
 
         finalizeRequest();
-    }
-
-    private void handleResponseError(Throwable error, BufferingReadStream responseStream) {
-        context.getResponse().reset();     // drop connection, so that partial client response won't seem complete
-        log.warn("Can't send response to client. Error:", error);
-        Deployment deployment = context.getDeployment();
-        if (deployment instanceof Model) {
-            // make sure we collect token usage in case if client accidentally closed the connection
-            responseStream.endStreamFuture()
-                    .onFailure(ignore -> context.getProxyRequest().reset()) // drop connection to stop origin response
-                    .compose(ignore -> {
-                        Buffer responseBody = responseStream.getContent();
-                        context.setResponseBody(responseBody);
-                        context.setResponseBodyTimestamp(System.currentTimeMillis());
-                        return collectTokenUsage(responseBody);
-                    })
-                    .onSuccess(ignored -> proxy.getLogStore().save(context))
-                    .onComplete(ignored -> finalizeRequest());
-        } else {
-            // drop connection to stop application responding
-            context.getProxyRequest().reset();
-        }
     }
 
     @Override

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesController.java
@@ -1,0 +1,177 @@
+package com.epam.aidial.core.server.controller.anthropic;
+
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Model;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.controller.ResponsesController;
+import com.epam.aidial.core.server.function.CollectMessagesTokenUsageFn;
+import com.epam.aidial.core.server.function.request.RequestObject;
+import com.epam.aidial.core.server.token.MessagesTokenUsageParser;
+import com.epam.aidial.core.server.token.TokenUsage;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Strings;
+
+import java.util.List;
+
+/**
+ * Anthropic Messages API pass-through controller. Mirrors {@link ResponsesController} but forwards
+ * the body verbatim (no server-side store, no response-id rewrite) and accounts token usage with
+ * Anthropic semantics (see {@link MessagesTokenUsageParser} / {@link CollectMessagesTokenUsageFn}).
+ */
+@Slf4j
+public class MessagesController extends MessagesBaseController {
+
+    public MessagesController(Proxy proxy, ProxyContext context) {
+        super(proxy, context);
+    }
+
+    public Future<?> handle() {
+        String contentType = context.getRequest().getHeader(HttpHeaders.CONTENT_TYPE);
+        if (!Strings.CI.contains(contentType, Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON)) {
+            return respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Only application/json is supported");
+        }
+        context.getRequest().body()
+                .map(MessagesBaseController::parseBody)
+                .compose(request -> {
+                    String model = request.getModel();
+                    return proxy.getTaskExecutor().submit(() -> setupDeployment(model))
+                            .compose(ignore -> verifyLimit())
+                            .compose(ignore -> proxy.getTokenStatsTracker().startSpan(context)
+                                    .map(ignored -> handleRequestBody(request)))
+                            .otherwise(error -> handleRequestError(model, error));
+                })
+                .onFailure(this::handleRequestBodyError);
+
+        return Future.succeededFuture();
+    }
+
+    private Future<Void> verifyLimit() {
+        return proxy.getRateLimiter().limit(context, context.getDeployment())
+                .map(rateLimit -> {
+                    rateLimit.throwIfError();
+                    return null;
+                });
+    }
+
+    @SneakyThrows
+    private Void handleRequestBody(RequestObject request) {
+        context.setStreamingRequest(request.isStreaming());
+        prepareUpstreamRoute(request);
+        sendRequest();
+
+        return null;
+    }
+
+    @Override
+    protected void processResponse(HttpClientResponse proxyResponse) {
+        if (!context.isStreamingRequest()) {
+            proxyResponse.body()
+                    .compose(body -> handleNonStreamingResponse(proxyResponse, body))
+                    .onFailure(this::handleProxyConnectionError);
+            return;
+        }
+
+        BufferingReadStream responseStream = createResponseStream(proxyResponse,
+                () -> new MessagesSseListener(List.of(new CollectMessagesTokenUsageFn(proxy, context))));
+
+        HttpServerResponse response = context.getResponse();
+        ProxyUtil.handleChunkedResponse(response, proxyResponse);
+        response.putHeader(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(context.getUpstreamRoute().getAttemptCount()));
+
+        responseStream.pipe()
+                .endOnFailure(false)
+                .endOnSuccess(false)
+                .to(response)
+                .onSuccess(ignored -> handleResponse(responseStream))
+                .onFailure(error -> handleResponseError(error, responseStream));
+    }
+
+    private Future<Void> handleNonStreamingResponse(HttpClientResponse proxyResponse, Buffer body) {
+        context.setResponseBody(body);
+        context.setResponseBodyTimestamp(System.currentTimeMillis());
+        HttpServerResponse response = context.getResponse();
+        ProxyUtil.handleChunkedResponse(response, proxyResponse);
+        response.setChunked(false);
+        response.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
+        response.putHeader(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(context.getUpstreamRoute().getAttemptCount()));
+        return response.end(body)
+                .compose(ignore -> collectTokenUsage(context.getResponseBody()))
+                .transform(result -> {
+                    if (result.failed()) {
+                        log.warn("Failed to collect token usage", result.cause());
+                    }
+                    completeProxyResponse();
+                    return Future.<Void>succeededFuture();
+                });
+    }
+
+    private void handleResponse(BufferingReadStream responseStream) {
+        Buffer responseBody = responseStream.getContent();
+        context.setResponseBody(responseBody);
+        context.setResponseBodyTimestamp(System.currentTimeMillis());
+        collectTokenUsage(responseBody).onComplete(result -> {
+            if (result.failed()) {
+                log.warn("Failed to collect token usage", result.cause());
+            }
+            HttpServerResponse response = context.getResponse();
+            responseStream.end(response);
+            completeProxyResponse();
+        });
+    }
+
+    private void completeProxyResponse() {
+        proxy.getLogStore().save(context);
+        Upstream currentUpstream = context.getUpstreamRoute().get();
+        log.info("Sent response to client. Deployment: {}. Interface: {}. Upstream: {}. Length: {}. Tokens: {}.",
+                context.getDeployment().getName(),
+                InterfaceType.ANTHROPIC_MESSAGES.getValue(),
+                currentUpstream == null ? "N/A" : currentUpstream.getEndpoint(),
+                context.getResponseBody() == null ? 0 : context.getResponseBody().length(),
+                context.getTokenUsage() == null ? "N/A" : context.getTokenUsage());
+
+        finalizeRequest();
+    }
+
+    private void handleResponseError(Throwable error, BufferingReadStream responseStream) {
+        context.getResponse().reset();     // drop connection, so that partial client response won't seem complete
+        log.warn("Can't send response to client. Error:", error);
+        Deployment deployment = context.getDeployment();
+        if (deployment instanceof Model) {
+            // make sure we collect token usage in case if client accidentally closed the connection
+            responseStream.endStreamFuture()
+                    .onFailure(ignore -> context.getProxyRequest().reset()) // drop connection to stop origin response
+                    .compose(ignore -> {
+                        Buffer responseBody = responseStream.getContent();
+                        context.setResponseBody(responseBody);
+                        context.setResponseBodyTimestamp(System.currentTimeMillis());
+                        return collectTokenUsage(responseBody);
+                    })
+                    .onSuccess(ignored -> proxy.getLogStore().save(context))
+                    .onComplete(ignored -> finalizeRequest());
+        } else {
+            // drop connection to stop application responding
+            context.getProxyRequest().reset();
+        }
+    }
+
+    @Override
+    protected TokenUsage parseTokenUsage(Buffer responseBody) {
+        if (context.isStreamingRequest()) {
+            // Populated event-by-event by CollectMessagesTokenUsageFn during streaming.
+            return context.getTokenUsage();
+        }
+        return MessagesTokenUsageParser.parse(responseBody);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesCountTokensController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesCountTokensController.java
@@ -1,0 +1,78 @@
+package com.epam.aidial.core.server.controller.anthropic;
+
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.function.request.RequestObject;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Strings;
+
+/**
+ * {@code POST /anthropic/v1/messages/count_tokens} pass-through. Counts tokens only: it does not
+ * generate, so it charges no rate limits and collects no token usage. Always non-streaming.
+ */
+@Slf4j
+public class MessagesCountTokensController extends MessagesBaseController {
+
+    public MessagesCountTokensController(Proxy proxy, ProxyContext context) {
+        super(proxy, context);
+    }
+
+    public Future<?> handle() {
+        String contentType = context.getRequest().getHeader(HttpHeaders.CONTENT_TYPE);
+        if (!Strings.CI.contains(contentType, Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON)) {
+            return respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Only application/json is supported");
+        }
+        context.getRequest().body()
+                .map(MessagesBaseController::parseBody)
+                .compose(request -> {
+                    String model = request.getModel();
+                    return proxy.getTaskExecutor().submit(() -> setupDeployment(model))
+                            .compose(ignore -> proxy.getTokenStatsTracker().startSpan(context)
+                                    .map(ignored -> handleRequestBody(request)))
+                            .otherwise(error -> handleRequestError(model, error));
+                })
+                .onFailure(this::handleRequestBodyError);
+
+        return Future.succeededFuture();
+    }
+
+    @SneakyThrows
+    private Void handleRequestBody(RequestObject request) {
+        prepareUpstreamRoute(request);
+        sendRequest();
+
+        return null;
+    }
+
+    @Override
+    protected void processResponse(HttpClientResponse proxyResponse) {
+        proxyResponse.body()
+                .compose(body -> forwardResponse(proxyResponse, body))
+                .onFailure(this::handleProxyConnectionError);
+    }
+
+    private Future<Void> forwardResponse(HttpClientResponse proxyResponse, Buffer body) {
+        context.setResponseBody(body);
+        context.setResponseBodyTimestamp(System.currentTimeMillis());
+        HttpServerResponse response = context.getResponse();
+        ProxyUtil.handleChunkedResponse(response, proxyResponse);
+        response.setChunked(false);
+        response.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
+        response.putHeader(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(context.getUpstreamRoute().getAttemptCount()));
+        // count_tokens must NOT charge limits or collect token usage — just log and finalize.
+        return response.end(body)
+                .transform(result -> {
+                    proxy.getLogStore().save(context);
+                    finalizeRequest();
+                    return Future.<Void>succeededFuture();
+                });
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesCountTokensController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesCountTokensController.java
@@ -2,54 +2,22 @@ package com.epam.aidial.core.server.controller.anthropic;
 
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
-import com.epam.aidial.core.server.function.request.RequestObject;
 import com.epam.aidial.core.server.util.ProxyUtil;
-import com.epam.aidial.core.storage.http.HttpStatus;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.Strings;
 
 /**
  * {@code POST /anthropic/v1/messages/count_tokens} pass-through. Counts tokens only: it does not
- * generate, so it charges no rate limits and collects no token usage. Always non-streaming.
+ * generate, so it charges no rate limits (inherits the no-op {@link #verifyLimit()}) and collects
+ * no token usage. Always non-streaming.
  */
-@Slf4j
 public class MessagesCountTokensController extends MessagesBaseController {
 
     public MessagesCountTokensController(Proxy proxy, ProxyContext context) {
         super(proxy, context);
-    }
-
-    public Future<?> handle() {
-        String contentType = context.getRequest().getHeader(HttpHeaders.CONTENT_TYPE);
-        if (!Strings.CI.contains(contentType, Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON)) {
-            return respond(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Only application/json is supported");
-        }
-        context.getRequest().body()
-                .map(MessagesBaseController::parseBody)
-                .compose(request -> {
-                    String model = request.getModel();
-                    return proxy.getTaskExecutor().submit(() -> setupDeployment(model))
-                            .compose(ignore -> proxy.getTokenStatsTracker().startSpan(context)
-                                    .map(ignored -> handleRequestBody(request)))
-                            .otherwise(error -> handleRequestError(model, error));
-                })
-                .onFailure(this::handleRequestBodyError);
-
-        return Future.succeededFuture();
-    }
-
-    @SneakyThrows
-    private Void handleRequestBody(RequestObject request) {
-        prepareUpstreamRoute(request);
-        sendRequest();
-
-        return null;
     }
 
     @Override
@@ -63,8 +31,7 @@ public class MessagesCountTokensController extends MessagesBaseController {
         context.setResponseBody(body);
         context.setResponseBodyTimestamp(System.currentTimeMillis());
         HttpServerResponse response = context.getResponse();
-        ProxyUtil.handleChunkedResponse(response, proxyResponse);
-        response.setChunked(false);
+        ProxyUtil.copyResponse(response, proxyResponse);
         response.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
         response.putHeader(Proxy.HEADER_UPSTREAM_ATTEMPTS, Integer.toString(context.getUpstreamRoute().getAttemptCount()));
         // count_tokens must NOT charge limits or collect token usage — just log and finalize.

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesSseListener.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesSseListener.java
@@ -1,0 +1,21 @@
+package com.epam.aidial.core.server.controller.anthropic;
+
+import com.epam.aidial.core.server.function.BaseResponseFunction;
+import com.epam.aidial.core.server.sse.SseEvent;
+import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+class MessagesSseListener extends BufferingReadStream.BaseEventListener {
+
+    MessagesSseListener(List<BaseResponseFunction> functions) {
+        super(functions);
+    }
+
+    @Override
+    protected boolean isLastEvent(SseEvent event, JsonNode data) {
+        return "message_stop".equals(event.getEvent())
+                || (data != null && "message_stop".equals(data.path("type").asText()));
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
@@ -7,6 +7,19 @@ import java.util.regex.Pattern;
 @Getter
 public enum RouteTemplate {
 
+    // Anthropic API routes.
+    // count_tokens is declared first: both regexes are $-anchored and mutually exclusive today, but
+    // keeping the more specific path ahead of the generic one stays correct if a greedy
+    // /messages/(?<id>...) route is ever added.
+    LLM_MESSAGES_API_COUNT_TOKENS(
+            "^/+anthropic/v1/messages/count_tokens$",
+            "/anthropic/v1/messages/count_tokens"
+    ),
+    LLM_MESSAGES_API(
+            "^/+anthropic/v1/messages$",
+            "/anthropic/v1/messages"
+    ),
+
     // OpenAI API routes
     LLM_RESPONSES_API(
             "^/+openai/v1/responses$",

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectMessagesTokenUsageFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectMessagesTokenUsageFn.java
@@ -1,0 +1,46 @@
+package com.epam.aidial.core.server.function;
+
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.token.MessagesTokenUsageParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vertx.core.Future;
+
+/**
+ * Accumulates Anthropic streaming token usage, which is split across events: {@code message_start}
+ * carries {@code input_tokens} (+ cache counters), while {@code message_delta} carries the final
+ * cumulative {@code output_tokens} (newer API versions may repeat the other counters there too).
+ * The generic {@link com.epam.aidial.core.server.token.TokenUsageParser} only sees the last
+ * {@code usage} (output-only), losing the prompt count. This function observes each event (returning
+ * the tree unchanged — pure pass-through) and stores the merged usage on the context, where
+ * {@code MessagesController.parseTokenUsage} picks it up for rate-limit/stats.
+ */
+public class CollectMessagesTokenUsageFn extends BaseResponseFunction {
+
+    private long inputTokens;
+    private long outputTokens;
+    private long cacheReadTokens;
+    private long cacheCreationTokens;
+
+    public CollectMessagesTokenUsageFn(Proxy proxy, ProxyContext context) {
+        super(proxy, context);
+    }
+
+    @Override
+    public Future<JsonNode> apply(JsonNode tree) {
+        JsonNode usage = switch (tree.path("type").asText()) {
+            case "message_start" -> tree.path("message").path("usage");
+            case "message_delta" -> tree.path("usage");
+            default -> null;
+        };
+        if (usage != null && usage.isObject()) {
+            // Counters are cumulative; fields absent from an event keep their previous values.
+            inputTokens = usage.path("input_tokens").asLong(inputTokens);
+            outputTokens = usage.path("output_tokens").asLong(outputTokens);
+            cacheReadTokens = usage.path("cache_read_input_tokens").asLong(cacheReadTokens);
+            cacheCreationTokens = usage.path("cache_creation_input_tokens").asLong(cacheCreationTokens);
+            context.setTokenUsage(MessagesTokenUsageParser.build(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens));
+        }
+        return Future.succeededFuture(tree);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/function/request/MessagesApiRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/request/MessagesApiRequest.java
@@ -1,0 +1,73 @@
+package com.epam.aidial.core.server.function.request;
+
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.server.util.ChatUtil;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Anthropic Messages API request. Pure pass-through: the body is forwarded verbatim except for the
+ * model-name override applied by {@code EnhanceModelRequestFn}.
+ */
+@RequiredArgsConstructor
+public class MessagesApiRequest implements RequestObject {
+    private final ObjectNode tree;
+
+    @Override
+    public String getModel() {
+        return tree.path("model").asText();
+    }
+
+    @Override
+    public void setModel(String model) {
+        tree.put("model", model);
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return tree.path("stream").asBoolean(false);
+    }
+
+    @Override
+    public Set<String> collectAttachments() {
+        // Pure pass-through: Anthropic bodies carry base64/public content, not DIAL file references,
+        // so there is nothing to access-check here.
+        return Set.of();
+    }
+
+    @Override
+    public Set<String> collectAppAttachments(List<String> paths) {
+        return ChatUtil.collectAttachments(tree, paths);
+    }
+
+    @Override
+    public List<CacheKey> buildMessageCacheKeys() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public List<CacheKey> buildToolCacheKeys() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void clearInterceptorSettings() {
+        ChatUtil.removeInterceptorConfiguration(tree);
+    }
+
+    @Override
+    public void applyDefaults(Deployment deployment) {
+        // No-op: Anthropic params differ from the OpenAI chat/responses defaults, so applying
+        // Deployment defaults here would be wrong. Per-interface defaults can be added later.
+    }
+
+    @Override
+    public byte[] serialize() throws JsonProcessingException {
+        return ProxyUtil.MAPPER.writeValueAsBytes(tree);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/token/MessagesTokenUsageParser.java
+++ b/server/src/main/java/com/epam/aidial/core/server/token/MessagesTokenUsageParser.java
@@ -1,0 +1,65 @@
+package com.epam.aidial.core.server.token;
+
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vertx.core.buffer.Buffer;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Token-usage accounting for the Anthropic Messages API. Anthropic reports usage as
+ * {@code {input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens}} with
+ * no {@code total_tokens}, and — unlike OpenAI, whose {@code prompt_tokens} includes cached tokens —
+ * {@code input_tokens} EXCLUDES the cache counters. DIAL accounting follows the OpenAI semantics
+ * that {@link TokenUsage} consumers (rate limiter, usage logs) are built around, so prompt tokens
+ * here are {@code input + cache_read + cache_creation}, with {@code cache_read_input_tokens} exposed
+ * as the {@link PromptTokensDetails#getCachedTokens()} subset.
+ */
+@Slf4j
+@UtilityClass
+public class MessagesTokenUsageParser {
+
+    /**
+     * Parses usage from a non-streaming Messages response body (top-level {@code usage} object).
+     */
+    public TokenUsage parse(Buffer body) {
+        try {
+            JsonNode usage = ProxyUtil.MAPPER.readTree(body.getBytes()).get("usage");
+            if (usage == null || !usage.isObject()) {
+                return null;
+            }
+            return fromUsageNode(usage);
+        } catch (Throwable e) {
+            log.warn("Can't parse Anthropic token usage: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Builds a {@link TokenUsage} from a single Anthropic {@code usage} JSON node.
+     */
+    public TokenUsage fromUsageNode(JsonNode usage) {
+        return build(
+                usage.path("input_tokens").asLong(0),
+                usage.path("output_tokens").asLong(0),
+                usage.path("cache_read_input_tokens").asLong(0),
+                usage.path("cache_creation_input_tokens").asLong(0));
+    }
+
+    /**
+     * Builds a {@link TokenUsage} from raw Anthropic usage counters (see the accounting rule above).
+     */
+    public TokenUsage build(long inputTokens, long outputTokens, long cacheReadTokens, long cacheCreationTokens) {
+        long promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(promptTokens);
+        tokenUsage.setCompletionTokens(outputTokens);
+        tokenUsage.setTotalTokens(promptTokens + outputTokens);
+        if (cacheReadTokens > 0) {
+            PromptTokensDetails details = new PromptTokensDetails();
+            details.setCachedTokens(cacheReadTokens);
+            tokenUsage.setPromptTokensDetails(details);
+        }
+        return tokenUsage;
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/util/ProxyUtil.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ProxyUtil.java
@@ -264,11 +264,14 @@ public class ProxyUtil {
         return socketAddress.host();
     }
 
+    public void copyResponse(HttpServerResponse response, HttpClientResponse proxyResponse) {
+        response.setStatusCode(proxyResponse.statusCode());
+        copyHeaders(proxyResponse.headers(), response.headers());
+    }
+
     public void handleChunkedResponse(HttpServerResponse response, HttpClientResponse proxyResponse) {
         response.setChunked(true);
-        int responseStatusCode = proxyResponse.statusCode();
-        response.setStatusCode(responseStatusCode);
-        copyHeaders(proxyResponse.headers(), response.headers());
+        copyResponse(response, proxyResponse);
         String contentType = proxyResponse.getHeader(HttpHeaders.CONTENT_TYPE);
         if (Strings.CI.contains(contentType, "text/event-stream")) {
             response.putHeader("X-Accel-Buffering", "no");

--- a/server/src/main/java/com/epam/aidial/core/server/util/ProxyUtil.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ProxyUtil.java
@@ -67,7 +67,8 @@ public class ProxyUtil {
             .add(HttpHeaders.TRANSFER_ENCODING, "whatever")
             .add(HttpHeaders.UPGRADE, "whatever")
             .add(HttpHeaders.CONTENT_LENGTH, "whatever")
-            .add(Proxy.HEADER_API_KEY, "whatever");
+            .add(Proxy.HEADER_API_KEY, "whatever")
+            .add(Proxy.HEADER_X_API_KEY, "whatever");
     public static final String METADATA_PREFIX = "metadata/";
 
     public static void copyHeaders(MultiMap from, MultiMap to) {

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -1,0 +1,224 @@
+package com.epam.aidial.core.server;
+
+import com.epam.aidial.core.server.data.LimitStats;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import io.vertx.core.http.HttpMethod;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MessagesApiTest extends ResourceBaseTest {
+
+    private static final String MESSAGES_PATH = "/anthropic/v1/messages";
+    private static final String COUNT_TOKENS_PATH = "/anthropic/v1/messages/count_tokens";
+
+    // input_tokens=10 (excludes cache), cache_read=2, output_tokens=8, no total_tokens.
+    // DIAL accounting: prompt = 10 + 2 = 12, total = 20 (OpenAI semantics: cached tokens are part of prompt).
+    private static final String NON_STREAM_RESPONSE = "{\"id\":\"msg_01\",\"type\":\"message\",\"role\":\"assistant\","
+            + "\"model\":\"claude-sonnet\",\"content\":[{\"type\":\"text\",\"text\":\"Who’s there?\"}],"
+            + "\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":10,\"output_tokens\":8,\"cache_read_input_tokens\":2}}";
+
+    private static String requestBody(String model, boolean stream) {
+        return "{\"model\":\"" + model + "\",\"max_tokens\":100,\"stream\":" + stream
+                + ",\"messages\":[{\"role\":\"user\",\"content\":\"Knock, knock\"}]}";
+    }
+
+    @Test
+    public void testNonStreamingRoundTripAndUsage() throws IOException, InterruptedException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-ns", false),
+                    "api-key", "proxyKey1", "anthropic-version", "2023-06-01");
+
+            assertEquals(200, response.status());
+            assertEquals(NON_STREAM_RESPONSE, response.body());
+            // exact ingress path is forwarded (base_url + request.uri())
+            assertEquals(MESSAGES_PATH, captured.get().getPath());
+            // Anthropic-specific headers pass through to the adapter
+            assertEquals("2023-06-01", captured.get().getHeader("anthropic-version"));
+
+            Thread.sleep(1000); // wait for core to save usage
+            assertUsed("claude-ns", 20);
+        }
+    }
+
+    @Test
+    public void testStreamingAccumulatesUsageFromBothEvents() throws IOException, InterruptedException {
+        String sse = readFixture("anthropic-messages-sse.txt");
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                MockResponse response = new MockResponse();
+                response.setResponseCode(200);
+                response.setHeader("Content-Type", "text/event-stream");
+                response.setChunkedBody(sse, 200);
+                return response;
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-stream", true), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            // events are re-serialized by the SSE listener chain, so assert content rather than exact bytes
+            String body = response.body();
+            assertTrue(body.contains("message_start"), body);
+            assertTrue(body.contains("message_stop"), body);
+            assertTrue(body.contains("Who"), body);
+
+            Thread.sleep(1000);
+            // input_tokens (10) + cache_read (3) from message_start + output_tokens (8, message_delta);
+            // the prompt half must not be lost to the usage split across events.
+            assertUsed("claude-stream", 21);
+        }
+    }
+
+    @Test
+    public void testCountTokensDoesNotChargeLimits() throws IOException, InterruptedException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, COUNT_TOKENS_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, "{\"input_tokens\":5}", "Content-Type", "application/json");
+            });
+
+            Response response = post(client, COUNT_TOKENS_PATH, requestBody("claude-count", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            assertEquals("{\"input_tokens\":5}", response.body());
+            assertEquals(COUNT_TOKENS_PATH, captured.get().getPath());
+
+            Thread.sleep(1000);
+            assertUsed("claude-count", 0); // count_tokens must not charge
+        }
+    }
+
+    @Test
+    public void testXapiKeyAuthenticatesAndIsNotLeaked() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            // Only x-api-key carries the DIAL key (no api-key, no Authorization) — mirrors Claude Code.
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-xapikey", false), "x-api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            RecordedRequest upstream = captured.get();
+            // client's x-api-key (the DIAL key) is stripped upstream ...
+            assertNull(upstream.getHeader("x-api-key"));
+            // ... while the per-request DIAL Api-Key is injected for the adapter.
+            assertNotNull(upstream.getHeader("Api-Key"));
+        }
+    }
+
+    @Test
+    public void testBadXapiKeyRejected() throws IOException {
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-xapikey", false), "x-api-key", "bad-key");
+            assertEquals(401, response.status());
+        }
+    }
+
+    @Test
+    public void testXapiKeyAcceptedOnAnyEndpointWhenOnlyCredential() throws IOException {
+        try (CloseableHttpClient client = newClient()) {
+            // The x-api-key fallback is global (consulted when neither api-key nor Authorization is
+            // present), so it authenticates non-Anthropic endpoints too: 404 (unknown model), not 401.
+            Response response = post(client, "/openai/v1/responses",
+                    "{\"model\":\"no-such-model\",\"input\":\"hi\"}", "x-api-key", "proxyKey1");
+            assertEquals(404, response.status());
+        }
+    }
+
+    @Test
+    public void testRateLimitReturns429() throws IOException, InterruptedException {
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH,
+                    request -> TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json"));
+
+            // claude-limited allows 10 tokens/minute; the first request passes and charges 20.
+            Response first = post(client, MESSAGES_PATH, requestBody("claude-limited", false), "api-key", "proxyKey1");
+            assertEquals(200, first.status());
+
+            Thread.sleep(1000); // wait for core to save usage
+            Response second = post(client, MESSAGES_PATH, requestBody("claude-limited", false), "api-key", "proxyKey1");
+            assertEquals(429, second.status());
+        }
+    }
+
+    @Test
+    public void testExplicitUpstreamSendsKeyButNoEndpointHeader() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-upstream", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            // adapters route by interfaces.base_url + ingress path; no per-upstream Messages API endpoint yet
+            assertNull(captured.get().getHeader("X-UPSTREAM-ENDPOINT"));
+            assertEquals("modelKey", captured.get().getHeader("X-UPSTREAM-KEY"));
+        }
+    }
+
+    @Test
+    public void testUnsupportedInterfaceReturns503() throws IOException {
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-no-iface", false), "api-key", "proxyKey1");
+            assertEquals(503, response.status());
+        }
+    }
+
+    private void assertUsed(String deployment, long expected) {
+        Response response = send(HttpMethod.GET, "/v1/deployments/" + deployment + "/limits", null, null);
+        verify(response, 200);
+        LimitStats stats = ProxyUtil.convertToObject(response.body(), LimitStats.class);
+        assertNotNull(stats);
+        assertEquals(expected, stats.getDayTokenStats().getUsed());
+        assertEquals(expected, stats.getMinuteTokenStats().getUsed());
+    }
+
+    private Response post(CloseableHttpClient client, String path, String body, String... headers) throws IOException {
+        String uri = "http://127.0.0.1:" + serverPort + path;
+        HttpUriRequestBase request = new HttpUriRequestBase(HttpMethod.POST.name(), URI.create(uri));
+        request.setHeader("content-type", "application/json");
+        for (int i = 0; i < headers.length; i += 2) {
+            request.setHeader(headers[i], headers[i + 1]);
+        }
+        request.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
+        return client.execute(request, ResourceBaseTest::toResponse);
+    }
+
+    private static CloseableHttpClient newClient() {
+        return HttpClientBuilder.create().disableAutomaticRetries().build();
+    }
+
+    private static String readFixture(String name) throws IOException {
+        try (InputStream stream = MessagesApiTest.class.getClassLoader().getResourceAsStream(name)) {
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/token/MessagesTokenUsageParserTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/token/MessagesTokenUsageParserTest.java
@@ -1,0 +1,74 @@
+package com.epam.aidial.core.server.token;
+
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vertx.core.buffer.Buffer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MessagesTokenUsageParserTest {
+
+    @Test
+    void parseDerivesTotalAndCache() {
+        Buffer body = Buffer.buffer(
+                "{\"id\":\"msg\",\"usage\":{\"input_tokens\":10,\"output_tokens\":8,\"cache_read_input_tokens\":2}}");
+
+        TokenUsage usage = MessagesTokenUsageParser.parse(body);
+
+        assertNotNull(usage);
+        // Anthropic's input_tokens excludes cache counters; DIAL prompt tokens include them (OpenAI semantics).
+        assertEquals(12, usage.getPromptTokens());
+        assertEquals(8, usage.getCompletionTokens());
+        // Anthropic omits total_tokens — it must be derived, not left at 0.
+        assertEquals(20, usage.getTotalTokens());
+        assertNotNull(usage.getPromptTokensDetails());
+        assertEquals(2, usage.getPromptTokensDetails().getCachedTokens());
+    }
+
+    @Test
+    void parseCountsCacheCreationTokens() {
+        Buffer body = Buffer.buffer(
+                "{\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":7,\"cache_creation_input_tokens\":3}}");
+
+        TokenUsage usage = MessagesTokenUsageParser.parse(body);
+
+        assertNotNull(usage);
+        assertEquals(20, usage.getPromptTokens());
+        assertEquals(25, usage.getTotalTokens());
+        // Only cache reads count as "cached" (subset semantics); cache writes are ordinary prompt tokens.
+        assertEquals(7, usage.getPromptTokensDetails().getCachedTokens());
+    }
+
+    @Test
+    void parseWithoutCacheLeavesDetailsNull() {
+        Buffer body = Buffer.buffer("{\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}");
+
+        TokenUsage usage = MessagesTokenUsageParser.parse(body);
+
+        assertNotNull(usage);
+        assertEquals(7, usage.getTotalTokens());
+        assertNull(usage.getPromptTokensDetails());
+    }
+
+    @Test
+    void parseReturnsNullWhenNoUsage() {
+        assertNull(MessagesTokenUsageParser.parse(Buffer.buffer("{\"id\":\"msg\"}")));
+        assertNull(MessagesTokenUsageParser.parse(Buffer.buffer("not json")));
+    }
+
+    @Test
+    void fromUsageNodeBuildsTokenUsage() throws Exception {
+        JsonNode node = ProxyUtil.MAPPER.readTree(
+                "{\"input_tokens\":25,\"output_tokens\":130,\"cache_read_input_tokens\":5}");
+
+        TokenUsage usage = MessagesTokenUsageParser.fromUsageNode(node);
+
+        assertEquals(30, usage.getPromptTokens());
+        assertEquals(130, usage.getCompletionTokens());
+        assertEquals(160, usage.getTotalTokens());
+        assertEquals(5, usage.getPromptTokensDetails().getCachedTokens());
+    }
+}

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -181,6 +181,37 @@
       "upstreams": [
         {"endpoint": "http://chat/completions", "responsesEndpoint": "http://responses", "key": "modelKey", "id": "responses-upstream"}
       ]
+    },
+    "claude-ns": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
+    "claude-stream": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
+    "claude-count": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
+    "claude-xapikey": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
+    "claude-limited": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
+    "claude-upstream": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
+      "upstreams": [
+        {"key": "modelKey", "id": "messages-upstream"}
+      ]
+    },
+    "claude-no-iface": {
+      "type": "chat",
+      "endpoint": "http://localhost:4848/v1/chat/completions"
     }
   },
   "toolsets": {
@@ -261,7 +292,14 @@
         "forecast": {},
         "calculator": {},
         "app": {},
-        "gpt-3-turbo": {"minute": "100", "day": "1000"}
+        "gpt-3-turbo": {"minute": "100", "day": "1000"},
+        "claude-ns": {"minute": "100000", "day": "10000000"},
+        "claude-stream": {"minute": "100000", "day": "10000000"},
+        "claude-count": {"minute": "100000", "day": "10000000"},
+        "claude-xapikey": {"minute": "100000", "day": "10000000"},
+        "claude-limited": {"minute": "10", "day": "10"},
+        "claude-upstream": {"minute": "100000", "day": "10000000"},
+        "claude-no-iface": {"minute": "100000", "day": "10000000"}
       }
     },
     "vstore_user": {

--- a/server/src/test/resources/anthropic-messages-sse.txt
+++ b/server/src/test/resources/anthropic-messages-sse.txt
@@ -1,0 +1,21 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":3,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Who"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"’s there?"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}
+


### PR DESCRIPTION
…`) in pass-through mode #1618

### Applicable issues

- feat #1618

### Description of changes

- Added Anthropic Messages API controllers in dedicated `controller/anthropic/` subpackage:
  - `MessagesBaseController`: abstract base with deployment resolution (anthropicMessages interface gate), enhancement chain, and upstream route preparation
  - `MessagesController`: POST `/anthropic/v1/messages` with streaming/non-streaming response handling; collects token usage with Anthropic semantics (input tokens exclude cache)
  - `MessagesCountTokensController`: POST `/anthropic/v1/messages/count_tokens` pass-through (no rate limit charge, no token usage collection)
  - `MessagesSseListener`: SSE event listener for streaming responses (recognizes `message_stop` event)
- Added token usage accounting:
  - `MessagesTokenUsageParser`: parses non-streaming response body for `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`
  - `CollectMessagesTokenUsageFn`: response function collecting token usage event-by-event for streaming
- Registered routes in `ControllerSelector` (count_tokens before messages for first-match-wins specificity)

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (MessagesApiTest 9/9, token parser tests, controller routing tests, checkstyle clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
