### PR TITLE
fix: propagate interfaces config into deployment features

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -356,10 +356,8 @@ public class ApplicationController {
         data.setIconUrl(application.getIconUrl());
         data.setDescription(application.getDescription());
         data.setIntro(application.getIntro());
-        FeaturesData featuresData = FeaturesData.createFeatures(application.getFeatures());
+        FeaturesData featuresData = FeaturesData.createDeploymentFeatures(application);
         featuresData.setMcp(application.getMcp() != null);
-        featuresData.setChatCompletion(application.getEndpoint() != null);
-        featuresData.setResponsesApi(application.getResponsesEndpoint() != null);
         data.setFeatures(featuresData);
         data.setInputAttachmentTypes(application.getInputAttachmentTypes());
         data.setMaxInputAttachments(application.getMaxInputAttachments());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ModelController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ModelController.java
@@ -99,10 +99,7 @@ public class ModelController {
         data.setIconUrl(model.getIconUrl());
         data.setDescription(model.getDescription());
         data.setIntro(model.getIntro());
-        FeaturesData featuresData = FeaturesData.createFeatures(model.getFeatures());
-        featuresData.setChatCompletion(model.getEndpoint() != null);
-        featuresData.setResponsesApi(model.getResponsesEndpoint() != null);
-        data.setFeatures(featuresData);
+        data.setFeatures(FeaturesData.createDeploymentFeatures(model));
         data.setInputAttachmentTypes(model.getInputAttachmentTypes());
         data.setMaxInputAttachments(model.getMaxInputAttachments());
         data.setReference(model.getName());

--- a/server/src/main/java/com/epam/aidial/core/server/data/ApplicationData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ApplicationData.java
@@ -70,7 +70,7 @@ public class ApplicationData extends DeploymentData {
         data.setIconUrl(application.getIconUrl());
         data.setDescription(application.getDescription());
         data.setIntro(application.getIntro());
-        data.setFeatures(FeaturesData.createFeatures(application.getFeatures()));
+        data.setFeatures(FeaturesData.createDeploymentFeatures(application));
         data.setInputAttachmentTypes(application.getInputAttachmentTypes());
         data.setMaxInputAttachments(application.getMaxInputAttachments());
         data.setDefaults(application.getDefaults());

--- a/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/FeaturesData.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.core.server.data;
 
+import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.Features;
+import com.epam.aidial.core.config.InterfaceType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -38,6 +40,19 @@ public class FeaturesData {
     private boolean maxCompletionTokensSupported = false;
     private boolean customTemperatureSupported = true;
     private List<String> reasoningEfforts = List.of();
+
+    /**
+     * Features of a deployment: the configured {@link Features} plus the API-surface flags derived from the
+     * deployment itself. A deployment serves an API when it declares it either in the {@code interfaces} map
+     * or via a legacy endpoint, so both flavours must light up the corresponding feature flag.
+     */
+    @JsonIgnore
+    public static FeaturesData createDeploymentFeatures(Deployment deployment) {
+        FeaturesData data = createFeatures(deployment.getFeatures());
+        data.setChatCompletion(deployment.supportsInterface(InterfaceType.OPENAI_CHAT_COMPLETIONS));
+        data.setResponsesApi(deployment.supportsInterface(InterfaceType.OPENAI_RESPONSES));
+        return data;
+    }
 
     @JsonIgnore
     public static FeaturesData createFeatures(Features features) {

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentApiTest extends ResourceBaseTest {
 
@@ -78,6 +80,43 @@ public class DeploymentApiTest extends ResourceBaseTest {
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
         assertEquals(1, body.size());
+    }
+
+    @DialConfigLocation("dial-config/deployment-interfaces-features.json")
+    @Test
+    public void testChatCompletionFeatureFollowsInterfaces() throws JsonProcessingException {
+        Map<String, JsonNode> deployments = collectFeatures(send(HttpMethod.GET, "/v1/deployments", null, null));
+        assertTrue(deployments.get("model-iface-only").get("chat_completion").asBoolean());
+        assertTrue(deployments.get("model-iface-only").get("responses_api").asBoolean());
+        assertTrue(deployments.get("app-iface-only").get("chat_completion").asBoolean());
+        assertTrue(deployments.get("app-legacy").get("chat_completion").asBoolean());
+        // anthropicMessages alone does not make the deployment an OpenAI chat-completions one
+        assertFalse(deployments.get("model-anthropic-only").get("chat_completion").asBoolean());
+
+        Map<String, JsonNode> models = collectFeatures(send(HttpMethod.GET, "/openai/models", null, null));
+        assertTrue(models.get("model-iface-only").get("chat_completion").asBoolean());
+        assertTrue(models.get("model-iface-only").get("responses_api").asBoolean());
+        assertFalse(models.get("model-anthropic-only").get("chat_completion").asBoolean());
+
+        Map<String, JsonNode> applications = collectFeatures(send(HttpMethod.GET, "/openai/applications", null, null));
+        assertTrue(applications.get("app-iface-only").get("chat_completion").asBoolean());
+        assertTrue(applications.get("app-legacy").get("chat_completion").asBoolean());
+    }
+
+    /**
+     * Maps deployment id to its {@code features} object. Handles both the bare array returned by
+     * {@code /v1/deployments} and the {@code {"data": [...]}} envelope of the legacy listings.
+     */
+    private static Map<String, JsonNode> collectFeatures(Response response) throws JsonProcessingException {
+        verify(response, 200);
+        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode deployments = body.isArray() ? body : body.get("data");
+
+        Map<String, JsonNode> result = new HashMap<>();
+        for (JsonNode deployment : deployments) {
+            result.put(deployment.get("id").asText(), deployment.get("features"));
+        }
+        return result;
     }
 
     private static Map<String, Set<String>> collectInterfaces(JsonNode body) {

--- a/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
@@ -135,6 +135,40 @@ public class ListingTest extends ResourceBaseTest {
                 """));
     }
 
+    @Test
+    void testFeaturesModelInterfacesOnly(Vertx vertx, VertxTestContext context) {
+        checkListing(vertx, context, "/openai/models", "model-iface-only", "features", new JsonObject("""
+                    { "rate": false, "tokenize": false, "truncate_prompt": false
+                    , "system_prompt": true, "tools": false, "seed": false
+                    , "url_attachments": false, "folder_attachments": false
+                    , "configuration": false, "allow_resume": true, "accessible_by_per_request_key": true,
+                    "content_parts": false, "temperature" : true, "cache" : false,
+                    "auto_caching" : false, "parallel_tool_calls": true,
+                    "assistant_attachments_in_request": false, "mcp" : false,
+                    "chat_completion": true, "responses_api": true,
+                    "max_tokens_supported": true, "max_completion_tokens_supported": false,
+                    "custom_temperature_supported": true, "reasoning_efforts": []
+                    }
+                """));
+    }
+
+    @Test
+    void testFeaturesModelAnthropicInterfaceOnly(Vertx vertx, VertxTestContext context) {
+        checkListing(vertx, context, "/openai/models", "claude-ns", "features", new JsonObject("""
+                    { "rate": false, "tokenize": false, "truncate_prompt": false
+                    , "system_prompt": true, "tools": false, "seed": false
+                    , "url_attachments": false, "folder_attachments": false
+                    , "configuration": false, "allow_resume": true, "accessible_by_per_request_key": true,
+                    "content_parts": false, "temperature" : true, "cache" : false,
+                    "auto_caching" : false, "parallel_tool_calls": true,
+                    "assistant_attachments_in_request": false, "mcp" : false,
+                    "chat_completion": false, "responses_api": false,
+                    "max_tokens_supported": true, "max_completion_tokens_supported": false,
+                    "custom_temperature_supported": true, "reasoning_efforts": []
+                    }
+                """));
+    }
+
     void checkResponse(Vertx vertx, VertxTestContext context, String uri, Consumer<String> checker) {
         WebClient client = WebClient.create(vertx);
         client.get(serverPort, "localhost", uri)

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -182,6 +182,14 @@
         {"endpoint": "http://chat/completions", "responsesEndpoint": "http://responses", "key": "modelKey", "id": "responses-upstream"}
       ]
     },
+    "model-iface-only": {
+      "type": "chat",
+      "displayName": "Model configured via interfaces only",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "http://localhost:4848"},
+        "openaiResponses": {"base_url": "http://localhost:4848"}
+      }
+    },
     "claude-ns": {
       "type": "chat",
       "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }

--- a/server/src/test/resources/dial-config/deployment-interfaces-features.json
+++ b/server/src/test/resources/dial-config/deployment-interfaces-features.json
@@ -1,0 +1,35 @@
+{
+  "applications": {
+    "app-iface-only": {
+      "displayName": "App configured via interfaces only",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "http://localhost:7001"}
+      }
+    },
+    "app-legacy": {
+      "endpoint": "http://localhost:7001/openai/deployments/app-legacy/chat/completions",
+      "displayName": "App configured via legacy endpoint"
+    }
+  },
+  "models": {
+    "model-iface-only": {
+      "type": "chat",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "http://localhost:7001"},
+        "openaiResponses": {"base_url": "http://localhost:7001"}
+      }
+    },
+    "model-anthropic-only": {
+      "type": "chat",
+      "interfaces": {
+        "anthropicMessages": {"base_url": "http://localhost:7001"}
+      }
+    }
+  },
+  "keys": {
+    "proxyKey1": {
+      "project": "EPM-RTC-GPT",
+      "role": "default"
+    }
+  }
+}


### PR DESCRIPTION
### Applicable issues

-
### Description of changes

- derive `features.chat_completion` and `features.responses_api` from `Deployment.supportsInterface(...)` instead of the legacy `endpoint`/`responsesEndpoint` fields only, so deployments configured purely via `interfaces.openaiChatCompletions` / `interfaces.openaiResponses` report the corresponding feature as `true` (DIAL Chat previously refused such models, claiming they have no chat completions endpoint)
- add `FeaturesData.createDeploymentFeatures(Deployment)` and route all three listing paths through it: `ModelController.createModel` (`/openai/models`, models in `/v1/deployments`), `ApplicationController.mapApplication` (`/openai/applications`) and `ApplicationData.mapApplication` (applications in `/v1/deployments`, which did not set the flags at all)
- toolsets keep using `createFeatures(Features)`: a toolset `endpoint` is its MCP endpoint and must not be reported as chat completions
- tests: interfaces-only model/application fixtures covering `/v1/deployments`, `/openai/models` and `/openai/applications`, plus a guard that `anthropicMessages` alone does not set `chat_completion`

### Checklist

- [x] Title of the pull request                                                                 follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
