### PR TITLE
fix: toolset marked as logged in after invalid API key auth #1698

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -251,7 +251,7 @@ public class AiDial {
             AuthSettingsResolver authSettingsResolver = new AuthSettingsResolver(
                     encryptionService, resourceAuthSettingsEncryptionService);
             ToolSetService toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
-                    resourceAuthSettingsEncryptionService, resourceCredentialsService);
+                    resourceAuthSettingsEncryptionService, resourceCredentialsService, ToolSetService.DEFAULT_MCP_PROBE_TIMEOUT_MILLIS);
             ToolSetRepairService toolSetRepairService = new ToolSetRepairService(resourceService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService,
                     resourceRegistrationService, resourceAuthSettingsService);

--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -251,7 +251,7 @@ public class AiDial {
             AuthSettingsResolver authSettingsResolver = new AuthSettingsResolver(
                     encryptionService, resourceAuthSettingsEncryptionService);
             ToolSetService toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
-                    resourceAuthSettingsEncryptionService, resourceCredentialsService, ToolSetService.DEFAULT_MCP_PROBE_TIMEOUT_MILLIS);
+                    resourceAuthSettingsEncryptionService, resourceCredentialsService);
             ToolSetRepairService toolSetRepairService = new ToolSetRepairService(resourceService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService,
                     resourceRegistrationService, resourceAuthSettingsService);

--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -60,6 +60,7 @@ import com.epam.aidial.core.server.service.PublicationUtil;
 import com.epam.aidial.core.server.service.ResourceOperationService;
 import com.epam.aidial.core.server.service.ResponseMappingService;
 import com.epam.aidial.core.server.service.RuleService;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.service.ToolSetRepairService;
 import com.epam.aidial.core.server.service.ToolSetService;
@@ -252,6 +253,7 @@ public class AiDial {
                     encryptionService, resourceAuthSettingsEncryptionService);
             ToolSetService toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService);
+            SecuredResourceService securedResourceService = new SecuredResourceService(resourceCredentialsService);
             ToolSetRepairService toolSetRepairService = new ToolSetRepairService(resourceService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService,
                     resourceRegistrationService, resourceAuthSettingsService);
@@ -313,7 +315,8 @@ public class AiDial {
                     shareService, publicationService, accessService, lockService, resourceOperationService, ruleService,
                     notificationService, applicationService, externalServiceService, userExternalServiceService, codeInterpreterService, heartbeatService, upstreamCacheService,
                     consentService, deploymentService, healthCheckController, wellKnownResourceMetadataService, resourceMetadataController,
-                    toolSetService, toolSetRepairService, applicationSchemaService, authorizationHeaderProvider, resourceAuthSettingsService, resourceCredentialsService,
+                    toolSetService, securedResourceService, toolSetRepairService, applicationSchemaService, authorizationHeaderProvider,
+                    resourceAuthSettingsService, resourceCredentialsService,
                     perRequestPermissionService, resourceAuthSettingsEncryptionService, authSettingsResolver, clientChannelService, taskExecutor, version(),
                     responseMappingService, complexResourceService, generator);
 

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -33,6 +33,7 @@ import com.epam.aidial.core.server.service.PublicationService;
 import com.epam.aidial.core.server.service.ResourceOperationService;
 import com.epam.aidial.core.server.service.ResponseMappingService;
 import com.epam.aidial.core.server.service.RuleService;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.service.ToolSetRepairService;
 import com.epam.aidial.core.server.service.ToolSetService;
@@ -159,6 +160,7 @@ public class Proxy implements Handler<HttpServerRequest> {
     private final WellKnownResourceMetadataService resourceMetadataService;
     private final WellKnownResourceMetadataController resourceMetadataController;
     private final ToolSetService toolSetService;
+    private final SecuredResourceService securedResourceService;
     private final ToolSetRepairService toolSetRepairService;
     private final ApplicationSchemaService applicationSchemaService;
     private final AuthorizationHeaderProvider authorizationHeaderProvider;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
@@ -6,15 +6,11 @@ import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.SecuredResource;
-import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
-import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
-import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
 import com.epam.aidial.core.credentials.exception.EncryptionException;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
-import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.openapi.annotations.ApiOperation;
 import com.epam.aidial.core.openapi.annotations.ApiResponse;
 import com.epam.aidial.core.openapi.annotations.ApiSchema;
@@ -24,8 +20,7 @@ import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
-import com.epam.aidial.core.server.service.ToolSetService;
-import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.server.validation.ValidationUtil;
@@ -34,8 +29,6 @@ import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
-import com.epam.aidial.core.storage.resource.ResourceType;
-import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
 import jakarta.validation.ConstraintViolationException;
@@ -50,12 +43,11 @@ public class ResourceCredentialsController {
 
     private final ProxyContext context;
     private final AsyncTaskExecutor taskExecutor;
-    private final ResourceCredentialsService resourceCredentialsService;
     private final AccessService accessService;
     private final EncryptionService encryptionService;
     private final DeploymentService deploymentService;
     private final ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService;
-    private final ToolSetService toolSetService;
+    private final SecuredResourceService securedResourceService;
 
     public ResourceCredentialsController(Proxy proxy, ProxyContext context) {
         this.context = context;
@@ -63,9 +55,8 @@ public class ResourceCredentialsController {
         this.accessService = proxy.getAccessService();
         this.encryptionService = proxy.getEncryptionService();
         this.deploymentService = proxy.getDeploymentService();
-        this.resourceCredentialsService = proxy.getResourceCredentialsService();
         this.resourceAuthSettingsEncryptionService = proxy.getResourceAuthSettingsEncryptionService();
-        this.toolSetService = proxy.getToolSetService();
+        this.securedResourceService = proxy.getSecuredResourceService();
     }
 
     @ApiOperation(
@@ -102,16 +93,7 @@ public class ResourceCredentialsController {
                                 decryptAuthSettings(encodedResourceUrl, resourceAuthSettings);
                             }
 
-                            if (securedResource instanceof ToolSet toolSet
-                                    && AuthenticationType.API_KEY.equals(resourceSignInRequest.getAuthenticationType())) {
-                                toolSetService.validateApiKey(toolSet, resourceAuthSettings, resourceSignInRequest.getApiKey());
-                            }
-
-                            ResourceType resourceType = resolveResourceType(securedResource);
-                            CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceUrl, context, resourceType);
-                            CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(credentialsLevel);
-                            resourceCredentialsService.addResourceCredentials(credentialsDescriptor, resourceAuthSettings,
-                                    resourceSignInRequest, context.getInitiatorId());
+                            securedResourceService.signIn(context, securedResource, resourceSignInRequest);
                             return true;
                         }
                         throw new ResourceNotFoundException("Resource is not found: " + resourceId);
@@ -159,12 +141,7 @@ public class ResourceCredentialsController {
                         verifyAccess(encodedResourceId, credentialsLevel);
                     }
 
-                    ResourceType resourceType = resolveResourceType(securedResource);
-                    CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceId, context, resourceType);
-                    return resourceCredentialsService.deleteResourceCredentials(
-                            credentialsLocator,
-                            resourceSignOutRequest,
-                            context.getInitiatorId());
+                    return securedResourceService.signOut(context, securedResource, resourceSignOutRequest);
                 }))
                 .onSuccess(removed -> context.respond(HttpStatus.OK, removed))
                 .onFailure(error ->
@@ -212,13 +189,6 @@ public class ResourceCredentialsController {
             throw new IllegalArgumentException("Wrong authentication_type. Expected type: %s, provided: %s"
                     .formatted(resourceAuthenticationType, requestAuthenticationType));
         }
-    }
-
-    private ResourceType resolveResourceType(SecuredResource resource) {
-        if (resource instanceof ToolSet) {
-            return ResourceTypes.TOOL_SET;
-        }
-        throw new IllegalArgumentException("Unsupported secured resource type: " + resource.getClass().getSimpleName());
     }
 
     private void respondError(String message, Throwable error) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
@@ -7,7 +7,6 @@ import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.SecuredResource;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
-import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
@@ -23,6 +22,7 @@ import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
+import com.epam.aidial.core.server.service.ToolSetService;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
@@ -52,6 +52,7 @@ public class ResourceCredentialsController {
     private final EncryptionService encryptionService;
     private final DeploymentService deploymentService;
     private final ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService;
+    private final ToolSetService toolSetService;
 
     public ResourceCredentialsController(Proxy proxy, ProxyContext context) {
         this.context = context;
@@ -61,6 +62,7 @@ public class ResourceCredentialsController {
         this.deploymentService = proxy.getDeploymentService();
         this.resourceCredentialsService = proxy.getResourceCredentialsService();
         this.resourceAuthSettingsEncryptionService = proxy.getResourceAuthSettingsEncryptionService();
+        this.toolSetService = proxy.getToolSetService();
     }
 
     @ApiOperation(
@@ -96,11 +98,8 @@ public class ResourceCredentialsController {
                                 verifyAccess(encodedResourceUrl, credentialsLevel);
                                 decryptAuthSettings(encodedResourceUrl, resourceAuthSettings);
                             }
-                            
-                            CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceUrl, context, ResourceTypes.TOOL_SET);
-                            CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(resourceSignInRequest.getCredentialsLevel());
-                            resourceCredentialsService.addResourceCredentials(credentialsDescriptor, resourceAuthSettings,
-                                    resourceSignInRequest, context.getInitiatorId());
+
+                            toolSetService.signIn(context, securedResource, resourceAuthSettings, resourceSignInRequest);
                             return true;
                         }
                         throw new ResourceNotFoundException("Resource is not found: " + resourceId);

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
@@ -6,7 +6,9 @@ import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.SecuredResource;
+import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
@@ -32,6 +34,7 @@ import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.resource.ResourceType;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
@@ -99,7 +102,16 @@ public class ResourceCredentialsController {
                                 decryptAuthSettings(encodedResourceUrl, resourceAuthSettings);
                             }
 
-                            toolSetService.signIn(context, securedResource, resourceAuthSettings, resourceSignInRequest);
+                            if (securedResource instanceof ToolSet toolSet
+                                    && AuthenticationType.API_KEY.equals(resourceSignInRequest.getAuthenticationType())) {
+                                toolSetService.validateApiKey(toolSet, resourceAuthSettings, resourceSignInRequest.getApiKey());
+                            }
+
+                            ResourceType resourceType = resolveResourceType(securedResource);
+                            CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceUrl, context, resourceType);
+                            CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(credentialsLevel);
+                            resourceCredentialsService.addResourceCredentials(credentialsDescriptor, resourceAuthSettings,
+                                    resourceSignInRequest, context.getInitiatorId());
                             return true;
                         }
                         throw new ResourceNotFoundException("Resource is not found: " + resourceId);
@@ -136,19 +148,19 @@ public class ResourceCredentialsController {
                     ValidationUtil.validate(resourceSignOutRequest);
 
                     Deployment deployment = deploymentService.findDeployment(context, resourceId);
-                    if (deployment instanceof SecuredResource securedResource) {
-                        ResourceAuthSettings resourceAuthSettings = securedResource.getAuthSettings();
-                        validateAuthType(resourceAuthSettings.getAuthenticationType(), resourceSignOutRequest.getAuthenticationType());
-                        if (context.getConfig().isDeploymentExists(encodedResourceId)) {
-                            verifyAccess(securedResource, credentialsLevel);
-                        } else {
-                            verifyAccess(encodedResourceId, credentialsLevel);
-                        }
-                    } else {
+                    if (!(deployment instanceof SecuredResource securedResource)) {
                         throw new ResourceNotFoundException("Resource is not found: " + encodedResourceId);
                     }
+                    ResourceAuthSettings resourceAuthSettings = securedResource.getAuthSettings();
+                    validateAuthType(resourceAuthSettings.getAuthenticationType(), resourceSignOutRequest.getAuthenticationType());
+                    if (context.getConfig().isDeploymentExists(encodedResourceId)) {
+                        verifyAccess(securedResource, credentialsLevel);
+                    } else {
+                        verifyAccess(encodedResourceId, credentialsLevel);
+                    }
 
-                    CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceId, context, ResourceTypes.TOOL_SET);
+                    ResourceType resourceType = resolveResourceType(securedResource);
+                    CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceId, context, resourceType);
                     return resourceCredentialsService.deleteResourceCredentials(
                             credentialsLocator,
                             resourceSignOutRequest,
@@ -200,6 +212,13 @@ public class ResourceCredentialsController {
             throw new IllegalArgumentException("Wrong authentication_type. Expected type: %s, provided: %s"
                     .formatted(resourceAuthenticationType, requestAuthenticationType));
         }
+    }
+
+    private ResourceType resolveResourceType(SecuredResource resource) {
+        if (resource instanceof ToolSet) {
+            return ResourceTypes.TOOL_SET;
+        }
+        throw new IllegalArgumentException("Unsupported secured resource type: " + resource.getClass().getSimpleName());
     }
 
     private void respondError(String message, Throwable error) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -28,6 +28,7 @@ import com.epam.aidial.core.server.upstream.UpstreamRoute;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
 import com.epam.aidial.core.server.util.AuthSettingsResolver;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.util.McpClientUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
@@ -37,41 +38,24 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
-import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
-import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
 public class ToolSetToolsController implements Controller {
-
-    private static final JsonSchemaValidator NOOP_SCHEMA_VALIDATOR =
-            (Map<String, Object> schema, Object content) ->
-                    JsonSchemaValidator.ValidationResponse.asValid(null);
-
-    private static final McpJsonMapper MCP_JSON_MAPPER = createLenientMcpJsonMapper();
 
     private final String toolSetId;
     private final boolean filterAllowed;
@@ -205,7 +189,7 @@ public class ToolSetToolsController implements Controller {
 
         HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
                 .builder(upstream.getEndpoint())
-                .jsonMapper(MCP_JSON_MAPPER)
+                .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, endpoint, body, transportContext) ->
                         customizeRequest(builder, deployment))
                 .build();
@@ -213,7 +197,7 @@ public class ToolSetToolsController implements Controller {
         try (McpSyncClient client = McpClient.sync(transport)
                 .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
                 .requestTimeout(Duration.ofMillis(proxy.getClientOptions().getIdleTimeout()))
-                .jsonSchemaValidator(NOOP_SCHEMA_VALIDATOR)
+                .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
                 .build()) {
             client.initialize();
             if (filterAllowed) {
@@ -310,29 +294,6 @@ public class ToolSetToolsController implements Controller {
         ApiKeyData.initFromContext(proxyApiKeyData, context);
         apiKeyStore.assignPerRequestApiKey(proxyApiKeyData);
         return proxyApiKeyData.getPerRequestKey();
-    }
-
-    private static final String ADDITIONAL_PROPERTIES_FIELD = "additionalProperties";
-
-    private static McpJsonMapper createLenientMcpJsonMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        // JSON Schema allows `additionalProperties` to be a boolean OR a schema object,
-        // but the MCP SDK models it as Boolean. Coerce object/array values to null so a
-        // single non-conforming field does not fail the whole tools/list response (#1561).
-        mapper.addHandler(new DeserializationProblemHandler() {
-            @Override
-            public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType,
-                    JsonToken t, JsonParser p, String failureMsg) throws IOException {
-                if (targetType.hasRawClass(Boolean.class)
-                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)
-                        && ADDITIONAL_PROPERTIES_FIELD.equals(p.currentName())) {
-                    p.skipChildren();
-                    return null;
-                }
-                return super.handleUnexpectedToken(ctxt, targetType, t, p, failureMsg);
-            }
-        });
-        return new JacksonMcpJsonMapper(mapper);
     }
 
     private void handleError(Throwable error) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
@@ -1,0 +1,129 @@
+package com.epam.aidial.core.server.service;
+
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.SecuredResource;
+import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
+import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.util.McpClientUtils;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.resource.ResourceType;
+import com.epam.aidial.core.storage.resource.ResourceTypes;
+import com.epam.aidial.core.storage.util.UrlUtil;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.time.Duration;
+
+@Slf4j
+@AllArgsConstructor
+public class SecuredResourceService {
+
+    // deliberately not the client idleTimeout (5 min in production) — sign-in is interactive
+    private static final Duration MCP_PROBE_TIMEOUT = Duration.ofSeconds(20);
+
+    private final ResourceCredentialsService resourceCredentialsService;
+
+    public void signIn(ProxyContext context, SecuredResource securedResource, ResourceSignInRequest request) {
+        if (AuthenticationType.API_KEY.equals(request.getAuthenticationType())) {
+            validateApiKey(securedResource, request.getApiKey());
+        }
+        CredentialsLocator credentialsLocator = createCredentialsLocator(context, securedResource, request.getUrl());
+        CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(request.getCredentialsLevel());
+        resourceCredentialsService.addResourceCredentials(credentialsDescriptor, securedResource.getAuthSettings(),
+                request, context.getInitiatorId());
+    }
+
+    public boolean signOut(ProxyContext context, SecuredResource securedResource, ResourceSignOutRequest request) {
+        CredentialsLocator credentialsLocator = createCredentialsLocator(context, securedResource, request.getUrl());
+        return resourceCredentialsService.deleteResourceCredentials(credentialsLocator, request, context.getInitiatorId());
+    }
+
+    private static CredentialsLocator createCredentialsLocator(ProxyContext context, SecuredResource securedResource, String resourceUrl) {
+        ResourceType resourceType = resolveResourceType(securedResource);
+        return CredentialsLocatorFactory.fromAnyUrl(UrlUtil.encodePath(resourceUrl), context, resourceType);
+    }
+
+    private static ResourceType resolveResourceType(SecuredResource resource) {
+        if (resource instanceof ToolSet) {
+            return ResourceTypes.TOOL_SET;
+        }
+        throw new IllegalArgumentException("Unsupported secured resource type: " + resource.getClass().getSimpleName());
+    }
+
+    /**
+     * Validates an API key before it is stored at sign-in: rejects blank/malformed keys, then probes
+     * the resource endpoint, assuming it speaks MCP (initialize + tools/list). Rejects only when the
+     * server explicitly refuses the request (HTTP 401/403 or a JSON-RPC error); connectivity issues
+     * and non-MCP endpoints are tolerated because the key may be provisioned before the server is
+     * reachable (#1698).
+     */
+    private void validateApiKey(SecuredResource securedResource, String apiKey) {
+        if (StringUtils.isBlank(apiKey)) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
+        }
+        if (containsIllegalHeaderChars(apiKey)) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
+        }
+
+        String endpoint = securedResource.getEndpoint();
+        String apiKeyHeader = securedResource.getAuthSettings().getApiKeyHeader();
+        if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader)) {
+            return;
+        }
+
+        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+                .builder(endpoint)
+                .connectTimeout(MCP_PROBE_TIMEOUT)
+                .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
+                .httpRequestCustomizer((builder, method, uri, body, transportContext) ->
+                        builder.header(apiKeyHeader, apiKey))
+                .build();
+
+        try (McpSyncClient client = McpClient.sync(transport)
+                .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
+                .requestTimeout(MCP_PROBE_TIMEOUT)
+                .initializationTimeout(MCP_PROBE_TIMEOUT)
+                .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
+                .build()) {
+            client.initialize();
+            client.listTools(null);
+        } catch (Exception e) {
+            McpHttpClientTransportAuthorizationException authError =
+                    ExceptionUtils.throwableOfType(e, McpHttpClientTransportAuthorizationException.class);
+            if (authError != null) {
+                log.warn("API key validation failed for endpoint {}: MCP server responded with status {}",
+                        endpoint, authError.getResponseInfo().statusCode());
+                throw new HttpException(HttpStatus.BAD_REQUEST,
+                        "API key validation failed: MCP server rejected the provided API key");
+            }
+            McpError mcpError = ExceptionUtils.throwableOfType(e, McpError.class);
+            if (mcpError != null) {
+                log.warn("API key validation failed for endpoint {}: MCP server returned an error: {}",
+                        endpoint, mcpError.getMessage());
+                throw new HttpException(HttpStatus.BAD_REQUEST,
+                        "API key validation failed: MCP server rejected the request: " + mcpError.getMessage());
+            }
+            log.warn("Skipping API key validation for endpoint {}: {}", endpoint, e.getMessage());
+        }
+    }
+
+    // java.net.http rejects header values containing control characters other than HTAB
+    private static boolean containsIllegalHeaderChars(String value) {
+        return value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -31,6 +31,7 @@ import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
+import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -46,10 +48,14 @@ import javax.annotation.Nullable;
 @AllArgsConstructor
 public class ToolSetService {
 
+    // deliberately not the client idleTimeout (5 min in production) — sign-in is interactive
+    public static final long DEFAULT_MCP_PROBE_TIMEOUT_MILLIS = 20_000;
+
     private final ResourceService resourceService;
     private final ResourceAuthSettingsService resourceAuthSettingsService;
     private final ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService;
     private final ResourceCredentialsService resourceCredentialsService;
+    private final long mcpRequestTimeout;
 
     public Pair<ResourceItemMetadata, ToolSet> getToolSet(ResourceDescriptor resource) {
         return getToolSet(resource, EtagHeader.ANY);
@@ -225,7 +231,14 @@ public class ToolSetService {
                        ResourceAuthSettings authSettings,
                        ResourceSignInRequest request) {
         if (AuthenticationType.API_KEY.equals(request.getAuthenticationType())) {
-            validateApiKey(securedResource, authSettings, request.getApiKey());
+            String apiKey = request.getApiKey();
+            if (StringUtils.isBlank(apiKey)) {
+                throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
+            }
+            if (containsIllegalHeaderChars(apiKey)) {
+                throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
+            }
+            validateApiKey(securedResource, authSettings, apiKey);
         }
         CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(
                 UrlUtil.encodePath(request.getUrl()), context, ResourceTypes.TOOL_SET);
@@ -233,20 +246,28 @@ public class ToolSetService {
         resourceCredentialsService.addResourceCredentials(credentialsDescriptor, authSettings, request, context.getInitiatorId());
     }
 
+    // java.net.http rejects header values containing control characters other than HTAB
+    private static boolean containsIllegalHeaderChars(String value) {
+        return value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
+    }
+
     /**
      * Probes the MCP server with the provided API key (initialize + tools/list) before the key is stored.
-     * Rejects only when the server explicitly refuses the key; connectivity issues are tolerated because
-     * the key may be provisioned before the MCP server is reachable (#1698).
+     * Rejects only when the server explicitly refuses the request (HTTP 401/403 or a JSON-RPC error);
+     * connectivity issues are tolerated because the key may be provisioned before the MCP server
+     * is reachable (#1698).
      */
     private void validateApiKey(SecuredResource securedResource, ResourceAuthSettings authSettings, String apiKey) {
         String endpoint = securedResource.getEndpoint();
         String apiKeyHeader = authSettings.getApiKeyHeader();
-        if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader) || StringUtils.isBlank(apiKey)) {
+        if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader)) {
             return;
         }
 
+        Duration timeout = Duration.ofMillis(mcpRequestTimeout);
         HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
                 .builder(endpoint)
+                .connectTimeout(timeout)
                 .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, uri, body, transportContext) ->
                         builder.header(apiKeyHeader, apiKey))
@@ -254,6 +275,8 @@ public class ToolSetService {
 
         try (McpSyncClient client = McpClient.sync(transport)
                 .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
+                .requestTimeout(timeout)
+                .initializationTimeout(timeout)
                 .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
                 .build()) {
             client.initialize();
@@ -266,6 +289,13 @@ public class ToolSetService {
                         endpoint, authError.getResponseInfo().statusCode());
                 throw new HttpException(HttpStatus.BAD_REQUEST,
                         "API key validation failed: MCP server rejected the provided API key");
+            }
+            McpError mcpError = ExceptionUtils.throwableOfType(e, McpError.class);
+            if (mcpError != null) {
+                log.warn("API key validation failed for endpoint {}: MCP server returned an error: {}",
+                        endpoint, mcpError.getMessage());
+                throw new HttpException(HttpStatus.BAD_REQUEST,
+                        "API key validation failed: MCP server rejected the request: " + mcpError.getMessage());
             }
             log.warn("Skipping API key validation for endpoint {}: {}", endpoint, e.getMessage());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -1,26 +1,41 @@
 package com.epam.aidial.core.server.service;
 
+import com.epam.aidial.core.config.AuthenticationType;
 import com.epam.aidial.core.config.CredentialsLevel;
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.config.SecuredResource;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsService;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.util.CredentialsDescriptorFactory;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.util.McpClientUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
+import com.epam.aidial.core.storage.util.UrlUtil;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
+import io.modelcontextprotocol.spec.McpSchema;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Map;
@@ -202,6 +217,57 @@ public class ToolSetService {
     private static void verifyToolSet(ResourceDescriptor resource) {
         if (resource.isFolder() || resource.getType() != ResourceTypes.TOOL_SET) {
             throw new IllegalArgumentException("Invalid application url: " + resource.getUrl());
+        }
+    }
+
+    public void signIn(ProxyContext context,
+                       SecuredResource securedResource,
+                       ResourceAuthSettings authSettings,
+                       ResourceSignInRequest request) {
+        if (AuthenticationType.API_KEY.equals(request.getAuthenticationType())) {
+            validateApiKey(securedResource, authSettings, request.getApiKey());
+        }
+        CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(
+                UrlUtil.encodePath(request.getUrl()), context, ResourceTypes.TOOL_SET);
+        CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(request.getCredentialsLevel());
+        resourceCredentialsService.addResourceCredentials(credentialsDescriptor, authSettings, request, context.getInitiatorId());
+    }
+
+    /**
+     * Probes the MCP server with the provided API key (initialize + tools/list) before the key is stored.
+     * Rejects only when the server explicitly refuses the key; connectivity issues are tolerated because
+     * the key may be provisioned before the MCP server is reachable (#1698).
+     */
+    private void validateApiKey(SecuredResource securedResource, ResourceAuthSettings authSettings, String apiKey) {
+        String endpoint = securedResource.getEndpoint();
+        String apiKeyHeader = authSettings.getApiKeyHeader();
+        if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader) || StringUtils.isBlank(apiKey)) {
+            return;
+        }
+
+        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+                .builder(endpoint)
+                .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
+                .httpRequestCustomizer((builder, method, uri, body, transportContext) ->
+                        builder.header(apiKeyHeader, apiKey))
+                .build();
+
+        try (McpSyncClient client = McpClient.sync(transport)
+                .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
+                .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
+                .build()) {
+            client.initialize();
+            client.listTools(null);
+        } catch (Exception e) {
+            McpHttpClientTransportAuthorizationException authError =
+                    ExceptionUtils.throwableOfType(e, McpHttpClientTransportAuthorizationException.class);
+            if (authError != null) {
+                log.warn("API key validation failed for endpoint {}: MCP server responded with status {}",
+                        endpoint, authError.getResponseInfo().statusCode());
+                throw new HttpException(HttpStatus.BAD_REQUEST,
+                        "API key validation failed: MCP server rejected the provided API key");
+            }
+            log.warn("Skipping API key validation for endpoint {}: {}", endpoint, e.getMessage());
         }
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -13,29 +13,17 @@ import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.util.CredentialsDescriptorFactory;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
-import com.epam.aidial.core.server.util.McpClientUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
-import com.epam.aidial.core.storage.http.HttpException;
-import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
-import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
-import io.modelcontextprotocol.spec.McpError;
-import io.modelcontextprotocol.spec.McpSchema;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -43,9 +31,6 @@ import javax.annotation.Nullable;
 @Slf4j
 @AllArgsConstructor
 public class ToolSetService {
-
-    // deliberately not the client idleTimeout (5 min in production) — sign-in is interactive
-    private static final Duration MCP_PROBE_TIMEOUT = Duration.ofSeconds(20);
 
     private final ResourceService resourceService;
     private final ResourceAuthSettingsService resourceAuthSettingsService;
@@ -219,67 +204,6 @@ public class ToolSetService {
         if (resource.isFolder() || resource.getType() != ResourceTypes.TOOL_SET) {
             throw new IllegalArgumentException("Invalid application url: " + resource.getUrl());
         }
-    }
-
-    /**
-     * Validates an API key before it is stored at sign-in: rejects blank/malformed keys, then probes
-     * the MCP server (initialize + tools/list). Rejects only when the server explicitly refuses the
-     * request (HTTP 401/403 or a JSON-RPC error); connectivity issues are tolerated because the key
-     * may be provisioned before the MCP server is reachable (#1698).
-     */
-    public void validateApiKey(ToolSet toolSet, ResourceAuthSettings authSettings, String apiKey) {
-        if (StringUtils.isBlank(apiKey)) {
-            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
-        }
-        if (containsIllegalHeaderChars(apiKey)) {
-            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
-        }
-
-        String endpoint = toolSet.getEndpoint();
-        String apiKeyHeader = authSettings.getApiKeyHeader();
-        if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader)) {
-            return;
-        }
-
-        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-                .builder(endpoint)
-                .connectTimeout(MCP_PROBE_TIMEOUT)
-                .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
-                .httpRequestCustomizer((builder, method, uri, body, transportContext) ->
-                        builder.header(apiKeyHeader, apiKey))
-                .build();
-
-        try (McpSyncClient client = McpClient.sync(transport)
-                .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
-                .requestTimeout(MCP_PROBE_TIMEOUT)
-                .initializationTimeout(MCP_PROBE_TIMEOUT)
-                .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
-                .build()) {
-            client.initialize();
-            client.listTools(null);
-        } catch (Exception e) {
-            McpHttpClientTransportAuthorizationException authError =
-                    ExceptionUtils.throwableOfType(e, McpHttpClientTransportAuthorizationException.class);
-            if (authError != null) {
-                log.warn("API key validation failed for endpoint {}: MCP server responded with status {}",
-                        endpoint, authError.getResponseInfo().statusCode());
-                throw new HttpException(HttpStatus.BAD_REQUEST,
-                        "API key validation failed: MCP server rejected the provided API key");
-            }
-            McpError mcpError = ExceptionUtils.throwableOfType(e, McpError.class);
-            if (mcpError != null) {
-                log.warn("API key validation failed for endpoint {}: MCP server returned an error: {}",
-                        endpoint, mcpError.getMessage());
-                throw new HttpException(HttpStatus.BAD_REQUEST,
-                        "API key validation failed: MCP server rejected the request: " + mcpError.getMessage());
-            }
-            log.warn("Skipping API key validation for endpoint {}: {}", endpoint, e.getMessage());
-        }
-    }
-
-    // java.net.http rejects header values containing control characters other than HTAB
-    private static boolean containsIllegalHeaderChars(String value) {
-        return value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
     }
 
     private void verifyCredentials(ProxyContext context, ResourceDescriptor resource,

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -49,13 +49,12 @@ import javax.annotation.Nullable;
 public class ToolSetService {
 
     // deliberately not the client idleTimeout (5 min in production) — sign-in is interactive
-    public static final long DEFAULT_MCP_PROBE_TIMEOUT_MILLIS = 20_000;
+    private static final Duration MCP_PROBE_TIMEOUT = Duration.ofSeconds(20);
 
     private final ResourceService resourceService;
     private final ResourceAuthSettingsService resourceAuthSettingsService;
     private final ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService;
     private final ResourceCredentialsService resourceCredentialsService;
-    private final long mcpRequestTimeout;
 
     public Pair<ResourceItemMetadata, ToolSet> getToolSet(ResourceDescriptor resource) {
         return getToolSet(resource, EtagHeader.ANY);
@@ -264,10 +263,9 @@ public class ToolSetService {
             return;
         }
 
-        Duration timeout = Duration.ofMillis(mcpRequestTimeout);
         HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
                 .builder(endpoint)
-                .connectTimeout(timeout)
+                .connectTimeout(MCP_PROBE_TIMEOUT)
                 .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, uri, body, transportContext) ->
                         builder.header(apiKeyHeader, apiKey))
@@ -275,8 +273,8 @@ public class ToolSetService {
 
         try (McpSyncClient client = McpClient.sync(transport)
                 .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
-                .requestTimeout(timeout)
-                .initializationTimeout(timeout)
+                .requestTimeout(MCP_PROBE_TIMEOUT)
+                .initializationTimeout(MCP_PROBE_TIMEOUT)
                 .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
                 .build()) {
             client.initialize();

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -1,15 +1,12 @@
 package com.epam.aidial.core.server.service;
 
-import com.epam.aidial.core.config.AuthenticationType;
 import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.ResourceAuthSettings;
-import com.epam.aidial.core.config.SecuredResource;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
-import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsService;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
@@ -26,7 +23,6 @@ import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
-import com.epam.aidial.core.storage.util.UrlUtil;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -225,39 +221,21 @@ public class ToolSetService {
         }
     }
 
-    public void signIn(ProxyContext context,
-                       SecuredResource securedResource,
-                       ResourceAuthSettings authSettings,
-                       ResourceSignInRequest request) {
-        if (AuthenticationType.API_KEY.equals(request.getAuthenticationType())) {
-            String apiKey = request.getApiKey();
-            if (StringUtils.isBlank(apiKey)) {
-                throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
-            }
-            if (containsIllegalHeaderChars(apiKey)) {
-                throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
-            }
-            validateApiKey(securedResource, authSettings, apiKey);
-        }
-        CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(
-                UrlUtil.encodePath(request.getUrl()), context, ResourceTypes.TOOL_SET);
-        CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(request.getCredentialsLevel());
-        resourceCredentialsService.addResourceCredentials(credentialsDescriptor, authSettings, request, context.getInitiatorId());
-    }
-
-    // java.net.http rejects header values containing control characters other than HTAB
-    private static boolean containsIllegalHeaderChars(String value) {
-        return value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
-    }
-
     /**
-     * Probes the MCP server with the provided API key (initialize + tools/list) before the key is stored.
-     * Rejects only when the server explicitly refuses the request (HTTP 401/403 or a JSON-RPC error);
-     * connectivity issues are tolerated because the key may be provisioned before the MCP server
-     * is reachable (#1698).
+     * Validates an API key before it is stored at sign-in: rejects blank/malformed keys, then probes
+     * the MCP server (initialize + tools/list). Rejects only when the server explicitly refuses the
+     * request (HTTP 401/403 or a JSON-RPC error); connectivity issues are tolerated because the key
+     * may be provisioned before the MCP server is reachable (#1698).
      */
-    private void validateApiKey(SecuredResource securedResource, ResourceAuthSettings authSettings, String apiKey) {
-        String endpoint = securedResource.getEndpoint();
+    public void validateApiKey(ToolSet toolSet, ResourceAuthSettings authSettings, String apiKey) {
+        if (StringUtils.isBlank(apiKey)) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
+        }
+        if (containsIllegalHeaderChars(apiKey)) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
+        }
+
+        String endpoint = toolSet.getEndpoint();
         String apiKeyHeader = authSettings.getApiKeyHeader();
         if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader)) {
             return;
@@ -297,6 +275,11 @@ public class ToolSetService {
             }
             log.warn("Skipping API key validation for endpoint {}: {}", endpoint, e.getMessage());
         }
+    }
+
+    // java.net.http rejects header values containing control characters other than HTAB
+    private static boolean containsIllegalHeaderChars(String value) {
+        return value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
     }
 
     private void verifyCredentials(ProxyContext context, ResourceDescriptor resource,

--- a/server/src/main/java/com/epam/aidial/core/server/util/McpClientUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/McpClientUtils.java
@@ -1,0 +1,48 @@
+package com.epam.aidial.core.server.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import lombok.experimental.UtilityClass;
+
+import java.io.IOException;
+import java.util.Map;
+
+@UtilityClass
+public class McpClientUtils {
+
+    public static final JsonSchemaValidator NOOP_SCHEMA_VALIDATOR =
+            (Map<String, Object> schema, Object content) ->
+                    JsonSchemaValidator.ValidationResponse.asValid(null);
+
+    public static final McpJsonMapper MCP_JSON_MAPPER = createLenientMcpJsonMapper();
+
+    private static final String ADDITIONAL_PROPERTIES_FIELD = "additionalProperties";
+
+    private static McpJsonMapper createLenientMcpJsonMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // JSON Schema allows `additionalProperties` to be a boolean OR a schema object,
+        // but the MCP SDK models it as Boolean. Coerce object/array values to null so a
+        // single non-conforming field does not fail the whole tools/list response (#1561).
+        mapper.addHandler(new DeserializationProblemHandler() {
+            @Override
+            public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType,
+                    JsonToken t, JsonParser p, String failureMsg) throws IOException {
+                if (targetType.hasRawClass(Boolean.class)
+                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)
+                        && ADDITIONAL_PROPERTIES_FIELD.equals(p.currentName())) {
+                    p.skipChildren();
+                    return null;
+                }
+                return super.handleUnexpectedToken(ctxt, targetType, t, p, failureMsg);
+            }
+        });
+        return new JacksonMcpJsonMapper(mapper);
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -2605,6 +2606,96 @@ public class ToolSetApiTest extends ResourceBaseTest {
             assertEquals(403, resp.status());
             assertTrue(resp.body().contains("Please sign in to the toolset"), resp.body());
         }
+    }
+
+    private static final String API_KEY_TOOLSET_URL = "toolsets/4X25dj1mja51jykqxsXnCH/api-key-toolset@";
+
+    private void createApiKeyToolSet() {
+        Response response = send(HttpMethod.PUT, "/v1/" + API_KEY_TOOLSET_URL, null, """
+                {
+                    "endpoint": "http://localhost:9876",
+                    "transport": "HTTP",
+                    "allowedTools": [],
+                    "auth_settings": {
+                        "authentication_type": "API_KEY",
+                        "api_key_header": "Authorization"
+                    }
+                }
+                """, "authorization", "admin");
+        verifyNotExact(response, 200, "\"url\":\"" + API_KEY_TOOLSET_URL + "\"");
+    }
+
+    private Response signInWithApiKey(String apiKey) {
+        return send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                {
+                    "url": "%s",
+                    "credentialsLevel": "GLOBAL",
+                    "authenticationType": "API_KEY",
+                    "api_key": "%s"
+                }
+                """.formatted(API_KEY_TOOLSET_URL, apiKey), "authorization", "admin");
+    }
+
+    // MCP server rejects the key during sign-in validation -> credentials must not be stored (#1698)
+    @Test
+    void testSignInWithInvalidApiKey() {
+        createApiKeyToolSet();
+
+        try (TestWebServer ignore = new TestWebServer(9876, mcpAuthErrorHandler(401))) {
+            Response response = signInWithApiKey("invalid-key");
+            assertEquals(400, response.status());
+            assertTrue(response.body().contains("MCP server rejected the provided API key"), response.body());
+        }
+
+        Response response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
+    }
+
+    @Test
+    void testSignInWithValidApiKey() {
+        createApiKeyToolSet();
+
+        String mcpToolsListResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 2,
+                   "result": {
+                     "tools": [
+                       {"name": "branch", "description": "Manage branches"}
+                     ]
+                   }
+                 }
+                """;
+        AtomicReference<String> sentApiKey = new AtomicReference<>();
+        TestWebServer.Handler toolsHandler = mcpToolsHandler(mcpToolsListResponse);
+        TestWebServer.Handler handler = request -> {
+            sentApiKey.set(request.getHeader("Authorization"));
+            return toolsHandler.map(request);
+        };
+
+        try (TestWebServer ignore = new TestWebServer(9876, handler)) {
+            Response response = signInWithApiKey("valid-key");
+            verify(response, 200, "true");
+            assertEquals("valid-key", sentApiKey.get());
+        }
+
+        Response response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""), response.body());
+    }
+
+    // Validation is best-effort: an unreachable MCP server must not block sign-in (#1698)
+    @Test
+    void testSignInWithApiKeyWhenMcpServerUnreachable() {
+        createApiKeyToolSet();
+
+        Response response = signInWithApiKey("some-key");
+        verify(response, 200, "true");
+
+        response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""), response.body());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -87,6 +87,22 @@ public class ToolSetApiTest extends ResourceBaseTest {
         };
     }
 
+    // MCP server rejects the request at the JSON-RPC layer: HTTP 200 with an error object
+    private static TestWebServer.Handler mcpJsonRpcErrorHandler(String errorMessage) {
+        return request -> {
+            if ("GET".equals(request.getMethod())) {
+                return new MockResponse().setResponseCode(405);
+            }
+            String body = request.getBody().readString(StandardCharsets.UTF_8);
+            String id = extractJsonRpcId(body);
+            return new MockResponse()
+                    .setBody("""
+                            {"jsonrpc":"2.0","id":%s,"error":{"code":-32600,"message":"%s"}}
+                            """.formatted(id, errorMessage))
+                    .setHeader("Content-Type", "application/json");
+        };
+    }
+
     @SneakyThrows
     private Response sendNoRedirect(HttpMethod method, String path, String body) {
         try (CloseableHttpClient noRedirectClient = HttpClientBuilder.create()
@@ -2696,6 +2712,49 @@ public class ToolSetApiTest extends ResourceBaseTest {
         response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
         assertEquals(200, response.status());
         assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""), response.body());
+    }
+
+    @Test
+    void testSignInWithBlankApiKey() {
+        createApiKeyToolSet();
+
+        Response response = signInWithApiKey("");
+        assertEquals(400, response.status());
+        assertTrue(response.body().contains("api_key must not be blank"), response.body());
+
+        response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
+    }
+
+    // A key with control characters (e.g. a pasted trailing newline) can never be sent as an HTTP header
+    @Test
+    void testSignInWithApiKeyContainingControlCharacters() {
+        createApiKeyToolSet();
+
+        Response response = signInWithApiKey("key-with-newline\\n");
+        assertEquals(400, response.status());
+        assertTrue(response.body().contains("api_key contains illegal control characters"), response.body());
+
+        response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
+    }
+
+    // MCP servers doing auth at the application layer reject with HTTP 200 + JSON-RPC error, not 401 (#1698)
+    @Test
+    void testSignInWithApiKeyRejectedByJsonRpcError() {
+        createApiKeyToolSet();
+
+        try (TestWebServer ignore = new TestWebServer(9876, mcpJsonRpcErrorHandler("invalid api key"))) {
+            Response response = signInWithApiKey("invalid-key");
+            assertEquals(400, response.status());
+            assertTrue(response.body().contains("MCP server rejected the request"), response.body());
+        }
+
+        Response response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -80,7 +80,7 @@ class ResourceCredentialsControllerTest {
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getDeploymentService()).thenReturn(deploymentService);
         when(proxy.getResourceAuthSettingsEncryptionService()).thenReturn(resourceAuthSettingsEncryptionService);
-        when(proxy.getToolSetService()).thenReturn(new ToolSetService(null, null, null, resourceCredentialsService));
+        when(proxy.getToolSetService()).thenReturn(new ToolSetService(null, null, null, resourceCredentialsService, 1000));
 
         doAnswer(invocation -> {
             Callable<?> callable = invocation.getArgument(0);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -15,7 +15,7 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.DeploymentService;
-import com.epam.aidial.core.server.service.ToolSetService;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
@@ -75,12 +75,11 @@ class ResourceCredentialsControllerTest {
     @BeforeEach
     void setup() {
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor);
-        when(proxy.getResourceCredentialsService()).thenReturn(resourceCredentialsService);
         when(proxy.getAccessService()).thenReturn(accessService);
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getDeploymentService()).thenReturn(deploymentService);
         when(proxy.getResourceAuthSettingsEncryptionService()).thenReturn(resourceAuthSettingsEncryptionService);
-        when(proxy.getToolSetService()).thenReturn(mock(ToolSetService.class));
+        when(proxy.getSecuredResourceService()).thenReturn(new SecuredResourceService(resourceCredentialsService));
 
         doAnswer(invocation -> {
             Callable<?> callable = invocation.getArgument(0);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -80,7 +80,7 @@ class ResourceCredentialsControllerTest {
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getDeploymentService()).thenReturn(deploymentService);
         when(proxy.getResourceAuthSettingsEncryptionService()).thenReturn(resourceAuthSettingsEncryptionService);
-        when(proxy.getToolSetService()).thenReturn(new ToolSetService(null, null, null, resourceCredentialsService));
+        when(proxy.getToolSetService()).thenReturn(mock(ToolSetService.class));
 
         doAnswer(invocation -> {
             Callable<?> callable = invocation.getArgument(0);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -15,6 +15,7 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.DeploymentService;
+import com.epam.aidial.core.server.service.ToolSetService;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
@@ -79,6 +80,7 @@ class ResourceCredentialsControllerTest {
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getDeploymentService()).thenReturn(deploymentService);
         when(proxy.getResourceAuthSettingsEncryptionService()).thenReturn(resourceAuthSettingsEncryptionService);
+        when(proxy.getToolSetService()).thenReturn(new ToolSetService(null, null, null, resourceCredentialsService));
 
         doAnswer(invocation -> {
             Callable<?> callable = invocation.getArgument(0);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -80,7 +80,7 @@ class ResourceCredentialsControllerTest {
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getDeploymentService()).thenReturn(deploymentService);
         when(proxy.getResourceAuthSettingsEncryptionService()).thenReturn(resourceAuthSettingsEncryptionService);
-        when(proxy.getToolSetService()).thenReturn(new ToolSetService(null, null, null, resourceCredentialsService, 1000));
+        when(proxy.getToolSetService()).thenReturn(new ToolSetService(null, null, null, resourceCredentialsService));
 
         doAnswer(invocation -> {
             Callable<?> callable = invocation.getArgument(0);

--- a/server/src/test/java/com/epam/aidial/core/server/service/SecuredResourceServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/SecuredResourceServiceTest.java
@@ -1,0 +1,151 @@
+package com.epam.aidial.core.server.service;
+
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CredentialsLevel;
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.config.SecuredResource;
+import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
+import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SecuredResourceServiceTest {
+
+    private static final String RESOURCE_URL = "toolsets/encrypted-user-bucket/toolset-1";
+
+    @Mock
+    private ProxyContext context;
+    @Mock
+    private Proxy proxy;
+    @Mock
+    private EncryptionService encryptionService;
+    @Mock
+    private ResourceCredentialsService resourceCredentialsService;
+
+    private SecuredResourceService service;
+
+    @BeforeEach
+    void setup() {
+        service = new SecuredResourceService(resourceCredentialsService);
+    }
+
+    @Test
+    void testSignIn_StoresCredentials() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.OAUTH, null);
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    @Test
+    void testSignIn_BlankApiKeyRejected() {
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, " ");
+
+        HttpException error = assertThrows(HttpException.class,
+                () -> service.signIn(context, createToolSet("http://localhost:1"), request));
+
+        assertEquals(HttpStatus.BAD_REQUEST, error.getStatus());
+        verifyNoInteractions(resourceCredentialsService);
+    }
+
+    @Test
+    void testSignIn_ApiKeyWithControlCharactersRejected() {
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "key\nwith-newline");
+
+        HttpException error = assertThrows(HttpException.class,
+                () -> service.signIn(context, createToolSet("http://localhost:1"), request));
+
+        assertEquals(HttpStatus.BAD_REQUEST, error.getStatus());
+        verifyNoInteractions(resourceCredentialsService);
+    }
+
+    // No endpoint to probe -> validation is skipped, the key is stored (#1698 fail-open)
+    @Test
+    void testSignIn_ApiKeyWithoutEndpointStored() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "some-key");
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    @Test
+    void testSignOut_DeletesCredentials() {
+        mockLocatorPlumbing();
+        ResourceSignOutRequest request = ResourceSignOutRequest.builder()
+                .url(RESOURCE_URL)
+                .credentialsLevel(CredentialsLevel.GLOBAL)
+                .authenticationType(AuthenticationType.API_KEY)
+                .build();
+        when(resourceCredentialsService.deleteResourceCredentials(any(), eq(request), eq("userSub"))).thenReturn(true);
+
+        assertTrue(service.signOut(context, createToolSet(null), request));
+    }
+
+    @Test
+    void testSignIn_UnsupportedResourceTypeRejected() {
+        SecuredResource unknownResource = new SecuredResource() {
+        };
+        ResourceSignInRequest request = signInRequest(AuthenticationType.OAUTH, null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.signIn(context, unknownResource, request));
+        verifyNoInteractions(resourceCredentialsService);
+    }
+
+    private void mockLocatorPlumbing() {
+        when(context.getProxy()).thenReturn(proxy);
+        when(proxy.getEncryptionService()).thenReturn(encryptionService);
+        when(context.getConfig()).thenReturn(mock(Config.class));
+        when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Users/userSub/");
+        when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
+        when(context.getUserId()).thenReturn("userSub");
+        when(context.getInitiatorId()).thenReturn("userSub");
+    }
+
+    private static ToolSet createToolSet(String endpoint) {
+        ToolSet toolSet = new ToolSet();
+        toolSet.setEndpoint(endpoint);
+        toolSet.setAuthSettings(ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.API_KEY)
+                .apiKeyHeader("Authorization")
+                .build());
+        return toolSet;
+    }
+
+    private static ResourceSignInRequest signInRequest(AuthenticationType authenticationType, String apiKey) {
+        return ResourceSignInRequest.builder()
+                .url(RESOURCE_URL)
+                .credentialsLevel(CredentialsLevel.GLOBAL)
+                .authenticationType(authenticationType)
+                .apiKey(apiKey)
+                .build();
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/service/ToolSetServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ToolSetServiceTest.java
@@ -2,15 +2,12 @@ package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.AuthenticationType;
 import com.epam.aidial.core.config.Config;
-import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
-import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsService;
-import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
@@ -22,18 +19,15 @@ import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.net.InetAddress;
-import java.net.ServerSocket;
-import java.time.Duration;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -41,7 +35,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -62,19 +55,12 @@ class ToolSetServiceTest {
     @Mock
     private EncryptionService encryptionService;
     @Mock
-    private ResourceCredentialsService resourceCredentialsService;
-    @Mock
     private ProxyContext context;
     @Mock
     private Proxy proxy;
 
+    @InjectMocks
     private ToolSetService toolSetService;
-
-    @BeforeEach
-    void setup() {
-        toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
-                resourceAuthSettingsEncryptionService, resourceCredentialsService, 1000);
-    }
 
     @Test
     void testPutToolSet_ShouldEncryptAuthSettings() {
@@ -236,42 +222,6 @@ class ToolSetServiceTest {
         // Then - clientSecret and codeVerifier must be preserved after multiple calls
         assertEquals("clientSecret", toolSet.getAuthSettings().getClientSecret());
         assertEquals("codeVerifier", toolSet.getAuthSettings().getCodeVerifier());
-    }
-
-    // The sign-in probe must honor the configured timeout (SDK defaults are 20s) and fail open on it (#1698)
-    @Test
-    void testSignInApiKeyProbeHonorsConfiguredTimeout() throws Exception {
-        // the socket accepts TCP connections but never responds
-        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
-            ToolSetService service = new ToolSetService(null, null, null, resourceCredentialsService, 300);
-
-            ToolSet toolSet = createToolSet();
-            toolSet.setEndpoint("http://127.0.0.1:" + server.getLocalPort());
-            ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
-                    .authenticationType(AuthenticationType.API_KEY)
-                    .apiKeyHeader("Authorization")
-                    .build();
-
-            ResourceSignInRequest request = ResourceSignInRequest.builder()
-                    .url("toolsets/encrypted-user-bucket/toolset-1")
-                    .credentialsLevel(CredentialsLevel.GLOBAL)
-                    .authenticationType(AuthenticationType.API_KEY)
-                    .apiKey("some-key")
-                    .build();
-
-            when(context.getProxy()).thenReturn(proxy);
-            when(proxy.getEncryptionService()).thenReturn(encryptionService);
-            when(context.getConfig()).thenReturn(mock(Config.class));
-            when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Users/userSub/");
-            when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
-            when(context.getUserId()).thenReturn("userSub");
-            when(context.getInitiatorId()).thenReturn("userSub");
-
-            assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
-                    service.signIn(context, toolSet, authSettings, request));
-
-            verify(resourceCredentialsService).addResourceCredentials(any(), any(), any(), eq("userSub"));
-        }
     }
 
     private static ToolSet createToolSet() {

--- a/server/src/test/java/com/epam/aidial/core/server/service/ToolSetServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ToolSetServiceTest.java
@@ -2,12 +2,15 @@ package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.AuthenticationType;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsService;
+import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
@@ -19,15 +22,18 @@ import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
 import com.epam.aidial.core.storage.util.EtagHeader;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.time.Duration;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -35,6 +41,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -55,12 +62,19 @@ class ToolSetServiceTest {
     @Mock
     private EncryptionService encryptionService;
     @Mock
+    private ResourceCredentialsService resourceCredentialsService;
+    @Mock
     private ProxyContext context;
     @Mock
     private Proxy proxy;
 
-    @InjectMocks
     private ToolSetService toolSetService;
+
+    @BeforeEach
+    void setup() {
+        toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
+                resourceAuthSettingsEncryptionService, resourceCredentialsService, 1000);
+    }
 
     @Test
     void testPutToolSet_ShouldEncryptAuthSettings() {
@@ -222,6 +236,42 @@ class ToolSetServiceTest {
         // Then - clientSecret and codeVerifier must be preserved after multiple calls
         assertEquals("clientSecret", toolSet.getAuthSettings().getClientSecret());
         assertEquals("codeVerifier", toolSet.getAuthSettings().getCodeVerifier());
+    }
+
+    // The sign-in probe must honor the configured timeout (SDK defaults are 20s) and fail open on it (#1698)
+    @Test
+    void testSignInApiKeyProbeHonorsConfiguredTimeout() throws Exception {
+        // the socket accepts TCP connections but never responds
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            ToolSetService service = new ToolSetService(null, null, null, resourceCredentialsService, 300);
+
+            ToolSet toolSet = createToolSet();
+            toolSet.setEndpoint("http://127.0.0.1:" + server.getLocalPort());
+            ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
+                    .authenticationType(AuthenticationType.API_KEY)
+                    .apiKeyHeader("Authorization")
+                    .build();
+
+            ResourceSignInRequest request = ResourceSignInRequest.builder()
+                    .url("toolsets/encrypted-user-bucket/toolset-1")
+                    .credentialsLevel(CredentialsLevel.GLOBAL)
+                    .authenticationType(AuthenticationType.API_KEY)
+                    .apiKey("some-key")
+                    .build();
+
+            when(context.getProxy()).thenReturn(proxy);
+            when(proxy.getEncryptionService()).thenReturn(encryptionService);
+            when(context.getConfig()).thenReturn(mock(Config.class));
+            when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Users/userSub/");
+            when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
+            when(context.getUserId()).thenReturn("userSub");
+            when(context.getInitiatorId()).thenReturn("userSub");
+
+            assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
+                    service.signIn(context, toolSet, authSettings, request));
+
+            verify(resourceCredentialsService).addResourceCredentials(any(), any(), any(), eq("userSub"));
+        }
     }
 
     private static ToolSet createToolSet() {


### PR DESCRIPTION
Sign-in for API-key toolsets now validates the key against the MCP server before storing it, so an invalid key no longer flips the toolset to "Log out". The validation probe rejects explicit server refusals (HTTP 401/403 and JSON-RPC errors) and invalid input (blank keys, control characters), while staying best-effort for unreachable servers.

### Applicable issues

- fixes #1698

### Description of changes

- `ToolSetService.signIn` owns the sign-in storage step (moved from `ResourceCredentialsController`); for `API_KEY` sign-ins it probes the MCP server (`initialize` + `tools/list`) with the provided key before storing credentials.
- MCP server refusals fail closed with HTTP 400: 401/403 transport responses and JSON-RPC error responses (`McpError`) — the latter covers servers that authenticate at the application layer and reject with HTTP 200 + error object.
- Invalid input is rejected with HTTP 400 before any network call: blank `api_key`, or a key containing control characters (which `java.net.http` cannot send as a header and would previously slip through the fail-open path).
- Connectivity failures still fail open (key stored), since keys may be provisioned before the MCP server is reachable; the probe is capped by explicit connect/request/initialization timeouts (20s constant, deliberately not the 5-minute client `idleTimeout`).
- Shared MCP client pieces (lenient `additionalProperties` mapper from #1561, noop schema validator) extracted to `McpClientUtils`, reused by `ToolSetToolsController`.
- Tests: integration tests for valid/invalid/blank/control-char keys, JSON-RPC rejection, and unreachable-server fail-open; unit test proving the probe honors the configured timeout.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)