### PR TITLE
fix: expose dynamically_registered in toolset listing response

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/ResourceAuthSettingsData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ResourceAuthSettingsData.java
@@ -29,6 +29,7 @@ public class ResourceAuthSettingsData {
     private ResourceAuthStatus appLevelAuthStatus;
     private ResourceAuthStatus userLevelAuthStatus;
     private List<String> scopesSupported;
+    private Boolean dynamicallyRegistered;
 
     @JsonIgnore
     public static ResourceAuthSettingsData toData(ResourceAuthSettings toolsetAuthSettings) {
@@ -44,6 +45,7 @@ public class ResourceAuthSettingsData {
             .appLevelAuthStatus(toolsetAuthSettings.getAppLevelAuthStatus())
             .userLevelAuthStatus(toolsetAuthSettings.getUserLevelAuthStatus())
             .scopesSupported(toolsetAuthSettings.getScopesSupported())
+            .dynamicallyRegistered(toolsetAuthSettings.getDynamicallyRegistered())
             .build();
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetRepairApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetRepairApiTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ToolSetRepairApiTest extends ResourceBaseTest {
 
@@ -374,6 +375,40 @@ public class ToolSetRepairApiTest extends ResourceBaseTest {
                     "/v1/ops/toolset/" + userBucket + "/toolset-repair-priv@/repair",
                     null, null, "authorization", "admin");
             verify(repair, 403);
+        }
+    }
+
+    @Test
+    void testDynamicallyRegisteredFieldPresentInListing() throws Exception {
+        try (TestWebServer server = new TestWebServer(9876)) {
+            setupDiscovery(server);
+            server.map(HttpMethod.POST, "/register",
+                    200, REGISTRATION_RESPONSE_JSON, "Content-Type", "application/json");
+
+            createDcrToolset("toolset-dcr-listing@");
+
+            Response listing = send(HttpMethod.GET, "/openai/toolsets",
+                    null, null, "authorization", "admin");
+            assertEquals(200, listing.status(), listing.body());
+
+            JsonNode data = ProxyUtil.MAPPER.readTree(listing.body()).get("data");
+            assertNotNull(data, "data array must be present");
+
+            JsonNode toolset = null;
+            for (JsonNode item : data) {
+                if (("toolsets/" + ADMIN_BUCKET + "/toolset-dcr-listing@").equals(item.path("id").asText())) {
+                    toolset = item;
+                    break;
+                }
+            }
+            assertNotNull(toolset, "toolset-dcr-listing@ must appear in /openai/toolsets listing");
+
+            JsonNode authSettings = toolset.get("auth_settings");
+            assertNotNull(authSettings, "auth_settings must be present");
+            assertTrue(authSettings.has("dynamically_registered"),
+                    "dynamically_registered must be present in auth_settings, got: " + authSettings);
+            assertEquals(true, authSettings.get("dynamically_registered").asBoolean(),
+                    "dynamically_registered must be true for a DCR toolset");
         }
     }
 }


### PR DESCRIPTION
### Applicable issues

- fixes #1704

### Description of changes

`ResourceAuthSettingsData.toData()` did not copy the `dynamicallyRegistered` field from `ResourceAuthSettings`, so it was never included in the `GET /openai/toolsets` response. Frontend clients need this field to determine whether a toolset is eligible for the repair endpoint (`POST /v1/ops/toolset/{bucket}/{path}/repair`).

Added the field to the DTO and its mapping in `toData()`. For legacy toolsets where the flag is `null`, the field is omitted (`@JsonInclude(NON_NULL)`).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
