### PR TITLE
feat: add acceptableResourceTypes to dial:resource meta-schema

### DIFF
--- a/config/src/main/resources/custom-application-schemas/schema.json
+++ b/config/src/main/resources/custom-application-schemas/schema.json
@@ -318,6 +318,13 @@
           "description": "Required to check resource existence in DIAL instance",
           "type": "boolean",
           "default": false
+        },
+        "acceptableResourceTypes": {
+          "description": "Optional list of DIAL resource types the referenced resource is allowed to be",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
Lets a custom application type schema restrict which DIAL resource types a dial:resource-marked property may reference.

### Description of changes

Adds an `acceptableResourceTypes` field to the `dialResourceFormatAndTypeSchema` definition in the custom application meta-schema (`config/src/main/resources/custom-application-schemas/schema.json`). This lets a custom application type schema restrict which DIAL resource types a `dial:resource`-marked property may reference, by declaring an array of allowed resource type names alongside the existing `format`, `type`, and `dial:resource` properties.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
