### PR TITLE
fix: upstreams might be set to null in ApplicationController #1713

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -338,8 +338,16 @@ public class ApplicationController {
         return accessService.hasAdminAccess(context);
     }
 
-    private static void clearUpstreams(Map<String, Route> routes) {
-        routes.forEach((name, route) -> route.setUpstreams(null));
+    // Routes may reference live Route instances shared with the Config (e.g. used for actual request routing),
+    // so upstreams must be cleared on copies rather than mutating the shared objects in place.
+    private static Map<String, Route> clearUpstreams(Map<String, Route> routes) {
+        Map<String, Route> copy = new LinkedHashMap<>();
+        routes.forEach((name, route) -> {
+            Route routeCopy = ProxyUtil.MAPPER.convertValue(route, Route.class);
+            routeCopy.setUpstreams(null);
+            copy.put(name, routeCopy);
+        });
+        return copy;
     }
 
     private ApplicationData mapApplication(Application application) {
@@ -392,7 +400,7 @@ public class ApplicationController {
             routes = application.getRoutes();
         }
         if (!hasWriteAccess(application) && routes != null) {
-            clearUpstreams(routes);
+            routes = clearUpstreams(routes);
         }
         data.setRoutes(routes);
         data.setViewerUrl(application.getViewerUrl());

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationRouteApiTest.java
@@ -40,6 +40,44 @@ public class ApplicationRouteApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testRouteStillWorksAfterUpstreamsHiddenInList() throws Exception {
+        // Non-admin caller lists the statically-configured app-route application - upstreams must be hidden
+        Response response = send(HttpMethod.GET, "/openai/applications/app-route");
+        Assertions.assertEquals(200, response.status());
+        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode routes = body.get("routes");
+        Assertions.assertNotNull(routes, "routes must be present");
+        Assertions.assertTrue(routes.get("index-search").path("upstreams").isMissingNode(),
+                "upstreams must be hidden for non-admin caller");
+
+        // The live Route config must not be corrupted by the listing above - the actual route request must still work
+        String responseBody = """
+                {
+                 "content": "some result",
+                 "attachments": "file1"
+                }
+                """;
+        try (TestWebServer server = new TestWebServer(4848)) {
+            TestWebServer.Handler handler = request -> {
+                MockResponse mockResponse = new MockResponse();
+                mockResponse.setResponseCode(200);
+                mockResponse.setBody(responseBody);
+                return mockResponse;
+            };
+            server.map(HttpMethod.POST, "/v1/index/search", handler);
+
+            String requestBody = """
+                    {
+                     "payload": "some content"
+                    }
+                    """;
+            Response routeResponse = send(HttpMethod.POST, "/v1/deployments/app-route/route/v1/index/search", null, requestBody);
+
+            verify(routeResponse, 200, responseBody);
+        }
+    }
+
+    @Test
     public void testAppRoute() {
         Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my%20custom%20application", null, """
                 {


### PR DESCRIPTION
Fixes a NullPointerException in `TieredBalancer.buildTiers` that occurred after listing/getting statically-configured DIAL Config applications, then routing a chat completion or application route request through them.

### Applicable issues

- fixes #1713

### Description of changes

- `ApplicationController.clearUpstreams` previously mutated the live, shared `Route` objects from `Config` in place, permanently nulling their `upstreams` field once any non-privileged caller listed/viewed a statically-configured application. Since those same `Route` instances are used for actual request routing (`UpstreamRouteProvider` → `TieredBalancer`), this broke routing for everyone until the config was reloaded.
- `clearUpstreams` now returns a new map of deep-copied `Route` objects with `upstreams` cleared on the copies, leaving the shared config untouched.
- Added a regression test (`ApplicationRouteApiTest.testRouteStillWorksAfterUpstreamsHiddenInList`) that lists a static app as a non-admin user and then verifies a subsequent live route request still succeeds.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.