### PR TITLE
feat: propagate x-dial-deployment-id header for anthropic messages

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -269,9 +269,19 @@ public class BaseDeploymentPostController {
             });
         }
 
+        enrichProxyRequestHeaders(proxyRequest);
+
         proxyRequest.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(context.getRequestBody().length()));
 
         return proxyRequest.send(context.getRequestBody());
+    }
+
+    /**
+     * Hook for route-specific headers. Invoked after the client headers have been copied, so anything set
+     * here replaces the value a client may have sent under the same name.
+     */
+    protected void enrichProxyRequestHeaders(HttpClientRequest proxyRequest) {
+        // no additional headers by default
     }
 
     protected boolean isRetriableError(int statusCode) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -48,6 +48,13 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
 
     protected final List<BaseRequestFunction<RequestObject>> enhancementFunctions;
 
+    /**
+     * The {@code model} value as it arrived in the request body, i.e. the DIAL deployment id. Captured before
+     * {@link EnhanceModelRequestFn} rewrites the body model to the deployment's {@code overrideName}, and
+     * forwarded upstream as {@link Proxy#HEADER_DEPLOYMENT_ID}.
+     */
+    private String deploymentId;
+
     protected MessagesBaseController(Proxy proxy, ProxyContext context) {
         super(proxy, context);
         this.enhancementFunctions = List.of(
@@ -67,6 +74,7 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
                 .map(MessagesBaseController::parseBody)
                 .compose(request -> {
                     String model = request.getModel();
+                    deploymentId = model;
                     return proxy.getTaskExecutor().submit(() -> setupDeployment(model))
                             .compose(ignore -> verifyLimit())
                             .compose(ignore -> proxy.getTokenStatsTracker().startSpan(context)
@@ -178,6 +186,15 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
         sendProxyRequest(proxyRequest, Upstream::getEndpoint)
                 .onSuccess(this::handleProxyResponse)
                 .onFailure(this::handleProxyResponseError);
+    }
+
+    /**
+     * The body's {@code model} may have been replaced by {@code overrideName}, so the deployment id is
+     * carried to the adapter out of band.
+     */
+    @Override
+    protected void enrichProxyRequestHeaders(HttpClientRequest proxyRequest) {
+        proxyRequest.putHeader(Proxy.HEADER_DEPLOYMENT_ID, deploymentId);
     }
 
     private void handleProxyResponse(HttpClientResponse proxyResponse) {

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -185,6 +185,61 @@ public class MessagesApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testDeploymentIdHeaderCarriesRequestedModel() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            // a client-supplied value must not survive: the header is set by the core, not forwarded
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-ns", false),
+                    "api-key", "proxyKey1", "X-DIAL-DEPLOYMENT-ID", "spoofed");
+
+            assertEquals(200, response.status());
+            assertEquals("claude-ns", captured.get().getHeader("X-DIAL-DEPLOYMENT-ID"));
+        }
+    }
+
+    @Test
+    public void testDeploymentIdHeaderKeepsRequestedModelWhenOverrideNameApplied() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-override", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            RecordedRequest upstream = captured.get();
+            // the header keeps the DIAL deployment id ...
+            assertEquals("claude-override", upstream.getHeader("X-DIAL-DEPLOYMENT-ID"));
+            // ... while the body model is rewritten to the provider-side name
+            assertTrue(upstream.getBody().readUtf8().contains("\"model\":\"claude-sonnet-4-5-20250929\""));
+            assertEquals("claude-sonnet-4-5-20250929", upstream.getHeader("X-DIAL-OVERRIDE-NAME"));
+        }
+    }
+
+    @Test
+    public void testCountTokensSendsDeploymentIdHeader() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, COUNT_TOKENS_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, "{\"input_tokens\":5}", "Content-Type", "application/json");
+            });
+
+            Response response = post(client, COUNT_TOKENS_PATH, requestBody("claude-count", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            assertEquals("claude-count", captured.get().getHeader("X-DIAL-DEPLOYMENT-ID"));
+        }
+    }
+
+    @Test
     public void testUnsupportedInterfaceReturns503() throws IOException {
         try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
             Response response = post(client, MESSAGES_PATH, requestBody("claude-no-iface", false), "api-key", "proxyKey1");

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -209,6 +209,11 @@
         {"endpoint": "http://messages-upstream/v1/messages", "key": "modelKey", "id": "messages-upstream"}
       ]
     },
+    "claude-override": {
+      "type": "chat",
+      "overrideName": "claude-sonnet-4-5-20250929",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
     "claude-no-iface": {
       "type": "chat",
       "endpoint": "http://localhost:4848/v1/chat/completions"
@@ -299,6 +304,7 @@
         "claude-xapikey": {"minute": "100000", "day": "10000000"},
         "claude-limited": {"minute": "10", "day": "10"},
         "claude-upstream": {"minute": "100000", "day": "10000000"},
+        "claude-override": {"minute": "100000", "day": "10000000"},
         "claude-no-iface": {"minute": "100000", "day": "10000000"}
       }
     },


### PR DESCRIPTION
### Applicable issues

-

### Description of changes

- propagate the requested DIAL deployment id as `X-DIAL-DEPLOYMENT-ID` header for `/anthropic/v1/messages` and `/anthropic/v1/messages/count_tokens` pass-through calls, so upstream adapters/translators can recover the original deployment id after the body's `model` is rewritten to the provider's `overrideName`

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.