### PR TITLE
fix: OIDC path-append discovery for path-scoped OAuth issuers #1685

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/metadata/AuthorizationServerMetadataService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/metadata/AuthorizationServerMetadataService.java
@@ -117,5 +117,7 @@ public class AuthorizationServerMetadataService {
         fallbackEndpoints.add(ResourceEndpointUtil.buildMetadataEndpoint(resourceEndpoint, WELL_KNOWN_AUTH_SERVER_SUFFIX, true));
         fallbackEndpoints.add(ResourceEndpointUtil.buildMetadataEndpoint(resourceEndpoint, WELL_KNOWN_OPENID_CONFIG_SUFFIX, false));
         fallbackEndpoints.add(ResourceEndpointUtil.buildMetadataEndpoint(resourceEndpoint, WELL_KNOWN_OPENID_CONFIG_SUFFIX, true));
+        // OpenID Connect Discovery 1.0 path-append form (e.g. Keycloak: {issuer}/.well-known/openid-configuration)
+        fallbackEndpoints.add(ResourceEndpointUtil.buildAppendedMetadataEndpoint(resourceEndpoint, WELL_KNOWN_OPENID_CONFIG_SUFFIX));
     }
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtil.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtil.java
@@ -83,5 +83,49 @@ public class ResourceEndpointUtil {
             throw new IllegalArgumentException("Resource endpoint is not valid URI");
         }
     }
+
+    /**
+     * Builds the metadata endpoint by appending the well-known suffix to the end of the resource path,
+     * following the OpenID Connect Discovery 1.0 convention (e.g. Keycloak: {@code {issuer}/.well-known/openid-configuration}).
+     *
+     * <p>This complements {@link #buildMetadataEndpoint}, which inserts the well-known component between
+     * the host and path per RFC 8414.</p>
+     *
+     * @param url             The resource endpoint URL
+     * @param wellKnownSuffix The well-known URI suffix
+     * @return The constructed metadata endpoint.
+     */
+    public static String buildAppendedMetadataEndpoint(String url, String wellKnownSuffix) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("URL cannot be null or empty.");
+        }
+
+        try {
+            URI resourceUri = new URI(url);
+
+            String scheme = resourceUri.getScheme();
+            String host = resourceUri.getHost();
+            String path = resourceUri.getPath();
+            int port = resourceUri.getPort();
+
+            if (scheme == null || host == null) {
+                throw new IllegalArgumentException("Invalid URL: Missing scheme or host.");
+            }
+
+            if (path.endsWith("/")) {
+                path = path.substring(0, path.length() - 1);
+            }
+
+            return String.format("%s://%s%s%s/.well-known/%s",
+                    scheme,
+                    host,
+                    (port > 0 ? ":" + port : ""),
+                    path,
+                    wellKnownSuffix
+            );
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Resource endpoint is not valid URI");
+        }
+    }
 }
 

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/metadata/AuthorizationServerMetadataServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/metadata/AuthorizationServerMetadataServiceTest.java
@@ -1,0 +1,113 @@
+package com.epam.aidial.core.credentials.service.metadata;
+
+import com.epam.aidial.core.credentials.data.registration.AuthorizationServerMetadata;
+import com.epam.aidial.core.credentials.data.registration.AuthorizationServerProtectedResourceMetadata;
+import com.epam.aidial.core.credentials.service.ResourceAuthorizationClient;
+import com.epam.aidial.core.credentials.validation.AuthorizationServerMetadataValidator;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthorizationServerMetadataServiceTest {
+
+    private static final String RESOURCE_ID = "toolsets/foo/bar";
+    private static final String BASE_URL = "https://keycloak.example.com";
+    private static final String ISSUER = BASE_URL + "/realms/dial";
+    // OpenID Connect Discovery 1.0 path-append form served by Keycloak.
+    private static final String OIDC_APPEND_URL = ISSUER + "/.well-known/openid-configuration";
+
+    private ResourceAuthorizationClient client;
+    private AuthorizationServerMetadataService service;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(ResourceAuthorizationClient.class);
+        service = new AuthorizationServerMetadataService(client, new AuthorizationServerMetadataValidator());
+    }
+
+    /**
+     * Keycloak-style issuer: metadata resolves only at the OIDC path-append URL, every RFC 8414
+     * path-insertion form 404s. The append form must be included in the fallback set for discovery to succeed.
+     */
+    @Test
+    void discoversMetadataViaOidcPathAppendForm() {
+        when(client.executeGet(anyString(), eq(AuthorizationServerMetadata.class)))
+                .thenThrow(notFound());
+        when(client.executeGet(eq(OIDC_APPEND_URL), eq(AuthorizationServerMetadata.class)))
+                .thenReturn(metadata(ISSUER + "/clients-registrations/openid-connect"));
+
+        AuthorizationServerMetadata result = service.getAuthorizationServerMetadata(
+                RESOURCE_ID, BASE_URL + "/mcp", protectedResourceMetadata(), true);
+
+        assertNotNull(result);
+        assertEquals(ISSUER, result.getIssuer());
+        assertEquals(ISSUER + "/clients-registrations/openid-connect", result.getRegistrationEndpoint());
+
+        ArgumentCaptor<String> endpoints = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeastOnce()).executeGet(endpoints.capture(), eq(AuthorizationServerMetadata.class));
+        assertTrue(endpoints.getAllValues().contains(OIDC_APPEND_URL),
+                "OIDC path-append discovery URL must be among the queried fallback endpoints");
+    }
+
+    @Test
+    void failsWhenNoDiscoveryFormResolves() {
+        when(client.executeGet(anyString(), eq(AuthorizationServerMetadata.class)))
+                .thenThrow(notFound());
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.getAuthorizationServerMetadata(RESOURCE_ID, BASE_URL + "/mcp", protectedResourceMetadata(), true));
+        assertEquals(
+                "The MCP server for Resource: %s does not support OAuth authentication.".formatted(RESOURCE_ID),
+                exception.getMessage());
+    }
+
+    @Test
+    void failsWhenMetadataHasNoRegistrationEndpoint() {
+        when(client.executeGet(anyString(), eq(AuthorizationServerMetadata.class)))
+                .thenThrow(notFound());
+        when(client.executeGet(eq(OIDC_APPEND_URL), eq(AuthorizationServerMetadata.class)))
+                .thenReturn(metadata(null));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.getAuthorizationServerMetadata(RESOURCE_ID, BASE_URL + "/mcp", protectedResourceMetadata(), true));
+        assertEquals(
+                "The MCP server for Resource: %s does not support dynamic client registration.".formatted(RESOURCE_ID),
+                exception.getMessage());
+    }
+
+    private static AuthorizationServerProtectedResourceMetadata protectedResourceMetadata() {
+        AuthorizationServerProtectedResourceMetadata metadata = new AuthorizationServerProtectedResourceMetadata();
+        metadata.setAuthorizationServers(List.of(ISSUER));
+        return metadata;
+    }
+
+    private static AuthorizationServerMetadata metadata(String registrationEndpoint) {
+        return AuthorizationServerMetadata.builder()
+                .issuer(ISSUER)
+                .authorizationEndpoint(ISSUER + "/protocol/openid-connect/auth")
+                .tokenEndpoint(ISSUER + "/protocol/openid-connect/token")
+                .registrationEndpoint(registrationEndpoint)
+                .build();
+    }
+
+    private static HttpException notFound() {
+        return new HttpException(HttpStatus.NOT_FOUND, "Not Found");
+    }
+}

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtilTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/util/ResourceEndpointUtilTest.java
@@ -112,6 +112,75 @@ class ResourceEndpointUtilTest {
         }
     }
 
+    static Stream<TestCaseBuildAppendedMetadataEndpoint> provideTestCasesForAppendedMetadataEndpoint() {
+        return Stream.of(
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        "https://keycloak.example.com/realms/dial",
+                        "openid-configuration",
+                        "https://keycloak.example.com/realms/dial/.well-known/openid-configuration",
+                        null
+                ),
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        "https://keycloak.example.com/realms/dial/",
+                        "openid-configuration",
+                        "https://keycloak.example.com/realms/dial/.well-known/openid-configuration",
+                        null
+                ),
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        "http://localhost:8080/realms/dial",
+                        "openid-configuration",
+                        "http://localhost:8080/realms/dial/.well-known/openid-configuration",
+                        null
+                ),
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        "https://example.com",
+                        "openid-configuration",
+                        "https://example.com/.well-known/openid-configuration",
+                        null
+                ),
+
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        "invalid-url",
+                        "openid-configuration",
+                        null,
+                        "Invalid URL: Missing scheme or host."
+                ),
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        null,
+                        "openid-configuration",
+                        null,
+                        "URL cannot be null or empty."
+                ),
+                new TestCaseBuildAppendedMetadataEndpoint(
+                        "",
+                        "openid-configuration",
+                        null,
+                        "URL cannot be null or empty."
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForAppendedMetadataEndpoint")
+    void testBuildAppendedMetadataEndpoint(TestCaseBuildAppendedMetadataEndpoint testCase) {
+        if (testCase.expectedExceptionMessage != null) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> ResourceEndpointUtil.buildAppendedMetadataEndpoint(
+                            testCase.resourceEndpoint,
+                            testCase.wellKnownSuffix
+                    )
+            );
+            assertEquals(testCase.expectedExceptionMessage, exception.getMessage());
+        } else {
+            String result = ResourceEndpointUtil.buildAppendedMetadataEndpoint(
+                    testCase.resourceEndpoint,
+                    testCase.wellKnownSuffix
+            );
+            assertEquals(testCase.expectedOutput, result);
+        }
+    }
+
     private static class TestCaseBuildBaseResourceEndpoint {
         String inputUrl;
         String expectedOutput;
@@ -135,6 +204,20 @@ class ResourceEndpointUtilTest {
             this.resourceEndpoint = resourceEndpoint;
             this.wellKnownSuffix = wellKnownSuffix;
             this.ignorePathSuffix = ignorePathSuffix;
+            this.expectedOutput = expectedOutput;
+            this.expectedExceptionMessage = expectedExceptionMessage;
+        }
+    }
+
+    private static class TestCaseBuildAppendedMetadataEndpoint {
+        String resourceEndpoint;
+        String wellKnownSuffix;
+        String expectedOutput;
+        String expectedExceptionMessage;
+
+        TestCaseBuildAppendedMetadataEndpoint(String resourceEndpoint, String wellKnownSuffix, String expectedOutput, String expectedExceptionMessage) {
+            this.resourceEndpoint = resourceEndpoint;
+            this.wellKnownSuffix = wellKnownSuffix;
             this.expectedOutput = expectedOutput;
             this.expectedExceptionMessage = expectedExceptionMessage;
         }


### PR DESCRIPTION
Dynamic Client Registration failed against MCP servers whose OAuth authorization server uses a path-scoped issuer (notably Keycloak, `https://<host>/realms/<realm>`). Authorization-server metadata discovery only tried the RFC 8414 path-insertion URL forms, so Keycloak's discovery endpoint always 404'd and toolset creation aborted with *"does not support OAuth authentication"*. This adds the OpenID Connect Discovery 1.0 path-append form as an additional discovery fallback.

### Applicable issues

- fixes #1685

### Description of changes

- Add `ResourceEndpointUtil.buildAppendedMetadataEndpoint(...)` — builds the OIDC Discovery 1.0 path-append URL (`{issuer}/.well-known/openid-configuration`), complementing the existing RFC 8414 path-insertion builder.
- Wire the `openid-configuration` path-append form into `AuthorizationServerMetadataService` discovery fallbacks, after the existing insertion forms (matching the ordering used by the MCP reference SDKs). Path-append is added for `openid-configuration` only, since that is the sole spec-defined append form (RFC 8414 defines only the insertion form for `oauth-authorization-server`).
- Tests: `ResourceEndpointUtilTest` covers the new URL builder; `AuthorizationServerMetadataServiceTest` (Mockito, no new deps) pins the wiring — metadata resolving only at the append URL succeeds, plus the no-discovery and no-registration-endpoint failure paths.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.