### PR TITLE
fix: exclude linter validation from the replaceSpec Gradle task

### DIFF
--- a/openapi-generator/README.md
+++ b/openapi-generator/README.md
@@ -63,18 +63,29 @@ See [Schema Guide](SCHEMAS.md) for modeling strategies.
 ## Gradle Tasks
 
 ```bash
-./gradlew mergeOpenApiSpec           # Generate spec
-./gradlew lintMergedOpenApi          # Lint spec
-./gradlew replaceSpec                # Update committed spec
-./gradlew :openapi-generator:test    # Run tests
+## Gradle Tasks
+
+```bash
+./gradlew mergeOpenApiSpec            # Generate merged specification
+./gradlew lintMergedOpenApi           # Generate and validate the specification
+./gradlew replaceSpec                 # Replace the committed specification (without Redocly linting)
+./gradlew replaceSpec -Plint          # Replace the committed specification with Redocly linting
+./gradlew :openapi-generator:test     # Run tests
 ```
 
 ## Workflow
 
 1. Annotate controller method.
-2. Run `./gradlew lintMergedOpenApi`.
+2. Run `./gradlew mergeOpenApiSpec`.
 3. Review `build/generated/openapi-merged.yaml`.
-4. Run `./gradlew replaceSpec`.
+4. Update the committed specification:
+   ```bash
+   ./gradlew replaceSpec
+   ```
+   Or, to validate it with Redocly before replacing:
+   ```bash
+   ./gradlew replaceSpec -Plint
+   ```
 5. Commit `docs/open_api_core.yaml`.
 
 `build/generated/openapi-merged.yaml` is a temporary build artifact generated during the build.

--- a/openapi-generator/build.gradle
+++ b/openapi-generator/build.gradle
@@ -37,6 +37,18 @@ tasks.register('generateOpenApiSkeleton', JavaExec) {
     args = [skeletonFile, "${project.version}"]
 }
 
+tasks.register('mergeOpenApiSpec', JavaExec) {
+    dependsOn generateOpenApiSkeleton
+
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.epam.aidial.core.openapi.SpecMerger'
+    args = [
+            skeletonFile,
+            targetSpec,
+            mergedFile
+    ]
+}
+
 tasks.register('lintOpenApiSkeleton', Exec) {
     dependsOn generateOpenApiSkeleton
 
@@ -47,19 +59,21 @@ tasks.register('lintOpenApiSkeleton', Exec) {
     }
 }
 
-tasks.register('mergeOpenApiSpec', JavaExec) {
+tasks.register('lintMergedOpenApi', Exec) {
     dependsOn lintOpenApiSkeleton
-    classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'com.epam.aidial.core.openapi.SpecMerger'
-    args = [
-        skeletonFile,
-        targetSpec,
-        mergedFile
-    ]
+    dependsOn mergeOpenApiSpec
+
+    if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+        commandLine "cmd", "/c", "npx", "@redocly/cli", "lint", mergedFile
+    } else {
+        commandLine "npx", "@redocly/cli", "lint", mergedFile
+    }
 }
 
 tasks.register('replaceSpec') {
-    dependsOn lintMergedOpenApi
+    dependsOn(project.hasProperty("lint")
+            ? "lintMergedOpenApi"
+            : "mergeOpenApiSpec")
 
     doLast {
         copy {
@@ -67,16 +81,6 @@ tasks.register('replaceSpec') {
             into file(targetSpec).parentFile
             rename { "open_api_core.yaml" }
         }
-    }
-}
-
-tasks.register('lintMergedOpenApi', Exec) {
-    dependsOn mergeOpenApiSpec
-
-    if (System.getProperty("os.name").toLowerCase().contains("windows")) {
-        commandLine "cmd", "/c", "npx", "@redocly/cli", "lint", mergedFile
-    } else {
-        commandLine "npx", "@redocly/cli", "lint", mergedFile
     }
 }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/ai-dial-admin-backend/issues/942

### Description of changes
This PR updates the replaceSpec Gradle task of openapi-generator to make Redocly lint validation optional.

Changes
* replaceSpec no longer runs Redocly lint validation by default.
* Validation can be enabled explicitly by passing the -Plint Gradle property:

./gradlew replaceSpec -Plint
<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
