### PR TITLE
feat: access control integration for skills #1640

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceMetadataController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceMetadataController.java
@@ -117,6 +117,7 @@ public class ComplexResourceMetadataController extends AccessControlBaseControll
                     if (result == null) {
                         context.respond(HttpStatus.NOT_FOUND);
                     } else {
+                        proxy.getAccessService().filterForbidden(context, resource, result);
                         context.respond(HttpStatus.OK, getContentType(), result);
                     }
                 })

--- a/server/src/main/java/com/epam/aidial/core/server/service/ShareService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ShareService.java
@@ -75,7 +75,8 @@ public class ShareService {
             ResourceTypes.FILE, new ShareResourceLimit(Integer.MAX_VALUE, 72),
             ResourceTypes.PROMPT, new ShareResourceLimit(Integer.MAX_VALUE, 72),
             ResourceTypes.TOOL_SET, new ShareResourceLimit(10, 72),
-            ResourceTypes.CREDENTIALS, new ShareResourceLimit(10, 72));
+            ResourceTypes.CREDENTIALS, new ShareResourceLimit(10, 72),
+            ResourceTypes.SKILL, new ShareResourceLimit(10, 72));
 
     private static final Set<ResourceType> CREDS_SHARABLE_RESOURCE_TYPES = Set.of(ResourceTypes.TOOL_SET);
 

--- a/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server;
 
+import com.epam.aidial.core.server.data.InvitationLink;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
@@ -498,6 +499,56 @@ public class SkillResourceApiTest extends ResourceBaseTest {
         assertEquals(400, downloadSkill("/as-folder").status());
         // trailing-slash GET -> 400
         assertEquals(400, send(HttpMethod.GET, "/v2/skills/" + bucket + "/as-folder/", null, "").status());
+    }
+
+    @Test
+    void testOwnerAccessAndDenialForOtherUser() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+        // owner (default user) can create and read the skill by bucket-location match, no marker walk needed
+        Response created = uploadSkill("/private-skill", files);
+        verify(created, 200);
+        assertEquals(200, downloadSkill("/private-skill").status());
+
+        // another user has no access: whole-resource, single-file and metadata ops are all forbidden, not merely "not found"
+        assertEquals(403, downloadSkill("/private-skill", "Api-key", "proxyKey2").status());
+        assertEquals(403, getSkillFile("/private-skill", "SKILL.md", "Api-key", "proxyKey2").status());
+        verify(listMetadata("private-skill", "Api-key", "proxyKey2"), 403);
+        verify(uploadSkill("/private-skill", files, "Api-key", "proxyKey2"), 403);
+        verify(putSkillFile("/private-skill", "a.txt", "x".getBytes(StandardCharsets.UTF_8), "Api-key", "proxyKey2"), 403);
+        verify(deleteSkill("/private-skill", "Api-key", "proxyKey2"), 403);
+    }
+
+    @Test
+    void testFolderShareInheritsFileAccess() {
+        Map<String, byte[]> files = new LinkedHashMap<>();
+        files.put("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+        files.put("scripts/run.sh", "echo hi".getBytes(StandardCharsets.UTF_8));
+        verify(uploadSkill("/shared-group/skill-a", files), 200);
+
+        // before sharing, the other user has no access
+        assertEquals(403, downloadSkill("/shared-group/skill-a", "Api-key", "proxyKey2").status());
+
+        // share the grouping folder (not the skill itself)
+        Response share = operationRequest("/v1/ops/resource/share/create", """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    { "url": "skills/%s/shared-group/" }
+                  ]
+                }
+                """.formatted(bucket));
+        verify(share, 200);
+        InvitationLink invitationLink = ProxyUtil.convertToObject(share.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        verify(send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey2"), 200);
+
+        // access to the skill, to a file beneath it, and to the folder's metadata listing is now inherited
+        // from the folder share, via the same recursive parent-permission lookup used for v1 resources
+        assertEquals(200, downloadSkill("/shared-group/skill-a", "Api-key", "proxyKey2").status());
+        assertEquals("echo hi", new String(
+                getSkillFile("/shared-group/skill-a", "scripts/run.sh", "Api-key", "proxyKey2").body(), StandardCharsets.UTF_8));
+        verify(listMetadata("shared-group", "Api-key", "proxyKey2"), 200);
     }
 
     private Response listMetadata(String relativePath, String... headers) {


### PR DESCRIPTION
Wires the existing generic access-control model (owner-by-bucket-match, recursive parent-permission lookup) into the v2 skill/complex-resource API, and closes the one gap where it wasn't already applied: metadata-listing filtering.

### Applicable issues

- fixes #1640

### Description of changes

- `ComplexResourceMetadataController`: call `AccessService.filterForbidden` after building a children/files listing, mirroring the v1 `ResourceController.getMetadata` pattern, so public folder listings omit items the caller can't see.
- `ShareService`: register `SKILL` in the sharing limits map (`DEFAULT_LIMITS`). Without this, sharing a skill or a skill folder failed outright with "Unsupported resource type: SKILL", which would have made it impossible to satisfy the "in-resource file access inherits from the enclosing resource via sharing" requirement.
- `SkillResourceApiTest`: added coverage for owner access + denial (403, not 404, for a non-owner on whole-resource/file/metadata/write operations) and for folder-share inheritance (sharing a grouping folder grants a second user access to a nested skill, its files, and its metadata listing).

Owner access by bucket-location match and whole-resource/single-file access gating before the operation were already generic and required no code changes — this PR only adds the missing metadata-filtering call, the sharing registration, and test coverage.

Note: publishing skills as *public* resources isn't supported yet (`PublicationService.ALLOWED_RESOURCES` doesn't include `SKILL`), so a public-metadata-filtering test for skills is out of scope here — that would require building out publication support for a new resource type, a separate, larger feature.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.