### PR TITLE
chore: Release patch 0.45.4

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/TokenService.java
@@ -6,6 +6,9 @@ import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenEndpointAuthMethod;
 import com.epam.aidial.core.credentials.data.credentials.TokenRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenResponse;
+import com.epam.aidial.core.credentials.util.JsonMapperUtil;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -13,8 +16,9 @@ import org.apache.commons.lang3.StringUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.function.BiFunction;
 
 @AllArgsConstructor
 @Slf4j
@@ -31,18 +35,17 @@ public class TokenService {
         TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolve(
                 resourceAuthSettings.getTokenEndpointAuthMethod(), resourceAuthSettings.getClientSecret());
 
-        TokenRequest.TokenRequestBuilder builder = TokenRequest.builder()
-                .code(resourceSignInRequest.getCode())
-                // TODO: do we need to support different?
-                .grantType("authorization_code")
-                .codeVerifier(resourceAuthSettings.getCodeVerifier())
-                .redirectUri(redirectUri);
-        Map<String, String> headers = applyClientAuthentication(authMethod,
-                resourceAuthSettings.getClientId(), resourceAuthSettings.getClientSecret(),
-                builder::clientId, builder::clientSecret);
-        TokenRequest tokenRequest = builder.build();
-
-        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData(), headers);
+        TokenResponse tokenResponse = fetchToken(authMethod, resourceAuthSettings, (clientId, clientSecret) ->
+                TokenRequest.builder()
+                        .code(resourceSignInRequest.getCode())
+                        // TODO: do we need to support different?
+                        .grantType("authorization_code")
+                        .codeVerifier(resourceAuthSettings.getCodeVerifier())
+                        .redirectUri(redirectUri)
+                        .clientId(clientId)
+                        .clientSecret(clientSecret)
+                        .build()
+                        .buildFormData());
         log.debug("Finished Resource {} token retrieval", resourceId);
         return tokenResponse;
     }
@@ -54,15 +57,14 @@ public class TokenService {
         TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.resolve(
                 resourceAuthSettings.getTokenEndpointAuthMethod(), resourceAuthSettings.getClientSecret());
 
-        RefreshTokenRequest.RefreshTokenRequestBuilder builder = RefreshTokenRequest.builder()
-                .grantType("refresh_token")
-                .refreshToken(refreshToken);
-        Map<String, String> headers = applyClientAuthentication(authMethod,
-                resourceAuthSettings.getClientId(), resourceAuthSettings.getClientSecret(),
-                builder::clientId, builder::clientSecret);
-        RefreshTokenRequest tokenRequest = builder.build();
-
-        TokenResponse tokenResponse = doTokenCall(resourceAuthSettings.getTokenEndpoint(), tokenRequest.buildFormData(), headers);
+        TokenResponse tokenResponse = fetchToken(authMethod, resourceAuthSettings, (clientId, clientSecret) ->
+                RefreshTokenRequest.builder()
+                        .grantType("refresh_token")
+                        .refreshToken(refreshToken)
+                        .clientId(clientId)
+                        .clientSecret(clientSecret)
+                        .build()
+                        .buildFormData());
         log.debug("Finished Resource {} refresh token retrieval", resourceId);
         return tokenResponse;
     }
@@ -88,6 +90,43 @@ public class TokenService {
                 || uri.equals(resourceAuthSettings.getRedirectUri());
     }
 
+    // formData receives the client_id/client_secret to place in the request BODY (null = omit).
+    private TokenResponse fetchToken(TokenEndpointAuthMethod authMethod,
+                                     ResourceAuthSettings settings,
+                                     BiFunction<String, String, String> formData) {
+        String clientId = settings.getClientId();
+        String clientSecret = settings.getClientSecret();
+        String tokenEndpoint = settings.getTokenEndpoint();
+        return switch (authMethod) {
+            case NONE -> doTokenCall(tokenEndpoint, formData.apply(clientId, null), Map.of());
+            case CLIENT_SECRET_POST -> doTokenCall(tokenEndpoint, formData.apply(clientId, clientSecret), Map.of());
+            case CLIENT_SECRET_BASIC -> {
+                // Strict servers (e.g. Notion MCP) enforce RFC 6749 §2.3's single-auth-method rule and
+                // reject a body client_id alongside the Basic header, while others (FastMCP's OAuth
+                // Proxy) resolve the client by the BODY client_id and fail without it. No single request
+                // shape satisfies both, so send the spec-pure request first and retry once with
+                // client_id in the body when the failure looks like a client-identification error.
+                Map<String, String> headers = Map.of("Authorization", buildBasicAuthHeader(clientId, clientSecret));
+                try {
+                    yield doTokenCall(tokenEndpoint, formData.apply(null, null), headers);
+                } catch (HttpException e) {
+                    if (!isClientIdentificationError(e)) {
+                        throw e;
+                    }
+                    log.info("Basic-authenticated token request to {} failed with a client identification error, "
+                            + "retrying with client_id in the body", tokenEndpoint);
+                    try {
+                        yield doTokenCall(tokenEndpoint, formData.apply(clientId, null), headers);
+                    } catch (HttpException retryException) {
+                        log.warn("Token request retry with client_id in the body failed too: {} {}",
+                                retryException.getMessage(), StringUtils.defaultString(retryException.getBody()));
+                        throw e;
+                    }
+                }
+            }
+        };
+    }
+
     private TokenResponse doTokenCall(String tokenEndpoint, String tokenRequest, Map<String, String> extraHeaders) {
         return resourceAuthorizationClient.executePost(
                 tokenEndpoint, tokenRequest,
@@ -96,29 +135,32 @@ public class TokenService {
                 TokenResponse.class);
     }
 
-    private static Map<String, String> applyClientAuthentication(TokenEndpointAuthMethod authMethod,
-                                                                 String clientId,
-                                                                 String clientSecret,
-                                                                 Consumer<String> setClientId,
-                                                                 Consumer<String> setClientSecret) {
-        return switch (authMethod) {
-            case CLIENT_SECRET_BASIC -> {
-                // Include client_id in the body too (RFC 6749 §3.2.1 permits it). Some token endpoints
-                // — e.g. FastMCP's OAuth Proxy — look up the client by the BODY client_id even when the
-                // secret is supplied via the Basic header; omitting it yields "Missing client_id".
-                setClientId.accept(clientId);
-                yield Map.of("Authorization", buildBasicAuthHeader(clientId, clientSecret));
-            }
-            case NONE -> {
-                setClientId.accept(clientId);
-                yield Map.of();
-            }
-            case CLIENT_SECRET_POST -> {
-                setClientId.accept(clientId);
-                setClientSecret.accept(clientSecret);
-                yield Map.of();
-            }
-        };
+    // 401 is RFC 6749 §5.2's designated invalid_client response for header-authenticated requests.
+    // The description match exists for proxies that misreport a missing body client_id as
+    // invalid_grant/invalid_request (e.g. "Client ID does not match the one used in the initial
+    // request"); ordinary grant failures (expired code, bad scope) must not trigger a retry.
+    private static boolean isClientIdentificationError(HttpException e) {
+        if (e.getStatus() == HttpStatus.UNAUTHORIZED) {
+            return true;
+        }
+        Map<?, ?> payload;
+        try {
+            payload = JsonMapperUtil.convertToObject(e.getBody(), Map.class);
+        } catch (IllegalArgumentException parseError) {
+            return false;
+        }
+        if (payload == null) {
+            return false;
+        }
+        String error = String.valueOf(payload.get("error"));
+        if ("invalid_client".equals(error)) {
+            return true;
+        }
+        if (!"invalid_grant".equals(error) && !"invalid_request".equals(error)) {
+            return false;
+        }
+        String description = String.valueOf(payload.get("error_description")).toLowerCase(Locale.ROOT);
+        return description.contains("client_id") || description.contains("client id");
     }
 
     // RFC 6749 §2.3.1 specifies URL-encoding credentials before base64, but real-world

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
@@ -4,6 +4,8 @@ import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.TokenEndpointAuthMethod;
 import com.epam.aidial.core.credentials.data.credentials.TokenResponse;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -212,12 +215,12 @@ class TokenServiceTest {
         assertEquals(expected, headersCaptor.getValue().get("Authorization"));
 
         String formData = formDataCaptor.getValue();
-        assertTrue(formData.contains("client_id="), "client_id must be in body: " + formData);
+        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
     }
 
     @Test
-    void testGetToken_clientSecretBasic_sendsBasicHeaderWithClientIdInBody() {
+    void testGetToken_clientSecretBasic_sendsBasicHeaderWithoutBodyCredentials() {
         TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
 
         ResourceAuthSettings authSettings = ResourceAuthSettings.builder()
@@ -244,10 +247,11 @@ class TokenServiceTest {
                 eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
 
         String formData = formDataCaptor.getValue();
-        // client_id is sent in the body even under Basic (RFC 6749 §3.2.1 MAY) so servers that look up
-        // the client by the body client_id (e.g. FastMCP's OAuth Proxy) work; the SECRET stays only in
-        // the Basic header — no second authentication method per RFC 6749 §2.3.1.
-        assertTrue(formData.contains("client_id="), "client_id must be in body: " + formData);
+        // Spec-pure Basic (RFC 6749 §2.3): credentials only in the Authorization header. Strict
+        // servers (e.g. Notion MCP, issue #1703) reject a body client_id alongside the header as
+        // "multiple authentication methods"; servers that need the body client_id (FastMCP's OAuth
+        // Proxy, issue #1608) are handled by the retry — see the retry tests below.
+        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must NOT be in body for basic: " + formData);
 
         // Plain RFC 7617 Basic: client_id and client_secret are concatenated as-is and base64'd
@@ -335,7 +339,7 @@ class TokenServiceTest {
         String formData = formDataCaptor.getValue();
         assertTrue(formData.contains("grant_type=refresh_token"));
         assertTrue(formData.contains("refresh_token=old-refresh-token"));
-        assertTrue(formData.contains("client_id="), "client_id must be in body for basic: " + formData);
+        assertFalse(formData.contains("client_id="), "client_id must not be in body for basic: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must NOT be in body for basic: " + formData);
 
         String expected = "Basic " + Base64.getEncoder().encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
@@ -368,7 +372,169 @@ class TokenServiceTest {
         assertEquals(expected, headersCaptor.getValue().get("Authorization"));
 
         String formData = formDataCaptor.getValue();
-        assertTrue(formData.contains("client_id="), "client_id must be in body: " + formData);
+        assertFalse(formData.contains("client_id="), "client_id must not be in body: " + formData);
         assertFalse(formData.contains("client_secret="), "client_secret must not be in body: " + formData);
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_retriesWithBodyClientIdOnInvalidClient() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_client", "Missing client_id"))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
+                ResourceSignInRequest.builder().code("auth-code").build());
+
+        assertEquals("access", response.getAccessToken());
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(resourceAuthorizationClient, times(2)).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), headersCaptor.capture(), eq(TokenResponse.class));
+
+        List<String> attempts = formDataCaptor.getAllValues();
+        assertFalse(attempts.get(0).contains("client_id="), "first attempt must be spec-pure Basic: " + attempts.get(0));
+        assertTrue(attempts.get(1).contains("client_id=client-id"), "retry must carry client_id in body: " + attempts.get(1));
+        assertFalse(attempts.get(1).contains("client_secret="), "secret must stay out of the body: " + attempts.get(1));
+        for (Map<String, String> headers : headersCaptor.getAllValues()) {
+            assertTrue(headers.get("Authorization").startsWith("Basic "), "Basic header expected on both attempts");
+        }
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_retriesOnBare401() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code", Map.of(), null))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
+                ResourceSignInRequest.builder().code("auth-code").build());
+
+        assertEquals("access", response.getAccessToken());
+        verify(resourceAuthorizationClient, times(2)).executePost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_retriesOnClientIdMismatchGrantError() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        // FastMCP's/Stack's OAuth proxy misreports a missing body client_id as invalid_grant (#1608)
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_grant",
+                        "Client ID does not match the one used in the initial request."))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
+                ResourceSignInRequest.builder().code("auth-code").build());
+
+        assertEquals("access", response.getAccessToken());
+        verify(resourceAuthorizationClient, times(2)).executePost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_retriesOnClientIdMentioningInvalidRequest() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_request", "client_id is required"))
+                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+
+        TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
+                ResourceSignInRequest.builder().code("auth-code").build());
+
+        assertEquals("access", response.getAccessToken());
+        verify(resourceAuthorizationClient, times(2)).executePost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_doesNotRetryOnOrdinaryGrantError() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        HttpException expiredCode = oauthError(HttpStatus.BAD_REQUEST, "invalid_grant", "Authorization code expired");
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any())).thenThrow(expiredCode);
+
+        HttpException thrown = assertThrows(HttpException.class,
+                () -> tokenService.getToken("resource-1", basicAuthSettings(),
+                        ResourceSignInRequest.builder().code("auth-code").build()));
+
+        assertEquals(expiredCode, thrown);
+        verify(resourceAuthorizationClient, times(1)).executePost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_doesNotRetryOnNonJsonErrorBody() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(new HttpException(HttpStatus.BAD_REQUEST, "Authorization server returns error code",
+                        Map.of(), "<html>Bad Request</html>"));
+
+        assertThrows(HttpException.class,
+                () -> tokenService.getToken("resource-1", basicAuthSettings(),
+                        ResourceSignInRequest.builder().code("auth-code").build()));
+
+        verify(resourceAuthorizationClient, times(1)).executePost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testGetToken_clientSecretBasic_propagatesFirstErrorWhenRetryFailsToo() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        HttpException firstError = oauthError(HttpStatus.UNAUTHORIZED, "invalid_client", "Client authentication failed");
+        HttpException retryError = oauthError(HttpStatus.BAD_REQUEST, "invalid_request",
+                "Client must not use multiple authentication methods");
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(firstError)
+                .thenThrow(retryError);
+
+        HttpException thrown = assertThrows(HttpException.class,
+                () -> tokenService.getToken("resource-1", basicAuthSettings(),
+                        ResourceSignInRequest.builder().code("auth-code").build()));
+
+        assertEquals(firstError, thrown);
+        verify(resourceAuthorizationClient, times(2)).executePost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testGetToken_refresh_clientSecretBasic_retriesWithBodyClientId() {
+        TokenService tokenService = new TokenService(resourceAuthorizationClient, List.of());
+
+        when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
+                .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_client", "Missing client_id"))
+                .thenReturn(new TokenResponse("new-access", "new-refresh", 3600L));
+
+        TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(), "old-refresh-token");
+
+        assertEquals("new-access", response.getAccessToken());
+
+        ArgumentCaptor<String> formDataCaptor = ArgumentCaptor.forClass(String.class);
+        verify(resourceAuthorizationClient, times(2)).executePost(
+                eq("http://auth-server/token"), formDataCaptor.capture(),
+                eq("application/x-www-form-urlencoded"), any(), eq(TokenResponse.class));
+
+        List<String> attempts = formDataCaptor.getAllValues();
+        assertFalse(attempts.get(0).contains("client_id="), "first attempt must be spec-pure Basic: " + attempts.get(0));
+        assertTrue(attempts.get(1).contains("client_id=client-id"), "retry must carry client_id in body: " + attempts.get(1));
+        assertTrue(attempts.get(1).contains("refresh_token=old-refresh-token"));
+    }
+
+    private static ResourceAuthSettings basicAuthSettings() {
+        return ResourceAuthSettings.builder()
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .tokenEndpoint("http://auth-server/token")
+                .redirectUri("http://admin/callback")
+                .tokenEndpointAuthMethod(TokenEndpointAuthMethod.CLIENT_SECRET_BASIC.value())
+                .build();
+    }
+
+    private static HttpException oauthError(HttpStatus status, String error, String description) {
+        String body = "{\"error\":\"%s\",\"error_description\":\"%s\"}".formatted(error, description);
+        return new HttpException(status, "Authorization server returns error code", Map.of(), body);
     }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -59,6 +59,7 @@ import com.epam.aidial.core.server.service.PublicationUtil;
 import com.epam.aidial.core.server.service.ResourceOperationService;
 import com.epam.aidial.core.server.service.ResponseMappingService;
 import com.epam.aidial.core.server.service.RuleService;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.service.ToolSetRepairService;
 import com.epam.aidial.core.server.service.ToolSetService;
@@ -240,6 +241,7 @@ public class AiDial {
                     encryptionService, resourceAuthSettingsEncryptionService);
             ToolSetService toolSetService = new ToolSetService(resourceService, resourceAuthSettingsService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService);
+            SecuredResourceService securedResourceService = new SecuredResourceService(resourceCredentialsService);
             ToolSetRepairService toolSetRepairService = new ToolSetRepairService(resourceService,
                     resourceAuthSettingsEncryptionService, resourceCredentialsService,
                     resourceRegistrationService, resourceAuthSettingsService);
@@ -293,7 +295,8 @@ public class AiDial {
                     shareService, publicationService, accessService, lockService, resourceOperationService, ruleService,
                     notificationService, applicationService, codeInterpreterService, heartbeatService, upstreamCacheService,
                     consentService, deploymentService, healthCheckController, wellKnownResourceMetadataService, resourceMetadataController,
-                    toolSetService, toolSetRepairService, applicationSchemaService, authorizationHeaderProvider, resourceAuthSettingsService, resourceCredentialsService,
+                    toolSetService, securedResourceService, toolSetRepairService, applicationSchemaService, authorizationHeaderProvider,
+                    resourceAuthSettingsService, resourceCredentialsService,
                     perRequestPermissionService, resourceAuthSettingsEncryptionService, authSettingsResolver, clientChannelService, taskExecutor, version(),
                     responseMappingService, generator);
 

--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -33,6 +33,7 @@ import com.epam.aidial.core.server.service.PublicationService;
 import com.epam.aidial.core.server.service.ResourceOperationService;
 import com.epam.aidial.core.server.service.ResponseMappingService;
 import com.epam.aidial.core.server.service.RuleService;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.service.ToolSetRepairService;
 import com.epam.aidial.core.server.service.ToolSetService;
@@ -147,6 +148,7 @@ public class Proxy implements Handler<HttpServerRequest> {
     private final WellKnownResourceMetadataService resourceMetadataService;
     private final WellKnownResourceMetadataController resourceMetadataController;
     private final ToolSetService toolSetService;
+    private final SecuredResourceService securedResourceService;
     private final ToolSetRepairService toolSetRepairService;
     private final ApplicationSchemaService applicationSchemaService;
     private final AuthorizationHeaderProvider authorizationHeaderProvider;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResourceCredentialsController.java
@@ -7,20 +7,17 @@ import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.SecuredResource;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
-import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
-import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
 import com.epam.aidial.core.credentials.exception.EncryptionException;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsEncryptionService;
-import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
-import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.server.validation.ValidationUtil;
@@ -29,7 +26,6 @@ import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
-import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
 import jakarta.validation.ConstraintViolationException;
@@ -44,11 +40,11 @@ public class ResourceCredentialsController {
 
     private final ProxyContext context;
     private final AsyncTaskExecutor taskExecutor;
-    private final ResourceCredentialsService resourceCredentialsService;
     private final AccessService accessService;
     private final EncryptionService encryptionService;
     private final DeploymentService deploymentService;
     private final ResourceAuthSettingsEncryptionService resourceAuthSettingsEncryptionService;
+    private final SecuredResourceService securedResourceService;
 
     public ResourceCredentialsController(Proxy proxy, ProxyContext context) {
         this.context = context;
@@ -56,8 +52,8 @@ public class ResourceCredentialsController {
         this.accessService = proxy.getAccessService();
         this.encryptionService = proxy.getEncryptionService();
         this.deploymentService = proxy.getDeploymentService();
-        this.resourceCredentialsService = proxy.getResourceCredentialsService();
         this.resourceAuthSettingsEncryptionService = proxy.getResourceAuthSettingsEncryptionService();
+        this.securedResourceService = proxy.getSecuredResourceService();
     }
 
     public Future<?> signIn() {
@@ -80,11 +76,8 @@ public class ResourceCredentialsController {
                                 verifyAccess(encodedResourceUrl, credentialsLevel);
                                 decryptAuthSettings(encodedResourceUrl, resourceAuthSettings);
                             }
-                            
-                            CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceUrl, context, ResourceTypes.TOOL_SET);
-                            CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(resourceSignInRequest.getCredentialsLevel());
-                            resourceCredentialsService.addResourceCredentials(credentialsDescriptor, resourceAuthSettings,
-                                    resourceSignInRequest, context.getInitiatorId());
+
+                            securedResourceService.signIn(context, securedResource, resourceSignInRequest);
                             return true;
                         }
                         throw new ResourceNotFoundException("Resource is not found: " + resourceId);
@@ -108,23 +101,18 @@ public class ResourceCredentialsController {
                     ValidationUtil.validate(resourceSignOutRequest);
 
                     Deployment deployment = deploymentService.findDeployment(context, resourceId);
-                    if (deployment instanceof SecuredResource securedResource) {
-                        ResourceAuthSettings resourceAuthSettings = securedResource.getAuthSettings();
-                        validateAuthType(resourceAuthSettings.getAuthenticationType(), resourceSignOutRequest.getAuthenticationType());
-                        if (context.getConfig().isDeploymentExists(encodedResourceId)) {
-                            verifyAccess(securedResource, credentialsLevel);
-                        } else {
-                            verifyAccess(encodedResourceId, credentialsLevel);
-                        }
-                    } else {
+                    if (!(deployment instanceof SecuredResource securedResource)) {
                         throw new ResourceNotFoundException("Resource is not found: " + encodedResourceId);
                     }
+                    ResourceAuthSettings resourceAuthSettings = securedResource.getAuthSettings();
+                    validateAuthType(resourceAuthSettings.getAuthenticationType(), resourceSignOutRequest.getAuthenticationType());
+                    if (context.getConfig().isDeploymentExists(encodedResourceId)) {
+                        verifyAccess(securedResource, credentialsLevel);
+                    } else {
+                        verifyAccess(encodedResourceId, credentialsLevel);
+                    }
 
-                    CredentialsLocator credentialsLocator = CredentialsLocatorFactory.fromAnyUrl(encodedResourceId, context, ResourceTypes.TOOL_SET);
-                    return resourceCredentialsService.deleteResourceCredentials(
-                            credentialsLocator,
-                            resourceSignOutRequest,
-                            context.getInitiatorId());
+                    return securedResourceService.signOut(context, securedResource, resourceSignOutRequest);
                 }))
                 .onSuccess(removed -> context.respond(HttpStatus.OK, removed))
                 .onFailure(error ->

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -22,6 +22,7 @@ import com.epam.aidial.core.server.upstream.UpstreamRoute;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
 import com.epam.aidial.core.server.util.AuthSettingsResolver;
 import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.util.McpClientUtils;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
@@ -31,41 +32,24 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
-import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
-import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
 public class ToolSetToolsController implements Controller {
-
-    private static final JsonSchemaValidator NOOP_SCHEMA_VALIDATOR =
-            (Map<String, Object> schema, Object content) ->
-                    JsonSchemaValidator.ValidationResponse.asValid(null);
-
-    private static final McpJsonMapper MCP_JSON_MAPPER = createLenientMcpJsonMapper();
 
     private final String toolSetId;
     private final boolean filterAllowed;
@@ -163,7 +147,7 @@ public class ToolSetToolsController implements Controller {
 
         HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
                 .builder(upstream.getEndpoint())
-                .jsonMapper(MCP_JSON_MAPPER)
+                .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, endpoint, body, transportContext) ->
                         customizeRequest(builder, deployment))
                 .build();
@@ -171,7 +155,7 @@ public class ToolSetToolsController implements Controller {
         try (McpSyncClient client = McpClient.sync(transport)
                 .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
                 .requestTimeout(Duration.ofMillis(proxy.getClientOptions().getIdleTimeout()))
-                .jsonSchemaValidator(NOOP_SCHEMA_VALIDATOR)
+                .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
                 .build()) {
             client.initialize();
             if (filterAllowed) {
@@ -268,29 +252,6 @@ public class ToolSetToolsController implements Controller {
         ApiKeyData.initFromContext(proxyApiKeyData, context);
         apiKeyStore.assignPerRequestApiKey(proxyApiKeyData);
         return proxyApiKeyData.getPerRequestKey();
-    }
-
-    private static final String ADDITIONAL_PROPERTIES_FIELD = "additionalProperties";
-
-    private static McpJsonMapper createLenientMcpJsonMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        // JSON Schema allows `additionalProperties` to be a boolean OR a schema object,
-        // but the MCP SDK models it as Boolean. Coerce object/array values to null so a
-        // single non-conforming field does not fail the whole tools/list response (#1561).
-        mapper.addHandler(new DeserializationProblemHandler() {
-            @Override
-            public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType,
-                    JsonToken t, JsonParser p, String failureMsg) throws IOException {
-                if (targetType.hasRawClass(Boolean.class)
-                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)
-                        && ADDITIONAL_PROPERTIES_FIELD.equals(p.currentName())) {
-                    p.skipChildren();
-                    return null;
-                }
-                return super.handleUnexpectedToken(ctxt, targetType, t, p, failureMsg);
-            }
-        });
-        return new JacksonMcpJsonMapper(mapper);
     }
 
     private void handleError(Throwable error) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
@@ -1,0 +1,129 @@
+package com.epam.aidial.core.server.service;
+
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.SecuredResource;
+import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
+import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.util.CredentialsLocatorFactory;
+import com.epam.aidial.core.server.util.McpClientUtils;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import com.epam.aidial.core.storage.resource.ResourceType;
+import com.epam.aidial.core.storage.resource.ResourceTypes;
+import com.epam.aidial.core.storage.util.UrlUtil;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.time.Duration;
+
+@Slf4j
+@AllArgsConstructor
+public class SecuredResourceService {
+
+    // deliberately not the client idleTimeout (5 min in production) — sign-in is interactive
+    private static final Duration MCP_PROBE_TIMEOUT = Duration.ofSeconds(20);
+
+    private final ResourceCredentialsService resourceCredentialsService;
+
+    public void signIn(ProxyContext context, SecuredResource securedResource, ResourceSignInRequest request) {
+        if (AuthenticationType.API_KEY.equals(request.getAuthenticationType())) {
+            validateApiKey(securedResource, request.getApiKey());
+        }
+        CredentialsLocator credentialsLocator = createCredentialsLocator(context, securedResource, request.getUrl());
+        CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(request.getCredentialsLevel());
+        resourceCredentialsService.addResourceCredentials(credentialsDescriptor, securedResource.getAuthSettings(),
+                request, context.getInitiatorId());
+    }
+
+    public boolean signOut(ProxyContext context, SecuredResource securedResource, ResourceSignOutRequest request) {
+        CredentialsLocator credentialsLocator = createCredentialsLocator(context, securedResource, request.getUrl());
+        return resourceCredentialsService.deleteResourceCredentials(credentialsLocator, request, context.getInitiatorId());
+    }
+
+    private static CredentialsLocator createCredentialsLocator(ProxyContext context, SecuredResource securedResource, String resourceUrl) {
+        ResourceType resourceType = resolveResourceType(securedResource);
+        return CredentialsLocatorFactory.fromAnyUrl(UrlUtil.encodePath(resourceUrl), context, resourceType);
+    }
+
+    private static ResourceType resolveResourceType(SecuredResource resource) {
+        if (resource instanceof ToolSet) {
+            return ResourceTypes.TOOL_SET;
+        }
+        throw new IllegalArgumentException("Unsupported secured resource type: " + resource.getClass().getSimpleName());
+    }
+
+    /**
+     * Validates an API key before it is stored at sign-in: rejects blank/malformed keys, then probes
+     * the resource endpoint, assuming it speaks MCP (initialize + tools/list). Rejects only when the
+     * server explicitly refuses the request (HTTP 401/403 or a JSON-RPC error); connectivity issues
+     * and non-MCP endpoints are tolerated because the key may be provisioned before the server is
+     * reachable (#1698).
+     */
+    private void validateApiKey(SecuredResource securedResource, String apiKey) {
+        if (StringUtils.isBlank(apiKey)) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
+        }
+        if (containsIllegalHeaderChars(apiKey)) {
+            throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
+        }
+
+        String endpoint = securedResource.getEndpoint();
+        String apiKeyHeader = securedResource.getAuthSettings().getApiKeyHeader();
+        if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader)) {
+            return;
+        }
+
+        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+                .builder(endpoint)
+                .connectTimeout(MCP_PROBE_TIMEOUT)
+                .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
+                .httpRequestCustomizer((builder, method, uri, body, transportContext) ->
+                        builder.header(apiKeyHeader, apiKey))
+                .build();
+
+        try (McpSyncClient client = McpClient.sync(transport)
+                .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
+                .requestTimeout(MCP_PROBE_TIMEOUT)
+                .initializationTimeout(MCP_PROBE_TIMEOUT)
+                .jsonSchemaValidator(McpClientUtils.NOOP_SCHEMA_VALIDATOR)
+                .build()) {
+            client.initialize();
+            client.listTools(null);
+        } catch (Exception e) {
+            McpHttpClientTransportAuthorizationException authError =
+                    ExceptionUtils.throwableOfType(e, McpHttpClientTransportAuthorizationException.class);
+            if (authError != null) {
+                log.warn("API key validation failed for endpoint {}: MCP server responded with status {}",
+                        endpoint, authError.getResponseInfo().statusCode());
+                throw new HttpException(HttpStatus.BAD_REQUEST,
+                        "API key validation failed: MCP server rejected the provided API key");
+            }
+            McpError mcpError = ExceptionUtils.throwableOfType(e, McpError.class);
+            if (mcpError != null) {
+                log.warn("API key validation failed for endpoint {}: MCP server returned an error: {}",
+                        endpoint, mcpError.getMessage());
+                throw new HttpException(HttpStatus.BAD_REQUEST,
+                        "API key validation failed: MCP server rejected the request: " + mcpError.getMessage());
+            }
+            log.warn("Skipping API key validation for endpoint {}: {}", endpoint, e.getMessage());
+        }
+    }
+
+    // java.net.http rejects header values containing control characters other than HTAB
+    private static boolean containsIllegalHeaderChars(String value) {
+        return value.chars().anyMatch(c -> (c < 0x20 && c != '\t') || c == 0x7f);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ToolSetService.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.CredentialsLevel;
+import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;

--- a/server/src/main/java/com/epam/aidial/core/server/util/McpClientUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/McpClientUtils.java
@@ -1,0 +1,48 @@
+package com.epam.aidial.core.server.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import lombok.experimental.UtilityClass;
+
+import java.io.IOException;
+import java.util.Map;
+
+@UtilityClass
+public class McpClientUtils {
+
+    public static final JsonSchemaValidator NOOP_SCHEMA_VALIDATOR =
+            (Map<String, Object> schema, Object content) ->
+                    JsonSchemaValidator.ValidationResponse.asValid(null);
+
+    public static final McpJsonMapper MCP_JSON_MAPPER = createLenientMcpJsonMapper();
+
+    private static final String ADDITIONAL_PROPERTIES_FIELD = "additionalProperties";
+
+    private static McpJsonMapper createLenientMcpJsonMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // JSON Schema allows `additionalProperties` to be a boolean OR a schema object,
+        // but the MCP SDK models it as Boolean. Coerce object/array values to null so a
+        // single non-conforming field does not fail the whole tools/list response (#1561).
+        mapper.addHandler(new DeserializationProblemHandler() {
+            @Override
+            public Object handleUnexpectedToken(DeserializationContext ctxt, JavaType targetType,
+                    JsonToken t, JsonParser p, String failureMsg) throws IOException {
+                if (targetType.hasRawClass(Boolean.class)
+                        && (t == JsonToken.START_OBJECT || t == JsonToken.START_ARRAY)
+                        && ADDITIONAL_PROPERTIES_FIELD.equals(p.currentName())) {
+                    p.skipChildren();
+                    return null;
+                }
+                return super.handleUnexpectedToken(ctxt, targetType, t, p, failureMsg);
+            }
+        });
+        return new JacksonMcpJsonMapper(mapper);
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -10,17 +10,26 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.http.HttpMethod;
+import lombok.SneakyThrows;
 import okhttp3.mockwebserver.MockResponse;
 import okio.Buffer;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,6 +83,38 @@ public class ToolSetApiTest extends ResourceBaseTest {
             // MCP server rejects authorization during the initialize handshake
             return new MockResponse().setResponseCode(statusCode);
         };
+    }
+
+    // MCP server rejects the request at the JSON-RPC layer: HTTP 200 with an error object
+    private static TestWebServer.Handler mcpJsonRpcErrorHandler(String errorMessage) {
+        return request -> {
+            if ("GET".equals(request.getMethod())) {
+                return new MockResponse().setResponseCode(405);
+            }
+            String body = request.getBody().readString(StandardCharsets.UTF_8);
+            String id = extractJsonRpcId(body);
+            return new MockResponse()
+                    .setBody("""
+                            {"jsonrpc":"2.0","id":%s,"error":{"code":-32600,"message":"%s"}}
+                            """.formatted(id, errorMessage))
+                    .setHeader("Content-Type", "application/json");
+        };
+    }
+
+    @SneakyThrows
+    private Response sendNoRedirect(HttpMethod method, String path, String body) {
+        try (CloseableHttpClient noRedirectClient = HttpClientBuilder.create()
+                .disableAutomaticRetries()
+                .disableRedirectHandling()
+                .build()) {
+            String uri = "http://127.0.0.1:" + serverPort + path;
+            HttpUriRequest request = new HttpUriRequestBase(method.name(), URI.create(uri));
+            request.setHeader("api-key", "proxyKey1");
+            if (body != null) {
+                request.setEntity(new StringEntity(body));
+            }
+            return noRedirectClient.execute(request, ResourceBaseTest::toResponse);
+        }
     }
 
     private static String extractJsonRpcId(String body) {
@@ -2508,6 +2549,139 @@ public class ToolSetApiTest extends ResourceBaseTest {
             assertEquals(403, resp.status());
             assertTrue(resp.body().contains("Please sign in to the toolset"), resp.body());
         }
+    }
+
+    private static final String API_KEY_TOOLSET_URL = "toolsets/4X25dj1mja51jykqxsXnCH/api-key-toolset@";
+
+    private void createApiKeyToolSet() {
+        Response response = send(HttpMethod.PUT, "/v1/" + API_KEY_TOOLSET_URL, null, """
+                {
+                    "endpoint": "http://localhost:9876",
+                    "transport": "HTTP",
+                    "allowedTools": [],
+                    "auth_settings": {
+                        "authentication_type": "API_KEY",
+                        "api_key_header": "Authorization"
+                    }
+                }
+                """, "authorization", "admin");
+        verifyNotExact(response, 200, "\"url\":\"" + API_KEY_TOOLSET_URL + "\"");
+    }
+
+    private Response signInWithApiKey(String apiKey) {
+        return send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                {
+                    "url": "%s",
+                    "credentialsLevel": "GLOBAL",
+                    "authenticationType": "API_KEY",
+                    "api_key": "%s"
+                }
+                """.formatted(API_KEY_TOOLSET_URL, apiKey), "authorization", "admin");
+    }
+
+    // MCP server rejects the key during sign-in validation -> credentials must not be stored (#1698)
+    @Test
+    void testSignInWithInvalidApiKey() {
+        createApiKeyToolSet();
+
+        try (TestWebServer ignore = new TestWebServer(9876, mcpAuthErrorHandler(401))) {
+            Response response = signInWithApiKey("invalid-key");
+            assertEquals(400, response.status());
+            assertTrue(response.body().contains("MCP server rejected the provided API key"), response.body());
+        }
+
+        Response response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
+    }
+
+    @Test
+    void testSignInWithValidApiKey() {
+        createApiKeyToolSet();
+
+        String mcpToolsListResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 2,
+                   "result": {
+                     "tools": [
+                       {"name": "branch", "description": "Manage branches"}
+                     ]
+                   }
+                 }
+                """;
+        AtomicReference<String> sentApiKey = new AtomicReference<>();
+        TestWebServer.Handler toolsHandler = mcpToolsHandler(mcpToolsListResponse);
+        TestWebServer.Handler handler = request -> {
+            sentApiKey.set(request.getHeader("Authorization"));
+            return toolsHandler.map(request);
+        };
+
+        try (TestWebServer ignore = new TestWebServer(9876, handler)) {
+            Response response = signInWithApiKey("valid-key");
+            verify(response, 200, "true");
+            assertEquals("valid-key", sentApiKey.get());
+        }
+
+        Response response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""), response.body());
+    }
+
+    // Validation is best-effort: an unreachable MCP server must not block sign-in (#1698)
+    @Test
+    void testSignInWithApiKeyWhenMcpServerUnreachable() {
+        createApiKeyToolSet();
+
+        Response response = signInWithApiKey("some-key");
+        verify(response, 200, "true");
+
+        response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_IN\""), response.body());
+    }
+
+    @Test
+    void testSignInWithBlankApiKey() {
+        createApiKeyToolSet();
+
+        Response response = signInWithApiKey("");
+        assertEquals(400, response.status());
+        assertTrue(response.body().contains("api_key must not be blank"), response.body());
+
+        response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
+    }
+
+    // A key with control characters (e.g. a pasted trailing newline) can never be sent as an HTTP header
+    @Test
+    void testSignInWithApiKeyContainingControlCharacters() {
+        createApiKeyToolSet();
+
+        Response response = signInWithApiKey("key-with-newline\\n");
+        assertEquals(400, response.status());
+        assertTrue(response.body().contains("api_key contains illegal control characters"), response.body());
+
+        response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
+    }
+
+    // MCP servers doing auth at the application layer reject with HTTP 200 + JSON-RPC error, not 401 (#1698)
+    @Test
+    void testSignInWithApiKeyRejectedByJsonRpcError() {
+        createApiKeyToolSet();
+
+        try (TestWebServer ignore = new TestWebServer(9876, mcpJsonRpcErrorHandler("invalid api key"))) {
+            Response response = signInWithApiKey("invalid-key");
+            assertEquals(400, response.status());
+            assertTrue(response.body().contains("MCP server rejected the request"), response.body());
+        }
+
+        Response response = send(HttpMethod.GET, "/openai/toolsets/" + API_KEY_TOOLSET_URL, null, null, "authorization", "admin");
+        assertEquals(200, response.status());
+        assertTrue(response.body().contains("\"global_auth_status\":\"SIGNED_OUT\""), response.body());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1824,8 +1824,9 @@ public class ToolSetApiTest extends ResourceBaseTest {
     @Test
     void testOauthSignInWithClientSecretBasic() {
         // Snowflake-managed MCP (and any RFC 6749 §2.3.1-strict authorization server) requires
-        // HTTP Basic auth at the token endpoint. DCR advertises this via
-        // token_endpoint_auth_method=client_secret_basic; DIAL must honor it on token exchange.
+        // HTTP Basic auth at the token endpoint; strict servers like Notion MCP additionally
+        // reject a body client_id alongside the Basic header as a second authentication method
+        // (RFC 6749 §2.3, issue #1703). The mock enforces both.
         String tokenResponse = """
                 {
                     "access_token": "test-access-token",
@@ -1841,6 +1842,11 @@ public class ToolSetApiTest extends ResourceBaseTest {
             server.map(HttpMethod.POST, "/token", request -> {
                 authHeaderRef.set(request.getHeader("Authorization"));
                 bodyRef.set(request.getBody().readUtf8());
+                if (bodyRef.get().contains("client_id=")) {
+                    return new MockResponse().setResponseCode(400)
+                            .setBody("{\"error\":\"invalid_request\",\"error_description\":\"Client must not use multiple authentication methods\"}")
+                            .setHeader("Content-Type", "application/json");
+                }
                 String expected = "Basic " + java.util.Base64.getEncoder().encodeToString(
                         "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
                 if (expected.equals(authHeaderRef.get())) {
@@ -1883,8 +1889,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                     "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
             assertEquals(expectedHeader, authHeaderRef.get(),
                     "client_secret_basic must produce an Authorization: Basic header per RFC 6749 §2.3.1");
-            assertTrue(bodyRef.get().contains("client_id="),
-                    "client_id must appear in body for client_secret_basic (RFC 6749 §3.2.1), got: " + bodyRef.get());
+            assertFalse(bodyRef.get().contains("client_id="),
+                    "client_id must NOT appear in body for client_secret_basic — strict servers reject it (#1703), got: " + bodyRef.get());
             assertFalse(bodyRef.get().contains("client_secret="),
                     "client_secret must NOT appear in body for client_secret_basic (secret stays in the header), got: " + bodyRef.get());
 
@@ -1896,6 +1902,64 @@ public class ToolSetApiTest extends ResourceBaseTest {
             assertEquals("client_secret_basic", authSettings.get("token_endpoint_auth_method").asText());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testOauthSignInWithClientSecretBasic_retriesWithBodyClientId() {
+        // FastMCP's OAuth Proxy (issue #1608) resolves the client by the BODY client_id even in
+        // client_secret_basic mode and fails with invalid_client "Missing client_id" without it.
+        // The spec-pure first attempt fails, and DIAL must retry once with client_id in the body.
+        String tokenResponse = """
+                {
+                    "access_token": "test-access-token",
+                    "refresh_token": "test-refresh-token",
+                    "expires_in": 3600
+                }
+                """;
+        java.util.concurrent.atomic.AtomicInteger tokenCalls = new java.util.concurrent.atomic.AtomicInteger();
+
+        try (TestWebServer server = new TestWebServer(9876)) {
+            server.map(HttpMethod.POST, "/mcp", 401, "");
+            server.map(HttpMethod.POST, "/token", request -> {
+                tokenCalls.incrementAndGet();
+                String body = request.getBody().readUtf8();
+                if (!body.contains("client_id=my-client-id")) {
+                    return new MockResponse().setResponseCode(400)
+                            .setBody("{\"error\":\"invalid_client\",\"error_description\":\"Missing client_id\"}")
+                            .setHeader("Content-Type", "application/json");
+                }
+                return new MockResponse().setBody(tokenResponse).setHeader("Content-Type", "application/json");
+            });
+
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset-basic-retry@", null, """
+                    {
+                        "endpoint": "http://localhost:9876/mcp",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "OAUTH",
+                            "client_id": "my-client-id",
+                            "client_secret": "my-client-secret",
+                            "redirect_uri": "http://admin/callback",
+                            "authorization_endpoint": "http://localhost:9876/authorize",
+                            "token_endpoint": "http://localhost:9876/token",
+                            "token_endpoint_auth_method": "client_secret_basic"
+                        }
+                    }
+                    """, "authorization", "admin");
+            assertEquals(200, response.status());
+
+            response = send(HttpMethod.POST, "/v1/ops/toolset/signin", null, """
+                    {
+                        "url": "toolsets/4X25dj1mja51jykqxsXnCH/toolset-basic-retry@",
+                        "credentialsLevel": "GLOBAL",
+                        "authenticationType": "OAUTH",
+                        "code": "auth-code"
+                    }
+                    """, "authorization", "admin");
+            verify(response, 200, "true");
+            assertEquals(2, tokenCalls.get(), "expected spec-pure attempt followed by one body-client_id retry");
         }
     }
 
@@ -1954,8 +2018,8 @@ public class ToolSetApiTest extends ResourceBaseTest {
                     "my-client-id:my-client-secret".getBytes(StandardCharsets.UTF_8));
             assertEquals(expectedAuth, authHeaderRef.get(),
                     "null token_endpoint_auth_method must default to client_secret_basic");
-            assertTrue(bodyRef.get().contains("client_id="),
-                    "client_id must be in body when defaulting to basic (RFC 6749 §3.2.1), got: " + bodyRef.get());
+            assertFalse(bodyRef.get().contains("client_id="),
+                    "client_id must NOT be in body when defaulting to basic (#1703), got: " + bodyRef.get());
             assertFalse(bodyRef.get().contains("client_secret="),
                     "client_secret must NOT be in body when defaulting to basic, got: " + bodyRef.get());
         }

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResourceCredentialsControllerTest.java
@@ -15,6 +15,7 @@ import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.DeploymentService;
+import com.epam.aidial.core.server.service.SecuredResourceService;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
@@ -74,11 +75,11 @@ class ResourceCredentialsControllerTest {
     @BeforeEach
     void setup() {
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor);
-        when(proxy.getResourceCredentialsService()).thenReturn(resourceCredentialsService);
         when(proxy.getAccessService()).thenReturn(accessService);
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getDeploymentService()).thenReturn(deploymentService);
         when(proxy.getResourceAuthSettingsEncryptionService()).thenReturn(resourceAuthSettingsEncryptionService);
+        when(proxy.getSecuredResourceService()).thenReturn(new SecuredResourceService(resourceCredentialsService));
 
         doAnswer(invocation -> {
             Callable<?> callable = invocation.getArgument(0);

--- a/server/src/test/java/com/epam/aidial/core/server/service/SecuredResourceServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/SecuredResourceServiceTest.java
@@ -1,0 +1,151 @@
+package com.epam.aidial.core.server.service;
+
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CredentialsLevel;
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.config.SecuredResource;
+import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
+import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SecuredResourceServiceTest {
+
+    private static final String RESOURCE_URL = "toolsets/encrypted-user-bucket/toolset-1";
+
+    @Mock
+    private ProxyContext context;
+    @Mock
+    private Proxy proxy;
+    @Mock
+    private EncryptionService encryptionService;
+    @Mock
+    private ResourceCredentialsService resourceCredentialsService;
+
+    private SecuredResourceService service;
+
+    @BeforeEach
+    void setup() {
+        service = new SecuredResourceService(resourceCredentialsService);
+    }
+
+    @Test
+    void testSignIn_StoresCredentials() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.OAUTH, null);
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    @Test
+    void testSignIn_BlankApiKeyRejected() {
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, " ");
+
+        HttpException error = assertThrows(HttpException.class,
+                () -> service.signIn(context, createToolSet("http://localhost:1"), request));
+
+        assertEquals(HttpStatus.BAD_REQUEST, error.getStatus());
+        verifyNoInteractions(resourceCredentialsService);
+    }
+
+    @Test
+    void testSignIn_ApiKeyWithControlCharactersRejected() {
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "key\nwith-newline");
+
+        HttpException error = assertThrows(HttpException.class,
+                () -> service.signIn(context, createToolSet("http://localhost:1"), request));
+
+        assertEquals(HttpStatus.BAD_REQUEST, error.getStatus());
+        verifyNoInteractions(resourceCredentialsService);
+    }
+
+    // No endpoint to probe -> validation is skipped, the key is stored (#1698 fail-open)
+    @Test
+    void testSignIn_ApiKeyWithoutEndpointStored() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "some-key");
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    @Test
+    void testSignOut_DeletesCredentials() {
+        mockLocatorPlumbing();
+        ResourceSignOutRequest request = ResourceSignOutRequest.builder()
+                .url(RESOURCE_URL)
+                .credentialsLevel(CredentialsLevel.GLOBAL)
+                .authenticationType(AuthenticationType.API_KEY)
+                .build();
+        when(resourceCredentialsService.deleteResourceCredentials(any(), eq(request), eq("userSub"))).thenReturn(true);
+
+        assertTrue(service.signOut(context, createToolSet(null), request));
+    }
+
+    @Test
+    void testSignIn_UnsupportedResourceTypeRejected() {
+        SecuredResource unknownResource = new SecuredResource() {
+        };
+        ResourceSignInRequest request = signInRequest(AuthenticationType.OAUTH, null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.signIn(context, unknownResource, request));
+        verifyNoInteractions(resourceCredentialsService);
+    }
+
+    private void mockLocatorPlumbing() {
+        when(context.getProxy()).thenReturn(proxy);
+        when(proxy.getEncryptionService()).thenReturn(encryptionService);
+        when(context.getConfig()).thenReturn(mock(Config.class));
+        when(encryptionService.decrypt("encrypted-user-bucket")).thenReturn("Users/userSub/");
+        when(context.getApiKeyData()).thenReturn(mock(ApiKeyData.class));
+        when(context.getUserId()).thenReturn("userSub");
+        when(context.getInitiatorId()).thenReturn("userSub");
+    }
+
+    private static ToolSet createToolSet(String endpoint) {
+        ToolSet toolSet = new ToolSet();
+        toolSet.setEndpoint(endpoint);
+        toolSet.setAuthSettings(ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.API_KEY)
+                .apiKeyHeader("Authorization")
+                .build());
+        return toolSet;
+    }
+
+    private static ResourceSignInRequest signInRequest(AuthenticationType authenticationType, String apiKey) {
+        return ResourceSignInRequest.builder()
+                .url(RESOURCE_URL)
+                .credentialsLevel(CredentialsLevel.GLOBAL)
+                .authenticationType(authenticationType)
+                .apiKey(apiKey)
+                .build();
+    }
+}


### PR DESCRIPTION
Cherry-picks two fixes to the 0.45 release line:

- #1710 — fix: toolset with dynamic OAuth fails on login #1703 (`da660519`)
- #1715 — fix: toolset marked as logged in after invalid API key auth #1698 (`c44323a7`)

Adaptations for release-0.45 (no functional changes):
- Dropped `com.epam.aidial.core.openapi.annotations.*` imports in `ResourceCredentialsController` — the `openapi-annotations` module doesn't exist on this branch.
- Added test-support imports in `ToolSetApiTest` (`SneakyThrows`, Apache HttpClient, `URI`) that pre-existed on `development` from an unrelated commit.

Verified: compile + checkstyle pass; `ToolSetApiTest`, `SecuredResourceServiceTest`, `ResourceCredentialsControllerTest`, and the full `:credentials:test` suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)