### PR TITLE
fix: release local lock in LockService when Redis lock acquisition fails

### DIFF
--- a/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/service/LockService.java
@@ -62,13 +62,21 @@ public class LockService {
         LocalLock localLock = acquireLocalLock(id);
         localLock.lock();
 
-        long ttl = tryLock(id, owner);
-        long interval = WAIT_MIN;
-        // it seems the lock has been acquired by another instance of Core
-        while (ttl > 0) {
-            LockSupport.parkNanos(interval);
-            interval = Math.min(2 * interval, Math.min(WAIT_MAX, ttl + 1));
-            ttl = tryLock(id, owner);
+        // A Redis failure here must not leak the held local lock: it is a plain ReentrantLock,
+        // so a leaked hold would block every subsequent lock() on this key until pod restart.
+        try {
+            long ttl = tryLock(id, owner);
+            long interval = WAIT_MIN;
+            // it seems the lock has been acquired by another instance of Core
+            while (ttl > 0) {
+                LockSupport.parkNanos(interval);
+                interval = Math.min(2 * interval, Math.min(WAIT_MAX, ttl + 1));
+                ttl = tryLock(id, owner);
+            }
+        } catch (Throwable e) {
+            localLock.unlock();
+            releaseLocalLock(id);
+            throw e;
         }
 
         return () -> unlock(id, owner, localLock);

--- a/storage/src/test/java/com/epam/aidial/core/storage/service/LockServiceFailureTest.java
+++ b/storage/src/test/java/com/epam/aidial/core/storage/service/LockServiceFailureTest.java
@@ -1,0 +1,67 @@
+package com.epam.aidial.core.storage.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.RedisException;
+import org.redisson.client.codec.StringCodec;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LockServiceFailureTest {
+
+    /**
+     * A Redis failure thrown from the lock script EVAL must not leak the per-key local
+     * ReentrantLock: otherwise every subsequent lock() on the same key blocks forever
+     * (until pod restart), which is how a single transient Redis outage wedged the
+     * bucket-locked config-rebuild pipeline in production.
+     */
+    @Test
+    void testLocalLockReleasedWhenRedisEvalFails() throws Exception {
+        RScript script = mock(RScript.class);
+        RedissonClient redis = mock(RedissonClient.class);
+        when(redis.getScript(any(StringCodec.class))).thenReturn(script);
+
+        AtomicInteger calls = new AtomicInteger();
+        when(script.eval(any(RScript.Mode.class), anyString(), any(RScript.ReturnType.class), anyList(), any(Object[].class)))
+                .thenAnswer(invocation -> {
+                    if (calls.getAndIncrement() == 0) {
+                        throw new RedisException("simulated connection failure");
+                    }
+                    RScript.ReturnType returnType = invocation.getArgument(2);
+                    return returnType == RScript.ReturnType.BOOLEAN ? Boolean.TRUE : 0L;
+                });
+
+        LockService service = new LockService(redis, null);
+
+        assertThrows(RedisException.class, () -> service.lock("key"));
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            // Lock must be acquired and closed on the same thread (ReentrantLock semantics).
+            Future<Boolean> reacquire = executor.submit(() -> {
+                try (LockService.Lock lock = service.lock("key")) {
+                    return lock != null;
+                }
+            });
+            assertTrue(reacquire.get(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- none filed; found via production troubleshooting -->

### Description of changes

A Redis failure thrown from the lock-script `EVAL` (e.g. `WriteRedisConnectionException` on a Valkey connection blip) escaped `LockService.lock()` **after** the per-key JVM-local `ReentrantLock` was already held, orphaning that lock permanently — it has no TTL and its owner thread dies with the exception. Every subsequent `lock()` on the same key then blocks forever.

Observed in a live environment (0.46.0-dev.14, 2 pods): one transient Valkey blip wedged the admin bucket locks on both pods simultaneously. From that moment every debounced merged-config rebuild (~1 per 60s file poll), `/v1/ops/config/reload`, and admin config write parked in the queue — a thread dump showed 377 blocked virtual threads and exactly one `Failed to rebuild merged config` warning per pod at the wedge start, then silence. Only a pod restart recovers.

The fix wraps the distributed spin-lock acquisition in try/catch and releases the local lock (and its refcount entry) before rethrowing, so a transient Redis error fails the single operation instead of permanently wedging the pod.

Regression test `LockServiceFailureTest` simulates the `EVAL` throwing once and asserts the exception propagates while the key remains acquirable by another thread; it reproduces the production hang (times out) without the fix.

`:storage:test`, `:server:test`, and checkstyle pass.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)