### PR TITLE
chore: propagate upstream `endpoint` in header for anthropic api

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -175,11 +175,7 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
         context.setProxyRequest(proxyRequest);
         context.setProxyConnectTimestamp(System.currentTimeMillis());
 
-        // TODO: no per-upstream endpoint for the Messages API yet. A single endpoint can't cover
-        //  /v1/messages, /v1/messages/count_tokens and /v1/messages/batches, and the only adapter
-        //  serving this interface (bedrock) routes by interfaces.base_url + ingress path on its own.
-        //  Investigate a proper way to provide Messages API URLs to adapters before adding one.
-        sendProxyRequest(proxyRequest, upstream -> null)
+        sendProxyRequest(proxyRequest, Upstream::getEndpoint)
                 .onSuccess(this::handleProxyResponse)
                 .onFailure(this::handleProxyResponseError);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -167,7 +167,7 @@ public class MessagesApiTest extends ResourceBaseTest {
     }
 
     @Test
-    public void testExplicitUpstreamSendsKeyButNoEndpointHeader() throws IOException {
+    public void testExplicitUpstreamSendsKeyAndEndpointHeader() throws IOException {
         AtomicReference<RecordedRequest> captured = new AtomicReference<>();
         try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
             server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
@@ -178,8 +178,8 @@ public class MessagesApiTest extends ResourceBaseTest {
             Response response = post(client, MESSAGES_PATH, requestBody("claude-upstream", false), "api-key", "proxyKey1");
 
             assertEquals(200, response.status());
-            // adapters route by interfaces.base_url + ingress path; no per-upstream Messages API endpoint yet
-            assertNull(captured.get().getHeader("X-UPSTREAM-ENDPOINT"));
+            // the upstream endpoint is propagated to the adapter (as for chat completions / responses)
+            assertEquals("http://messages-upstream/v1/messages", captured.get().getHeader("X-UPSTREAM-ENDPOINT"));
             assertEquals("modelKey", captured.get().getHeader("X-UPSTREAM-KEY"));
         }
     }

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -206,7 +206,7 @@
       "type": "chat",
       "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
       "upstreams": [
-        {"key": "modelKey", "id": "messages-upstream"}
+        {"endpoint": "http://messages-upstream/v1/messages", "key": "modelKey", "id": "messages-upstream"}
       ]
     },
     "claude-no-iface": {


### PR DESCRIPTION
### Applicable issues

-

### Description of changes

- propagate Upstream.endpoint as x-upstream-endpoint header to support pass-through calls to Azure Foundry Anthropic models

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
