### PR TITLE
feat: sweep/GC reconciliation for complex resources #1639

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ Priority order:
 </details>
 
 <details> 
+<summary><b>Complex Resource Sweep Configurations</b></summary>
+
+Periodic job that reclaims storage for folder-as-resource complex resources (e.g. skills): it finishes
+reclaiming resources tombstoned by DELETE and GCs stale versions left behind by a failed/interrupted write.
+
+| Setting                                | Default  | Required | Description                                                                                                                                          |
+|-----------------------------------------|:--------:|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| complexResourceSweep.period              |  10000   |    No    | Period in milliseconds between sweep ticks.                                                                                                          |
+| complexResourceSweep.batch               |   1000   |    No    | Number of references listed (and potentially processed) per batch.                                                                                   |
+| complexResourceSweep.activeBatches       |    5     |    No    | Max number of batches this instance may have mid-processing in parallel at any moment. Enforced locally per instance; not a cluster-wide total.      |
+| complexResourceSweep.gracePeriod         | 3600000  |    No    | Minimum age in milliseconds a tombstoned resource or a superseded version must reach before the sweep physically deletes it, to protect any reader that started before the delete/supersession. |
+
+</details>
+
+<details> 
 <summary><b>Redis Configurations</b></summary>
 
 | Setting                                  | Default | Required | Description                                                                                                                                                                                                                                                                                                                                                                                    |

--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -70,6 +70,7 @@ import com.epam.aidial.core.server.service.WellKnownResourceMetadataService;
 import com.epam.aidial.core.server.service.clientchannel.ClientChannelService;
 import com.epam.aidial.core.server.service.codeinterpreter.CodeInterpreterService;
 import com.epam.aidial.core.server.service.resource.ComplexResourceService;
+import com.epam.aidial.core.server.service.resource.ComplexResourceSweepService;
 import com.epam.aidial.core.server.token.TokenStatsTracker;
 import com.epam.aidial.core.server.tracing.DialTracingFactory;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
@@ -162,6 +163,7 @@ public class AiDial {
 
     private BlobStorage storage;
     private ResourceService resourceService;
+    private ComplexResourceSweepService complexResourceSweepService;
     private EncryptionService encryptionService;
 
     private LongSupplier clock = System::currentTimeMillis;
@@ -305,7 +307,11 @@ public class AiDial {
             responseMappingService.init(vertx, taskExecutor);
 
             ComplexResourceService complexResourceService = new ComplexResourceService(
-                    resourceService, lockService, shareService, invitationService);
+                    resourceService, lockService, shareService, invitationService, storage);
+            ComplexResourceSweepService.Settings complexResourceSweepSettings = Json.decodeValue(
+                    settings("complexResourceSweep").toBuffer(), ComplexResourceSweepService.Settings.class);
+            complexResourceSweepService = new ComplexResourceSweepService(timerService, storage, redis, lockService,
+                    complexResourceService, encryptionService, complexResourceSweepSettings);
 
             proxy = new Proxy(vertx, clientOptions, apiKeyValidation, client, webSocketClient, configStore, logStore,
                     rateLimiter, upstreamRouteProvider, accessTokenValidator,
@@ -409,6 +415,7 @@ public class AiDial {
             close(server, HttpServer::close);
             close(client, HttpClient::close);
             close(resourceService);
+            close(complexResourceSweepService);
             // Unhook from the global composite before vertx.close() so its shutdown metrics
             // stop flowing here; close the registries only after vertx has flushed its own.
             if (prometheusRegistry != null) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceController.java
@@ -189,7 +189,7 @@ public class ComplexResourceController extends AccessControlBaseController {
                 .exceptionHandler(received::tryFail);
 
         received.future()
-                .compose(v -> proxy.getTaskExecutor().submit(() -> complexResourceService.putFolder(resource, handler, uploads, etag, author)))
+                .compose(v -> proxy.getTaskExecutor().submit(() -> complexResourceService.put(resource, handler, uploads, etag, author)))
                 .compose(aggregateEtag -> context.putHeader(HttpHeaders.ETAG, aggregateEtag)
                         .exposeHeaders()
                         .respond(HttpStatus.OK)
@@ -226,7 +226,7 @@ public class ComplexResourceController extends AccessControlBaseController {
     )
     private Future<?> putFolderCreate(ResourceDescriptor resource) {
         String author = context.getUserDisplayName();
-        proxy.getTaskExecutor().submit(() -> complexResourceService.createDialFolder(resource, author))
+        proxy.getTaskExecutor().submit(() -> complexResourceService.createFolder(resource, author))
                 .compose(etag -> context.putHeader(HttpHeaders.ETAG, etag)
                         .exposeHeaders()
                         .respond(HttpStatus.OK)
@@ -265,7 +265,7 @@ public class ComplexResourceController extends AccessControlBaseController {
     private Future<?> deleteFolderTarget(ResourceDescriptor resource) {
         EtagHeader etag = ProxyUtil.etag(context.getRequest());
         proxy.getTaskExecutor().submit(() -> {
-            complexResourceService.deleteDialFolder(resource, etag);
+            complexResourceService.deleteFolder(resource, etag);
             return null;
         })
                 .compose(v -> context.respond(HttpStatus.OK).mapEmpty())
@@ -344,7 +344,7 @@ public class ComplexResourceController extends AccessControlBaseController {
     private Future<?> delete(ResourceDescriptor resource) {
         EtagHeader etag = ProxyUtil.etag(context.getRequest());
         proxy.getTaskExecutor().submit(() -> {
-            complexResourceService.deleteFolder(resource, etag);
+            complexResourceService.delete(resource, etag);
             return null;
         })
                 .compose(v -> context.respond(HttpStatus.OK).mapEmpty())

--- a/server/src/main/java/com/epam/aidial/core/server/data/folder/ComplexResourceRef.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/folder/ComplexResourceRef.java
@@ -1,0 +1,18 @@
+package com.epam.aidial.core.server.data.folder;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Sweep-enumeration pointer stored at {@code complex_resource_refs/{uuid}.json}, written once on first
+ * whole-resource creation so {@code ComplexResourceSweepService} can enumerate every complex resource in the
+ * system without walking every bucket. The marker (not this pointer) remains the source of truth for the
+ * resource's state/version.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ComplexResourceRef {
+    private String url;
+}

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -687,7 +687,11 @@ public class ComplexResourceService {
      */
     boolean reclaimDeletingResource(ResourceDescriptor resource, long gracePeriodMs) {
         ResourceDescriptor marker = markerDescriptor(resource);
-        try (LockService.Lock ignore = resourceService.lockResource(marker)) {
+        try (LockService.Lock lock = resourceService.tryLockResource(marker)) {
+            if (lock == null) {
+                log.warn("Lock is not acquired to delete inactive resource {}", resource.getDecodedUrl());
+                return false;
+            }
             FolderResourceMarker current = readMarker(marker, false);
             if (current == null || !STATE_DELETING.equals(current.getState())) {
                 return false;
@@ -714,7 +718,10 @@ public class ComplexResourceService {
      */
     boolean gcObsoleteVersions(ResourceDescriptor resource, long gracePeriodMs) {
         ResourceDescriptor marker = markerDescriptor(resource);
-        try (LockService.Lock ignore = resourceService.lockResource(marker)) {
+        try (LockService.Lock lock = resourceService.tryLockResource(marker)) {
+            if (lock == null) {
+                return false;
+            }
             FolderResourceMarker current = readMarker(marker, false);
             if (!isActive(current)) {
                 return false;

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -1,9 +1,11 @@
 package com.epam.aidial.core.server.service.resource;
 
+import com.epam.aidial.core.server.data.folder.ComplexResourceRef;
 import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
 import com.epam.aidial.core.server.service.InvitationService;
 import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.storage.blobstore.BlobStorage;
 import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
 import com.epam.aidial.core.storage.data.FileMetadata;
 import com.epam.aidial.core.storage.data.MetadataBase;
@@ -21,7 +23,6 @@ import io.vertx.core.buffer.Buffer;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -55,13 +56,20 @@ public class ComplexResourceService {
 
     public static final String MARKER_NAME = ".dial-resource";
     public static final String FOLDER_MARKER_NAME = ".dial-folder";
+    /**
+     * Root-level (not bucket-scoped) prefix for the sweep-enumeration reference registry, sibling to the
+     * {@code .dial-tmp} temp-folder prefix. Manipulated via raw {@link BlobStorage} calls, not through
+     * {@link ResourceService}, since it is infrastructure bookkeeping rather than an access-controlled resource.
+     */
+    public static final String COMPLEX_RESOURCE_REFS_FOLDER = "complex_resource_refs";
 
     private static final String VERSION_PREFIX = "v";
     private static final String FILES_SEGMENT = "files";
     private static final String FOLDER_TYPE = "folder";
     private static final int SCHEMA_VERSION = 1;
     private static final String STATE_ACTIVE = "active";
-    private static final String STATE_DELETING = "deleting";
+    // Package-visible: ComplexResourceSweepService compares the raw marker state read via readMarkerForSweep.
+    static final String STATE_DELETING = "deleting";
     private static final int PAGE_SIZE = 1000;
     // A file inside a resource must not be named after a structural token.
     private static final Set<String> RESERVED_SEGMENTS = Set.of(VERSION_PREFIX, MARKER_NAME, FOLDER_MARKER_NAME);
@@ -72,13 +80,16 @@ public class ComplexResourceService {
     private final LockService lockService;
     private final ShareService shareService;
     private final InvitationService invitationService;
+    private final BlobStorage blobStorage;
 
     public ComplexResourceService(ResourceService resourceService, LockService lockService,
-                                 ShareService shareService, InvitationService invitationService) {
+                                 ShareService shareService, InvitationService invitationService,
+                                 BlobStorage blobStorage) {
         this.resourceService = resourceService;
         this.lockService = lockService;
         this.shareService = shareService;
         this.invitationService = invitationService;
+        this.blobStorage = blobStorage;
     }
 
     /**
@@ -88,8 +99,8 @@ public class ComplexResourceService {
      *
      * @param uploads relative path -> file content (as received from the multipart body)
      */
-    public String putFolder(ResourceDescriptor resource, ComplexResourceHandler handler,
-                            Map<String, Buffer> uploads, EtagHeader etag, String author) {
+    public String put(ResourceDescriptor resource, ComplexResourceHandler handler,
+                      Map<String, Buffer> uploads, EtagHeader etag, String author) {
         String name = resource.getName();
         if (name == null) {
             throw new HttpException(HttpStatus.BAD_REQUEST, "Resource name is missing");
@@ -133,6 +144,11 @@ public class ComplexResourceService {
                         fileEtags.put(relativePath, written.getEtag());
                     }
                     FolderResourceMarker existing = readMarker(marker, false);
+                    if (existing == null) {
+                        // First creation only: an overwrite of an existing (even `deleting`) marker reuses
+                        // its reference, which is keyed by URL, not by version.
+                        writeReference(resource);
+                    }
                     return commitMarker(marker, resource, versionId, aggregateEtag(fileEtags),
                             handler.buildMarkerMetadata(files), fileEtags, existing, author);
                 } catch (Exception e) {
@@ -282,6 +298,18 @@ public class ComplexResourceService {
     }
 
     /**
+     * Writes a sweep-enumeration reference pointer for a newly created resource, before the marker commits
+     * (crash-safe: a resource can never exist without a reference). Written via a plain {@link BlobStorage}
+     * call, not through {@link ResourceService}, exactly like the existing {@code .dial-tmp} bookkeeping.
+     */
+    private void writeReference(ResourceDescriptor resource) {
+        String refId = UUID.randomUUID().toString().replace("-", "");
+        String path = COMPLEX_RESOURCE_REFS_FOLDER + ResourceDescriptor.PATH_SEPARATOR + refId + ".json";
+        String json = Objects.requireNonNull(ProxyUtil.convertToString(new ComplexResourceRef(resource.getUrl())));
+        blobStorage.store(path, "application/json", null, Map.of(), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
      * Aggregate etag derived from the per-file etags (relative path -> etag), sorted by path so the result
      * is deterministic regardless of insertion order.
      */
@@ -327,7 +355,7 @@ public class ComplexResourceService {
      * structural invariants (auto-vivifying intermediate folders), then rejects if a resource or folder
      * already exists at the target. Returns the folder's synthetic etag.
      */
-    public String createDialFolder(ResourceDescriptor resource, String author) {
+    public String createFolder(ResourceDescriptor resource, String author) {
         String name = resource.getName();
         if (name == null) {
             throw new HttpException(HttpStatus.BAD_REQUEST, "Folder name is missing");
@@ -349,7 +377,7 @@ public class ComplexResourceService {
      * @throws HttpException NOT_FOUND if the folder is absent/deleting, PRECONDITION_FAILED on If-Match
      *                       mismatch, CONFLICT if the folder is not empty
      */
-    public void deleteDialFolder(ResourceDescriptor resource, EtagHeader etag) {
+    public void deleteFolder(ResourceDescriptor resource, EtagHeader etag) {
         ResourceDescriptor marker = folderMarkerDescriptor(resource);
         lockService.underBucketLock(resource.getBucketLocation(), () -> {
             FolderResourceMarker current = readMarker(marker, false);
@@ -366,10 +394,12 @@ public class ComplexResourceService {
     }
 
     /**
-     * Lists DIAL resources and grouping folders at a grouping level. A node is classified purely by the
-     * presence of its marker file ({@code .dial-resource} → {@code ITEM}, {@code .dial-folder} →
-     * {@code FOLDER}); the marker content is never read. Files that live inside a resource are excluded,
-     * so only resource/folder nodes are returned.
+     * Lists DIAL resources and grouping folders at a grouping level. A node is classified by the presence
+     * of its marker file ({@code .dial-resource} → {@code ITEM}, {@code .dial-folder} → {@code FOLDER}).
+     * A {@code .dial-resource} marker is additionally read to exclude a tombstoned ({@code deleting})
+     * resource: since the sweep (not this request path) reclaims it, its marker file can otherwise outlive
+     * the DELETE response. Files that live inside a resource are excluded, so only resource/folder nodes
+     * are returned.
      *
      * <p>When {@code recursive} is {@code true} the whole subtree is walked (as in the v1 metadata API);
      * otherwise only immediate children are returned. Pagination reuses the blob continuation token, so a
@@ -403,6 +433,11 @@ public class ComplexResourceService {
             // "v" can only be a version prefix (it is a reserved name), so a "v" segment means the marker
             // lives inside a resource's version tree and does not denote a nested node.
             if (isInsideVersionTree(relativePath)) {
+                continue;
+            }
+            // A folder marker has no tombstone lifecycle, but a resource marker does: its file can still
+            // exist in a `deleting` state until the sweep reclaims it, so presence alone isn't enough.
+            if (nodeType == NodeType.ITEM && !isActive(readMarker(item.getDescriptor(), false))) {
                 continue;
             }
             items.add(nodeMetadata(item.getDescriptor().getParent(), nodeType, (ResourceItemMetadata) item));
@@ -589,22 +624,22 @@ public class ComplexResourceService {
     }
 
     /**
-     * Tombstones the resource by flipping the {@code .dial-resource} marker to {@code state: deleting},
-     * then best-effort removes the version tree and marker. If the marker does not exist the method
-     * returns without doing anything (idempotent).
+     * Tombstones the resource by flipping the {@code .dial-resource} marker to {@code state: deleting} and
+     * stamping {@code deletedAt}, then (for a private resource) cleans up its invitation links and shares.
+     * The version tree, the marker file itself and its {@code complex_resource_refs} pointer are <b>not</b>
+     * touched here: they are reclaimed later, once {@code gracePeriod} has elapsed, by
+     * {@code ComplexResourceSweepService} via {@link #reclaimDeletingResource}.
      *
      * <p>The tombstone write (via {@link ResourceService#computeResource}) is the linearization point:
      * once committed, all read paths return 404 even if the version tree still physically exists.
      *
-     * @throws HttpException PRECONDITION_FAILED if the {@code If-Match} header does not match
+     * @throws HttpException NOT_FOUND if the resource does not exist or is already {@code deleting};
+     *                       PRECONDITION_FAILED if the {@code If-Match} header does not match
      */
-    public void deleteFolder(ResourceDescriptor resource, EtagHeader etag) {
+    public void delete(ResourceDescriptor resource, EtagHeader etag) {
         ResourceDescriptor marker = markerDescriptor(resource);
 
-        // DELETE is structural (it may affect ancestor-folder emptiness). Take the bucket lock so the
-        // tombstone commit and access-control cleanup happen atomically; the inner resource lock taken by
-        // computeResource is nested inside it (bucket-before-resource, the global order).
-        MutableObject<String> capturedVersion = new MutableObject<>();
+        // use bucket lock since the operation involves updating multiple resources
         lockService.underBucketLock(resource.getBucketLocation(), () -> {
             resourceService.computeResource(marker, json -> {
                 if (json == null) {
@@ -615,7 +650,6 @@ public class ComplexResourceService {
                     throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
                 }
                 etag.validate(current.getEtag());
-                capturedVersion.setValue(current.getCurrentVersion());
                 current.setState(STATE_DELETING);
                 current.setDeletedAt(System.currentTimeMillis());
                 return Objects.requireNonNull(ProxyUtil.convertToString(current));
@@ -629,11 +663,88 @@ public class ComplexResourceService {
             }
             return null;
         });
+    }
 
-        if (capturedVersion.get() != null) {
-            ResourceDescriptor folderVersion = versionFolder(resource, capturedVersion.get());
-            deleteVersion(folderVersion);
-            resourceService.deleteResource(marker, EtagHeader.ANY);
+    /**
+     * Reads the {@code .dial-resource} marker as-is, including a {@code deleting} state (unlike
+     * {@link #getMarker}, which treats it as absent). Package-visible: called only by
+     * {@code ComplexResourceSweepService} to decide how to treat a reference during the sweep.
+     */
+    @Nullable
+    FolderResourceMarker readMarkerForSweep(ResourceDescriptor resource) {
+        return readMarker(markerDescriptor(resource), false);
+    }
+
+    /**
+     * Reclaims a {@code deleting} resource: deletes its version tree and the marker itself, once
+     * {@code gracePeriodMs} has elapsed since the marker was tombstoned. Package-visible: called only by
+     * {@code ComplexResourceSweepService}, after the marker has been reclaimed the caller deletes the
+     * reference.
+     *
+     * @return {@code true} if the resource was reclaimed; {@code false} if the marker has since become
+     *         {@code active} again (a recreate raced ahead of the sweep) or is still inside the grace window
+     *         (the caller should retry on a later pass)
+     */
+    boolean reclaimDeletingResource(ResourceDescriptor resource, long gracePeriodMs) {
+        ResourceDescriptor marker = markerDescriptor(resource);
+        try (LockService.Lock ignore = resourceService.lockResource(marker)) {
+            FolderResourceMarker current = readMarker(marker, false);
+            if (current == null || !STATE_DELETING.equals(current.getState())) {
+                return false;
+            }
+            long deletedAt = current.getDeletedAt() == null ? 0L : current.getDeletedAt();
+            if (System.currentTimeMillis() - deletedAt < gracePeriodMs) {
+                return false;
+            }
+            deleteVersion(versionFolder(resource, current.getCurrentVersion()));
+            // Already holding the marker's resource lock (acquired above); deleteResource must not
+            // re-acquire it itself, or it deadlocks against the outstanding lock.
+            resourceService.deleteResource(marker, EtagHeader.ANY, false);
+            return true;
+        }
+    }
+
+    /**
+     * GCs {@code v/{versionId}} siblings of an {@code active} resource other than its current version, once
+     * {@code gracePeriodMs} has elapsed since the marker was last updated. Safety net for {@code copyOnWrite}'s
+     * inline old-version delete when that previously failed. Package-visible: called only by
+     * {@code ComplexResourceSweepService}.
+     *
+     * @return {@code true} if any orphan version was GC'd
+     */
+    boolean gcObsoleteVersions(ResourceDescriptor resource, long gracePeriodMs) {
+        ResourceDescriptor marker = markerDescriptor(resource);
+        try (LockService.Lock ignore = resourceService.lockResource(marker)) {
+            FolderResourceMarker current = readMarker(marker, false);
+            if (!isActive(current)) {
+                return false;
+            }
+            long updatedAt = current.getUpdatedAt() == null ? 0L : current.getUpdatedAt();
+            if (System.currentTimeMillis() - updatedAt < gracePeriodMs) {
+                return false;
+            }
+            String currentVersion = current.getCurrentVersion();
+            ResourceDescriptor versionsFolder = versionsFolder(resource);
+            boolean gced = false;
+            String token = null;
+            do {
+                ResourceFolderMetadata page = resourceService.getFolderMetadata(versionsFolder, token, PAGE_SIZE, false);
+                if (page == null) {
+                    break;
+                }
+                for (MetadataBase item : page.getItems()) {
+                    if (item.getNodeType() != NodeType.FOLDER) {
+                        continue;
+                    }
+                    ResourceDescriptor obsoleteVersion = versionsFolder.resolveByUrl(item.getUrl());
+                    if (!obsoleteVersion.getName().equals(currentVersion)) {
+                        deleteVersion(obsoleteVersion);
+                        gced = true;
+                    }
+                }
+                token = page.getNextToken();
+            } while (token != null);
+            return gced;
         }
     }
 
@@ -758,6 +869,14 @@ public class ComplexResourceService {
         parentFolders.add(resource.getName());
         parentFolders.add(VERSION_PREFIX);
         return new ResourceDescriptor(resource.getType(), versionId, parentFolders,
+                resource.getBucketName(), resource.getBucketLocation(), true);
+    }
+
+    /** Folder descriptor for the {@code v/} prefix itself, used to list all version-id siblings. */
+    private static ResourceDescriptor versionsFolder(ResourceDescriptor resource) {
+        List<String> parentFolders = new ArrayList<>(resource.getParentFolders());
+        parentFolders.add(resource.getName());
+        return new ResourceDescriptor(resource.getType(), VERSION_PREFIX, parentFolders,
                 resource.getBucketName(), resource.getBucketLocation(), true);
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceSweepService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceSweepService.java
@@ -1,0 +1,227 @@
+package com.epam.aidial.core.server.service.resource;
+
+import com.epam.aidial.core.server.data.folder.ComplexResourceRef;
+import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
+import com.epam.aidial.core.storage.blobstore.BlobStorage;
+import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.service.LockService;
+import com.epam.aidial.core.storage.service.TimerService;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+/**
+ * Periodic sweep that reclaims storage for the folder-as-resource machinery: it finishes tombstoned
+ * ({@code deleting}) resources and GCs {@code v/{versionId}} siblings left behind by a failed/interrupted
+ * inline delete. It enumerates every complex resource in the system via the {@code complex_resource_refs}
+ * reference registry (written by {@link ComplexResourceService#put}), so it never has to walk every
+ * bucket.
+ *
+ * <p>Cursor advancement (sequential, must be exclusive cluster-wide) is decoupled from batch processing:
+ * a brief {@link LockService#tryLock(String)} claims and advances the shared cursor, then the (potentially slow)
+ * per-item work runs outside that lock. Like {@code ResourceService.sync()}/{@code cleanupTempFolder},
+ * {@code TimerService.scheduleWithFixedDelay} fires unconditionally every {@code period}, so ticks on this
+ * same instance can overlap if a batch takes longer than {@code period} to process; {@link Settings#activeBatches}
+ * is this instance's own concurrency budget for that, enforced purely locally via {@link #activeBatchCount},
+ * independent of what any other instance is doing.
+ */
+@Slf4j
+public class ComplexResourceSweepService implements AutoCloseable {
+
+    private static final String CURSOR_STATE_KEY = "cursor_state";
+
+    private final BlobStorage blobStorage;
+    private final RedissonClient redis;
+    private final LockService lockService;
+    private final ComplexResourceService complexResourceService;
+    private final EncryptionService encryptionService;
+    private final Settings settings;
+    private final TimerService.Timer timer;
+    private final AtomicInteger activeBatchCount = new AtomicInteger(0);
+    private final String cursorStateKey;
+
+    private final Counter batchesCounter;
+    private final Counter reclaimedCounter;
+    private final Counter orphanVersionsCounter;
+    private final Counter danglingRefsCounter;
+
+    public ComplexResourceSweepService(TimerService timerService, BlobStorage blobStorage, RedissonClient redis,
+                                       LockService lockService, ComplexResourceService complexResourceService,
+                                       EncryptionService encryptionService, Settings settings) {
+        this.blobStorage = blobStorage;
+        this.redis = redis;
+        this.lockService = lockService;
+        this.complexResourceService = complexResourceService;
+        this.encryptionService = encryptionService;
+        this.settings = settings;
+
+        this.batchesCounter = Counter.builder("dial_complex_resource_sweep_batches_total").register(Metrics.globalRegistry);
+        this.reclaimedCounter = Counter.builder("dial_complex_resource_sweep_reclaimed_total").register(Metrics.globalRegistry);
+        this.orphanVersionsCounter = Counter.builder("dial_complex_resource_sweep_orphan_versions_total").register(Metrics.globalRegistry);
+        this.danglingRefsCounter = Counter.builder("dial_complex_resource_sweep_dangling_refs_total").register(Metrics.globalRegistry);
+
+        this.timer = timerService.scheduleWithFixedDelay(settings.getPeriod(), settings.getPeriod(), this::tick);
+        String prefix = lockService.getPrefix();
+        this.cursorStateKey = "complex_resource:" + BlobStorageUtil.toStoragePath(prefix, CURSOR_STATE_KEY);
+    }
+
+    @SneakyThrows
+    @Override
+    public void close() {
+        timer.close();
+    }
+
+    @VisibleForTesting
+    void tick() {
+        if (activeBatchCount.incrementAndGet() > settings.getActiveBatches()) {
+            // This instance is already at its own activeBatches cap; skip this tick.
+            activeBatchCount.decrementAndGet();
+            return;
+        }
+        try {
+            List<? extends StorageMetadata> batch = claimBatch();
+            if (batch == null) {
+                return;
+            }
+            batchesCounter.increment();
+            for (StorageMetadata meta : batch) {
+                try {
+                    processRef(meta);
+                } catch (Throwable e) {
+                    log.warn("Failed to process complex resource ref: {}", meta.getName(), e);
+                }
+            }
+        } catch (Throwable e) {
+            log.warn("Failed to run complex resource sweep tick", e);
+        } finally {
+            activeBatchCount.decrementAndGet();
+        }
+    }
+
+    /**
+     * Claims (and advances) the next batch slice under a brief, exclusive lock, then releases the lock
+     * before returning so a concurrent tick can already claim the next slice while this one processes its
+     * own. Returns {@code null} if another tick is mid-claim. Once a pass completes (the cursor wraps back
+     * to {@code null}), the next tick immediately starts a new pass from the beginning.
+     */
+    @Nullable
+    private List<? extends StorageMetadata> claimBatch() {
+        try (LockService.Lock lock = lockService.tryLock(cursorStateKey)) {
+            if (lock == null) {
+                return null;
+            }
+            ScanState state = readState();
+            PageSet<? extends StorageMetadata> page = blobStorage.list(
+                    ComplexResourceService.COMPLEX_RESOURCE_REFS_FOLDER, state.getNextToken(), settings.getBatch(), true);
+            state.setNextToken(page.getNextMarker());
+            writeState(state);
+            return new ArrayList<>(page);
+        }
+    }
+
+    private void processRef(StorageMetadata meta) {
+        if (meta.getType() != StorageType.BLOB) {
+            return;
+        }
+        String path = meta.getName();
+        ComplexResourceRef ref = loadRef(path);
+        if (ref == null) {
+            return;
+        }
+        ResourceDescriptor resource = ResourceDescriptorFactory.fromAnyUrl(ref.getUrl(), encryptionService);
+        FolderResourceMarker marker = complexResourceService.readMarkerForSweep(resource);
+        if (marker == null) {
+            blobStorage.delete(path);
+            danglingRefsCounter.increment();
+        } else if (ComplexResourceService.STATE_DELETING.equals(marker.getState())) {
+            if (complexResourceService.reclaimDeletingResource(resource, settings.getGracePeriod())) {
+                blobStorage.delete(path);
+                reclaimedCounter.increment();
+            }
+        } else if (complexResourceService.gcObsoleteVersions(resource, settings.getGracePeriod())) {
+            orphanVersionsCounter.increment();
+        }
+    }
+
+
+    @Nullable
+    private ComplexResourceRef loadRef(String path) {
+        Blob blob = blobStorage.load(path);
+        if (blob == null) {
+            return null;
+        }
+        try (InputStream input = blob.getPayload().openStream()) {
+            return ProxyUtil.convertToObject(input.readAllBytes(), ComplexResourceRef.class);
+        } catch (Exception e) {
+            log.warn("Failed to read complex resource ref: {}", path, e);
+            return null;
+        }
+    }
+
+    private ScanState readState() {
+        RBucket<String> bucket = redis.getBucket(cursorStateKey, StringCodec.INSTANCE);
+        String json = bucket.get();
+        ScanState state = json == null ? null : ProxyUtil.convertToObject(json, ScanState.class);
+        return state == null ? new ScanState() : state;
+    }
+
+    private void writeState(ScanState state) {
+        RBucket<String> bucket = redis.getBucket(cursorStateKey, StringCodec.INSTANCE);
+        bucket.set(Objects.requireNonNull(ProxyUtil.convertToString(state)));
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ScanState {
+        private String nextToken;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Settings {
+        /**
+         * Period in milliseconds between sweep ticks.
+         */
+        private long period;
+        /**
+         * Number of references listed (and potentially processed) per batch.
+         */
+        private int batch;
+        /**
+         * Max number of batches this instance may have mid-processing in parallel at any moment. Enforced
+         * purely locally (an in-process counter); each instance gets its own independent budget, not a
+         * cluster-wide total.
+         */
+        private int activeBatches;
+        /**
+         * Minimum age in milliseconds a {@code deleting} marker or a superseded version must reach before
+         * the sweep will physically delete it, to protect any reader that started before the
+         * tombstone/supersession.
+         */
+        private long gracePeriod;
+    }
+}

--- a/server/src/main/resources/aidial.settings.json
+++ b/server/src/main/resources/aidial.settings.json
@@ -65,6 +65,12 @@
     "compressionMinSize": 256,
     "heartbeatPeriod": 60000
   },
+  "complexResourceSweep": {
+    "period": 10000,
+    "batch": 1000,
+    "activeBatches": 5,
+    "gracePeriod": 3600000
+  },
   "applications": {
     "includeCustomApps": true
   },

--- a/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceServiceTest.java
@@ -1,0 +1,260 @@
+package com.epam.aidial.core.server.service.resource;
+
+import com.epam.aidial.core.server.FileUtil;
+import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
+import com.epam.aidial.core.server.service.InvitationService;
+import com.epam.aidial.core.server.service.ShareService;
+import com.epam.aidial.core.storage.blobstore.BlobStorage;
+import com.epam.aidial.core.storage.blobstore.Storage;
+import com.epam.aidial.core.storage.data.ResourceItemMetadata;
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.resource.ResourceTypes;
+import com.epam.aidial.core.storage.service.LockService;
+import com.epam.aidial.core.storage.service.ResourceService;
+import com.epam.aidial.core.storage.service.TimerService;
+import com.epam.aidial.core.storage.util.EtagHeader;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.buffer.Buffer;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComplexResourceServiceTest {
+
+    private static final String MANIFEST = """
+            ---
+            name: Test Skill
+            description: A skill used for tests
+            ---
+            # Body
+            """;
+
+    private RedisServer redisServer;
+    private RedissonClient redis;
+    private BlobStorage blobStorage;
+    private Path testDir;
+    private ResourceService resourceService;
+    private ComplexResourceService complexResourceService;
+    private final SkillHandler handler = new SkillHandler();
+
+    @BeforeEach
+    void init() throws IOException {
+        try {
+            redisServer = RedisServer.newRedisServer()
+                    .port(16380)
+                    .bind("127.0.0.1")
+                    .setting("maxmemory 8M")
+                    .setting("maxmemory-policy volatile-lfu")
+                    .build();
+            redisServer.start();
+
+            Config config = new Config();
+            config.useSingleServer().setAddress("redis://localhost:16380");
+            redis = Redisson.create(config);
+
+            testDir = FileUtil.baseTestPath(ComplexResourceServiceTest.class);
+            FileUtil.deleteDir(testDir);
+            FileUtil.createDir(testDir.resolve("test"));
+            String blobStorageConfig = """
+                    {
+                        "bucket": "test",
+                        "provider": "filesystem",
+                        "identity": "access-key",
+                        "credential": "secret-key",
+                        "overrides": {
+                          "jclouds.filesystem.basedir": "%s"
+                        }
+                      }
+                    """.formatted(testDir.toString());
+            ObjectMapper mapper = new ObjectMapper();
+            Storage storageConfig = mapper.readValue(blobStorageConfig, Storage.class);
+            blobStorage = new BlobStorage(storageConfig);
+
+            TimerService timerService = Mockito.mock(TimerService.class);
+            LockService lockService = new LockService(redis, null);
+
+            String serviceConfig = """
+                    {
+                     "maxSize" : 67108864,
+                     "maxSizeToCache": 1048576,
+                     "syncPeriod": 60000,
+                     "syncDelay": 120000,
+                     "syncBatch": 4096,
+                     "cacheExpiration": 300000,
+                     "compressionMinSize": 256,
+                     "heartbeatPeriod": 60000
+                    }
+                    """;
+            ResourceService.Settings settings = mapper.readValue(serviceConfig, ResourceService.Settings.class);
+            resourceService = new ResourceService(timerService, redis, blobStorage, lockService, settings, null);
+
+            ShareService shareService = Mockito.mock(ShareService.class);
+            InvitationService invitationService = Mockito.mock(InvitationService.class);
+            complexResourceService = new ComplexResourceService(
+                    resourceService, lockService, shareService, invitationService, blobStorage);
+        } catch (Throwable e) {
+            destroy();
+            throw e;
+        }
+    }
+
+    @AfterEach
+    void destroy() throws IOException {
+        try {
+            if (redis != null) {
+                redis.shutdown();
+            }
+            if (blobStorage != null) {
+                blobStorage.close();
+            }
+        } finally {
+            if (redisServer != null) {
+                redisServer.stop();
+            }
+            if (testDir != null) {
+                FileUtil.deleteDir(testDir);
+            }
+        }
+    }
+
+    private ResourceDescriptor skill(String name) {
+        return new ResourceDescriptor(ResourceTypes.SKILL, name, List.of(), "public", "public/", false);
+    }
+
+    private void putSkill(ResourceDescriptor resource, EtagHeader etag) {
+        Map<String, Buffer> uploads = Map.of("SKILL.md", Buffer.buffer(MANIFEST));
+        complexResourceService.put(resource, handler, uploads, etag, "user1");
+    }
+
+    private List<StorageMetadata> listRefs() {
+        PageSet<? extends StorageMetadata> page = blobStorage.list(
+                ComplexResourceService.COMPLEX_RESOURCE_REFS_FOLDER, null, 1000, true);
+        List<StorageMetadata> blobs = new ArrayList<>();
+        for (StorageMetadata meta : page) {
+            if (meta.getType() == StorageType.BLOB) {
+                blobs.add(meta);
+            }
+        }
+        return blobs;
+    }
+
+    private ResourceDescriptor versionFile(ResourceDescriptor resource, String versionId, String fileName) {
+        return new ResourceDescriptor(resource.getType(), fileName,
+                List.of(resource.getName(), "v", versionId), resource.getBucketName(), resource.getBucketLocation(), false);
+    }
+
+    @Test
+    void testReferenceWrittenOnFirstCreationOnly() {
+        ResourceDescriptor resource = skill("mySkill");
+
+        putSkill(resource, EtagHeader.ANY);
+        assertEquals(1, listRefs().size());
+
+        // A second whole-resource write to the same path is a new version of an already-existing
+        // resource, not a first creation, so it must not add another reference.
+        putSkill(resource, EtagHeader.ANY);
+        assertEquals(1, listRefs().size());
+    }
+
+    @Test
+    void testDeleteOnlyTombstonesMarker() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource, EtagHeader.ANY);
+
+        FolderResourceMarker before = complexResourceService.readMarkerForSweep(resource);
+        assertNotNull(before);
+        String versionId = before.getCurrentVersion();
+
+        complexResourceService.delete(resource, EtagHeader.ANY);
+
+        FolderResourceMarker after = complexResourceService.readMarkerForSweep(resource);
+        assertNotNull(after);
+        assertEquals("deleting", after.getState());
+        assertNotNull(after.getDeletedAt());
+
+        // The version tree and the marker itself are left in place for the sweep to reclaim.
+        ResourceItemMetadata manifest = resourceService.getResourceMetadata(versionFile(resource, versionId, "SKILL.md"));
+        assertNotNull(manifest);
+        assertEquals(1, listRefs().size());
+    }
+
+    @Test
+    void testReclaimDeletingResourceRespectsGracePeriod() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource, EtagHeader.ANY);
+        FolderResourceMarker marker = complexResourceService.readMarkerForSweep(resource);
+        String versionId = marker.getCurrentVersion();
+        complexResourceService.delete(resource, EtagHeader.ANY);
+
+        // Still within the grace period: nothing is reclaimed.
+        assertFalse(complexResourceService.reclaimDeletingResource(resource, 3_600_000L));
+        assertNotNull(complexResourceService.readMarkerForSweep(resource));
+        assertNotNull(resourceService.getResourceMetadata(versionFile(resource, versionId, "SKILL.md")));
+
+        // Past the grace period: the version tree and the marker are reclaimed.
+        assertTrue(complexResourceService.reclaimDeletingResource(resource, 0L));
+        assertNull(complexResourceService.readMarkerForSweep(resource));
+        assertNull(resourceService.getResourceMetadata(versionFile(resource, versionId, "SKILL.md")));
+    }
+
+    @Test
+    void testReclaimDeletingResourceNoOpWhenActive() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource, EtagHeader.ANY);
+
+        assertFalse(complexResourceService.reclaimDeletingResource(resource, 0L));
+        assertNotNull(complexResourceService.readMarkerForSweep(resource));
+    }
+
+    @Test
+    void testGcObsoleteVersionsRespectsGracePeriod() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource, EtagHeader.ANY);
+        FolderResourceMarker marker = complexResourceService.readMarkerForSweep(resource);
+        String currentVersion = marker.getCurrentVersion();
+
+        // Simulate an orphan version left behind by a previously failed inline delete in copyOnWrite.
+        String orphanVersionId = "orphanversion";
+        ResourceDescriptor orphanFile = versionFile(resource, orphanVersionId, "orphan.txt");
+        resourceService.putFile(orphanFile, "x".getBytes(), EtagHeader.ANY, "text/plain", "user1");
+        assertNotNull(resourceService.getResourceMetadata(orphanFile));
+
+        // Still within the grace period: the orphan version is left alone.
+        assertFalse(complexResourceService.gcObsoleteVersions(resource, 3_600_000L));
+        assertNotNull(resourceService.getResourceMetadata(orphanFile));
+
+        // Past the grace period: the orphan version is GC'd, the current version is untouched.
+        assertTrue(complexResourceService.gcObsoleteVersions(resource, 0L));
+        assertNull(resourceService.getResourceMetadata(orphanFile));
+        assertNotNull(resourceService.getResourceMetadata(versionFile(resource, currentVersion, "SKILL.md")));
+    }
+
+    @Test
+    void testGcObsoleteVersionsNoOpWhenDeleting() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource, EtagHeader.ANY);
+        complexResourceService.delete(resource, EtagHeader.ANY);
+
+        assertFalse(complexResourceService.gcObsoleteVersions(resource, 0L));
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceSweepServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceSweepServiceTest.java
@@ -1,0 +1,352 @@
+package com.epam.aidial.core.server.service.resource;
+
+import com.epam.aidial.core.server.FileUtil;
+import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.service.InvitationService;
+import com.epam.aidial.core.server.service.ShareService;
+import com.epam.aidial.core.storage.blobstore.BlobStorage;
+import com.epam.aidial.core.storage.blobstore.Storage;
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.resource.ResourceTypes;
+import com.epam.aidial.core.storage.service.LockService;
+import com.epam.aidial.core.storage.service.ResourceService;
+import com.epam.aidial.core.storage.service.TimerService;
+import com.epam.aidial.core.storage.util.EtagHeader;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComplexResourceSweepServiceTest {
+
+    private static final String MANIFEST = """
+            ---
+            name: Test Skill
+            description: A skill used for tests
+            ---
+            # Body
+            """;
+
+    private RedisServer redisServer;
+    private RedissonClient redis;
+    private BlobStorage blobStorage;
+    private Path testDir;
+    private LockService lockService;
+    private ResourceService resourceService;
+    private ComplexResourceService complexResourceService;
+    private EncryptionService encryptionService;
+    private SimpleMeterRegistry meterRegistry;
+    private final SkillHandler handler = new SkillHandler();
+
+    @BeforeEach
+    void init() throws IOException {
+        try {
+            // Metrics.globalRegistry is a bare CompositeMeterRegistry with no backing registry outside a
+            // running AiDial instance, so counters registered on it never actually accumulate; attach a
+            // real registry for the duration of the test so dial_complex_resource_sweep_* counters work.
+            meterRegistry = new SimpleMeterRegistry();
+            Metrics.addRegistry(meterRegistry);
+
+            redisServer = RedisServer.newRedisServer()
+                    .port(16381)
+                    .bind("127.0.0.1")
+                    .setting("maxmemory 8M")
+                    .setting("maxmemory-policy volatile-lfu")
+                    .build();
+            redisServer.start();
+
+            Config config = new Config();
+            config.useSingleServer().setAddress("redis://localhost:16381");
+            redis = Redisson.create(config);
+
+            testDir = FileUtil.baseTestPath(ComplexResourceSweepServiceTest.class);
+            FileUtil.deleteDir(testDir);
+            FileUtil.createDir(testDir.resolve("test"));
+            String blobStorageConfig = """
+                    {
+                        "bucket": "test",
+                        "provider": "filesystem",
+                        "identity": "access-key",
+                        "credential": "secret-key",
+                        "overrides": {
+                          "jclouds.filesystem.basedir": "%s"
+                        }
+                      }
+                    """.formatted(testDir.toString());
+            ObjectMapper mapper = new ObjectMapper();
+            Storage storageConfig = mapper.readValue(blobStorageConfig, Storage.class);
+            blobStorage = new BlobStorage(storageConfig);
+
+            TimerService timerService = Mockito.mock(TimerService.class);
+            Mockito.when(timerService.scheduleWithFixedDelay(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                    .thenReturn(() -> { });
+            lockService = new LockService(redis, null);
+
+            String serviceConfig = """
+                    {
+                     "maxSize" : 67108864,
+                     "maxSizeToCache": 1048576,
+                     "syncPeriod": 60000,
+                     "syncDelay": 120000,
+                     "syncBatch": 4096,
+                     "cacheExpiration": 300000,
+                     "compressionMinSize": 256,
+                     "heartbeatPeriod": 60000
+                    }
+                    """;
+            ResourceService.Settings settings = mapper.readValue(serviceConfig, ResourceService.Settings.class);
+            resourceService = new ResourceService(timerService, redis, blobStorage, lockService, settings, null);
+
+            ShareService shareService = Mockito.mock(ShareService.class);
+            InvitationService invitationService = Mockito.mock(InvitationService.class);
+            complexResourceService = new ComplexResourceService(
+                    resourceService, lockService, shareService, invitationService, blobStorage);
+            encryptionService = new EncryptionService(new JsonObject().put("secret", "secret").put("key", "key"));
+        } catch (Throwable e) {
+            destroy();
+            throw e;
+        }
+    }
+
+    @AfterEach
+    void destroy() throws IOException {
+        try {
+            if (meterRegistry != null) {
+                Metrics.removeRegistry(meterRegistry);
+                meterRegistry.close();
+            }
+            if (redis != null) {
+                redis.shutdown();
+            }
+            if (blobStorage != null) {
+                blobStorage.close();
+            }
+        } finally {
+            if (redisServer != null) {
+                redisServer.stop();
+            }
+            if (testDir != null) {
+                FileUtil.deleteDir(testDir);
+            }
+        }
+    }
+
+    private ComplexResourceSweepService newSweepService(int batch, int activeBatches, long gracePeriod) {
+        ComplexResourceSweepService.Settings settings = new ComplexResourceSweepService.Settings();
+        settings.setPeriod(10_000);
+        settings.setBatch(batch);
+        settings.setActiveBatches(activeBatches);
+        settings.setGracePeriod(gracePeriod);
+        TimerService timerService = Mockito.mock(TimerService.class);
+        Mockito.when(timerService.scheduleWithFixedDelay(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+                .thenReturn(() -> { });
+        return new ComplexResourceSweepService(
+                timerService, blobStorage, redis, lockService, complexResourceService, encryptionService, settings);
+    }
+
+    private ResourceDescriptor skill(String name) {
+        return new ResourceDescriptor(ResourceTypes.SKILL, name, List.of(), "public", "public/", false);
+    }
+
+    private void putSkill(ResourceDescriptor resource) {
+        Map<String, Buffer> uploads = Map.of("SKILL.md", Buffer.buffer(MANIFEST));
+        complexResourceService.put(resource, handler, uploads, EtagHeader.ANY, "user1");
+    }
+
+    private ResourceDescriptor versionFile(ResourceDescriptor resource, String versionId, String fileName) {
+        return new ResourceDescriptor(resource.getType(), fileName,
+                List.of(resource.getName(), "v", versionId), resource.getBucketName(), resource.getBucketLocation(), false);
+    }
+
+    private List<? extends StorageMetadata> listRefs() {
+        PageSet<? extends StorageMetadata> page = blobStorage.list(
+                ComplexResourceService.COMPLEX_RESOURCE_REFS_FOLDER, null, 1000, true);
+        return page.stream().filter(meta -> meta.getType() == StorageType.BLOB).toList();
+    }
+
+    private void writeDanglingRef(String url) {
+        String refId = java.util.UUID.randomUUID().toString().replace("-", "");
+        String path = ComplexResourceService.COMPLEX_RESOURCE_REFS_FOLDER + "/" + refId + ".json";
+        blobStorage.store(path, "application/json", null, Map.of(),
+                ("{\"url\":\"" + url + "\"}").getBytes());
+    }
+
+    @Test
+    void testDanglingRefIsDeletedAfterBucketLockConfirmsAbsence() {
+        ResourceDescriptor resource = skill("neverCreated");
+        writeDanglingRef(resource.getUrl());
+        assertEquals(1, listRefs().size());
+
+        double before = counterValue("dial_complex_resource_sweep_dangling_refs_total");
+        ComplexResourceSweepService sweep = newSweepService(100, 1, 3_600_000L);
+        sweep.tick();
+
+        assertEquals(0, listRefs().size());
+        assertEquals(before + 1, counterValue("dial_complex_resource_sweep_dangling_refs_total"));
+    }
+
+    @Test
+    void testTickReclaimsDeletingResourcePastGracePeriod() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource);
+        FolderResourceMarker marker = complexResourceService.readMarkerForSweep(resource);
+        String versionId = marker.getCurrentVersion();
+        complexResourceService.delete(resource, EtagHeader.ANY);
+
+        double before = counterValue("dial_complex_resource_sweep_reclaimed_total");
+        ComplexResourceSweepService sweep = newSweepService(100, 1, 0L);
+        sweep.tick();
+
+        assertNull(complexResourceService.readMarkerForSweep(resource));
+        assertNull(resourceService.getResourceMetadata(versionFile(resource, versionId, "SKILL.md")));
+        assertEquals(0, listRefs().size());
+        assertEquals(before + 1, counterValue("dial_complex_resource_sweep_reclaimed_total"));
+    }
+
+    @Test
+    void testTickDoesNotReclaimWithinGracePeriod() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource);
+        complexResourceService.delete(resource, EtagHeader.ANY);
+
+        ComplexResourceSweepService sweep = newSweepService(100, 1, 3_600_000L);
+        sweep.tick();
+
+        assertNotNull(complexResourceService.readMarkerForSweep(resource));
+        assertEquals(1, listRefs().size());
+    }
+
+    @Test
+    void testTickGcsObsoleteVersionPastGracePeriod() {
+        ResourceDescriptor resource = skill("mySkill");
+        putSkill(resource);
+        FolderResourceMarker marker = complexResourceService.readMarkerForSweep(resource);
+        String currentVersion = marker.getCurrentVersion();
+
+        String orphanVersionId = "orphanversion";
+        ResourceDescriptor orphanFile = versionFile(resource, orphanVersionId, "orphan.txt");
+        resourceService.putFile(orphanFile, "x".getBytes(), EtagHeader.ANY, "text/plain", "user1");
+
+        double before = counterValue("dial_complex_resource_sweep_orphan_versions_total");
+        ComplexResourceSweepService sweep = newSweepService(100, 1, 0L);
+        sweep.tick();
+
+        assertNull(resourceService.getResourceMetadata(orphanFile));
+        assertNotNull(resourceService.getResourceMetadata(versionFile(resource, currentVersion, "SKILL.md")));
+        // Still active: the reference stays.
+        assertEquals(1, listRefs().size());
+        assertEquals(before + 1, counterValue("dial_complex_resource_sweep_orphan_versions_total"));
+    }
+
+    @Test
+    void testTickSkipsWhenThisInstanceIsAtItsOwnActiveBatchesCap() throws Exception {
+        ResourceDescriptor resource = skill("neverCreated");
+        writeDanglingRef(resource.getUrl());
+
+        ComplexResourceSweepService sweep = newSweepService(100, 1, 3_600_000L);
+        Field field = ComplexResourceSweepService.class.getDeclaredField("activeBatchCount");
+        field.setAccessible(true);
+        AtomicInteger activeBatchCount = (AtomicInteger) field.get(sweep);
+
+        // Simulate this instance already having one batch mid-processing (its own activeBatches=1 cap).
+        activeBatchCount.set(1);
+        try {
+            sweep.tick();
+            assertEquals(1, listRefs().size());
+        } finally {
+            activeBatchCount.set(0);
+        }
+
+        // Budget freed up: the same instance now processes the batch.
+        sweep.tick();
+        assertEquals(0, listRefs().size());
+    }
+
+    @Test
+    void testActiveBatchesCapIsPerInstanceNotClusterWide() throws Exception {
+        // Simulate two Core pods, each with its own activeBatches=1 instance. Saturating instance1's own
+        // budget must not block instance2's independent budget, since the cap is enforced purely locally
+        // (a plain instance field), not via a shared cluster-wide count.
+        ResourceDescriptor resource = skill("neverCreated");
+        writeDanglingRef(resource.getUrl());
+
+        ComplexResourceSweepService instance1 = newSweepService(100, 1, 3_600_000L);
+        ComplexResourceSweepService instance2 = newSweepService(100, 1, 3_600_000L);
+
+        Field field = ComplexResourceSweepService.class.getDeclaredField("activeBatchCount");
+        field.setAccessible(true);
+        AtomicInteger instance1Count = (AtomicInteger) field.get(instance1);
+        instance1Count.set(1);
+        try {
+            instance2.tick();
+            // instance2's own budget was untouched, so it made progress despite instance1 being saturated.
+            assertEquals(0, listRefs().size());
+        } finally {
+            instance1Count.set(0);
+        }
+    }
+
+    @Test
+    void testTickSkipsWhenAnotherTickHoldsTheCursorLock() throws InterruptedException {
+        ResourceDescriptor resource = skill("neverCreated");
+        writeDanglingRef(resource.getUrl());
+
+        CountDownLatch holderAcquired = new CountDownLatch(1);
+        CountDownLatch releaseSignal = new CountDownLatch(1);
+        String lockKey = "complex_resource:cursor_state";
+        Thread holder = new Thread(() -> {
+            try (LockService.Lock ignored = lockService.lock(lockKey)) {
+                holderAcquired.countDown();
+                releaseSignal.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        holder.start();
+        try {
+            assertTrue(holderAcquired.await(5, TimeUnit.SECONDS));
+
+            ComplexResourceSweepService sweep = newSweepService(100, 1, 3_600_000L);
+            sweep.tick();
+
+            // Another tick holds the cursor claim lock: this tick must skip, not block or steal work.
+            assertEquals(1, listRefs().size());
+        } finally {
+            releaseSignal.countDown();
+            holder.join(5000);
+        }
+    }
+
+    private static double counterValue(String name) {
+        Counter counter = Metrics.globalRegistry.find(name).counter();
+        return counter == null ? 0.0 : counter.count();
+    }
+}

--- a/server/src/test/resources/aidial.settings.json
+++ b/server/src/test/resources/aidial.settings.json
@@ -61,6 +61,12 @@
     "compressionMinSize": 256,
     "heartbeatPeriod": 60000
   },
+  "complexResourceSweep": {
+    "period": 10000,
+    "batch": 1000,
+    "activeBatches": 1,
+    "gracePeriod": 3600000
+  },
   "applications": {
     "includeCustomApps": true
   },


### PR DESCRIPTION
Adds a periodic sweep scanner that reclaims storage for folder-as-resource complex resources (e.g. skills): it finishes deleting tombstoned resources and GCs orphaned versions left behind by interrupted writes.

### Applicable issues

- fixes #1639

### Description of changes

- Added `ComplexResourceSweepService`, a periodic job (`TimerService`) that walks a new `complex_resource_refs` reference registry in batches, so it can enumerate every complex resource without walking every bucket.
- `ComplexResourceService.put` now writes a `complex_resource_refs/{uuid}.json` pointer before committing the marker on first creation only (crash-safe: a resource can never exist without a reference).
- `ComplexResourceService.delete` no longer reclaims storage inline — it only tombstones the marker (`state: deleting`); the version tree, marker, and reference are reclaimed later by the sweep, once a configurable grace period has elapsed.
- Added package-visible `reclaimDeletingResource`/`gcObsoleteVersions`/`readMarkerForSweep` methods used only by the sweep.
- Fixed `listChildren` (metadata listing) to also exclude a `deleting` marker rather than relying on marker-file presence alone, since the marker can now outlive the DELETE response until swept.
- Cursor advancement over `complex_resource_refs` is a brief, cluster-wide exclusive claim decoupled from per-item processing, which is bounded by an `activeBatches` setting enforced per-instance (a plain in-process counter, not a distributed limit).
- New `complexResourceSweep` config block (`period`, `batch`, `activeBatches`, `gracePeriod`) and 4 Micrometer counters (`dial_complex_resource_sweep_{batches,reclaimed,orphan_versions,dangling_refs}_total`).
- Added unit tests covering reference lifecycle, grace-period gating, dangling-reference cleanup, and per-instance concurrency behavior.
- Updated README with the new settings.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.