### PR TITLE
fix: preserve dynamically_registered on DCR toolset update when client_secret absent

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -70,6 +70,12 @@ public class ResourceAuthSettingsService {
                 && existingResource.getAuthSettings() != null) {
             ResourceAuthSettings existingResourceAuthSettings = existingResource.getAuthSettings();
 
+            // Capture before clientSecret is filled in from existing: only a PUT that explicitly
+            // supplies both clientId and clientSecret signals intentional DCR→static conversion.
+            // GET never returns clientSecret, so an update without it must preserve the flag.
+            boolean explicitlyConvertingToStatic = resourceAuthSettings.getClientId() != null
+                    && resourceAuthSettings.getClientSecret() != null;
+
             // do not re-write clientSecret with null values
             if (resourceAuthSettings.getClientSecret() == null) {
                 resourceAuthSettings.setClientSecret(existingResourceAuthSettings.getClientSecret());
@@ -82,12 +88,6 @@ public class ResourceAuthSettingsService {
 
             resolveCodeChallengeSettings(resourceAuthSettings, existingResourceAuthSettings);
 
-            // Preserve dynamicallyRegistered; re-derive to false only when the PUT explicitly supplies
-            // both clientId and clientSecret — i.e. the caller is intentionally converting a DCR toolset
-            // to a static one. When clientSecret is absent (GET never returns it), the caller is just
-            // editing other fields of an existing DCR toolset and must not lose the flag.
-            boolean explicitlyConvertingToStatic = resourceAuthSettings.getClientId() != null
-                    && resourceAuthSettings.getClientSecret() != null;
             if (explicitlyConvertingToStatic && Boolean.TRUE.equals(existingResourceAuthSettings.getDynamicallyRegistered())) {
                 resourceAuthSettings.setDynamicallyRegistered(false);
             } else {

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -82,8 +82,13 @@ public class ResourceAuthSettingsService {
 
             resolveCodeChallengeSettings(resourceAuthSettings, existingResourceAuthSettings);
 
-            // Preserve dynamicallyRegistered; re-derive to false when update explicitly supplies clientId
-            if (!requiresDynamicClientRegistration && Boolean.TRUE.equals(existingResourceAuthSettings.getDynamicallyRegistered())) {
+            // Preserve dynamicallyRegistered; re-derive to false only when the PUT explicitly supplies
+            // both clientId and clientSecret — i.e. the caller is intentionally converting a DCR toolset
+            // to a static one. When clientSecret is absent (GET never returns it), the caller is just
+            // editing other fields of an existing DCR toolset and must not lose the flag.
+            boolean explicitlyConvertingToStatic = resourceAuthSettings.getClientId() != null
+                    && resourceAuthSettings.getClientSecret() != null;
+            if (explicitlyConvertingToStatic && Boolean.TRUE.equals(existingResourceAuthSettings.getDynamicallyRegistered())) {
                 resourceAuthSettings.setDynamicallyRegistered(false);
             } else {
                 resourceAuthSettings.setDynamicallyRegistered(existingResourceAuthSettings.getDynamicallyRegistered());

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsServiceTest.java
@@ -325,6 +325,38 @@ class ResourceAuthSettingsServiceTest {
     }
 
     @Test
+    void testProcessResourceAuthSettings_DcrToolsetUpdate_WithClientIdButNoSecret_PreservesDynamicallyRegistered() {
+        // Frontend echoes back client_id (returned by GET) but no client_secret (never returned).
+        // dynamically_registered must NOT be reset to false — the toolset is still DCR.
+        ToolSet updatedToolSet = createOauthToolSet("dcr-client-id", null);
+        ToolSet existingToolSet = createOauthToolSet("dcr-client-id", "encrypted-client-secret");
+        existingToolSet.getAuthSettings().setDynamicallyRegistered(true);
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        assertEquals(Boolean.TRUE, updatedToolSet.getAuthSettings().getDynamicallyRegistered());
+        verify(resourceRegistrationService, never()).register(any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    void testProcessResourceAuthSettings_DcrToolsetConvertedToStatic_SetsDynamicallyRegisteredFalse() {
+        // Admin explicitly provides both client_id and client_secret → converting DCR to static.
+        // dynamically_registered must be set to false.
+        ToolSet updatedToolSet = createOauthToolSet("static-client-id", "static-client-secret");
+        ToolSet existingToolSet = createOauthToolSet("dcr-client-id", "encrypted-dcr-secret");
+        existingToolSet.getAuthSettings().setDynamicallyRegistered(true);
+
+        when(validatorFactory.getValidator(AuthenticationType.OAUTH)).thenReturn(oauthAuthSettingsValidator);
+
+        resourceAuthSettingsService.processResourceAuthSettings(updatedToolSet, existingToolSet);
+
+        assertEquals(Boolean.FALSE, updatedToolSet.getAuthSettings().getDynamicallyRegistered());
+        verify(resourceRegistrationService, never()).register(any(), any(), any(), anyBoolean());
+    }
+
+    @Test
     void testProcessResourceAuthSettings_OauthUpdate_TokenEndpointAuthMethodNull_PreservesExisting() {
         ToolSet updatedToolSet = createOauthToolSetWithTokenEndpointAuthMethod("clientId", "clientSecret", null);
         ToolSet existingToolSet = createOauthToolSetWithTokenEndpointAuthMethod("clientId", "clientSecret",


### PR DESCRIPTION
### Applicable issues

- fixes [#7700](https://github.com/epam/ai-dial-chat/issues/7700)

### Description of changes

When the frontend calls `GET /openai/toolsets`, the response includes `client_id` in `auth_settings` but never `client_secret` (stripped before serialization). When the user edits a DCR toolset and the frontend PUTs the toolset back, it echoes `client_id` without `client_secret`.

`processResourceAuthSettings` checks `requiresDynamicClientRegistration` (= `client_id == null && client_secret == null`) to decide whether to reset `dynamically_registered` to `false`. Since `client_id` is present, `requiresDynamicClientRegistration` was `false`, and the flag was incorrectly reset — making the toolset appear ineligible for repair on the next GET.

**Fix**: only reset `dynamically_registered` to `false` when both `client_id` and `client_secret` are present in the PUT body. Providing both is the genuine signal that the caller intends to convert a DCR toolset to a static one. A PUT with `client_id` but no `client_secret` is a regular update of an existing DCR toolset and must preserve the flag.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.