### PR TITLE
fix: error thrown on Approve quick app 2.0 with Context files #1732

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationService.java
@@ -391,7 +391,7 @@ public class ApplicationService {
                     resourceService.copyFolder(sourceFile, destFile, false);
                 } else {
                     if (!resourceService.copyResource(sourceFile, destFile, null, false)) {
-                        throw new IllegalArgumentException("Can't copy source file: " + source.getUrl()
+                        throw new IllegalArgumentException("Can't copy source file: " + sourceFile.getUrl()
                                 + " to destination file: " + destFile.getUrl());
                     }
                 }

--- a/server/src/main/java/com/epam/aidial/core/server/validation/ListCollector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/validation/ListCollector.java
@@ -4,7 +4,9 @@ import com.networknt.schema.Collector;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ListCollector<T> implements Collector<List<T>> {
 
@@ -32,7 +34,7 @@ public class ListCollector<T> implements Collector<List<T>> {
         }
     }
 
-    private final List<T> references = new ArrayList<>();
+    private final Set<T> references = new LinkedHashSet<>();
 
     @Override
     @SuppressWarnings("unchecked")
@@ -46,7 +48,7 @@ public class ListCollector<T> implements Collector<List<T>> {
 
     @Override
     public List<T> collect() {
-        return references;
+        return new ArrayList<>(references);
     }
 }
 

--- a/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/PublicationApiTest.java
@@ -1854,6 +1854,64 @@ class PublicationApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testApplicationWithTypeSchemaPublish_Ok_DuplicateFileReference() {
+        Response response = upload(HttpMethod.PUT, "/v1/files/%s/screenshot.png".formatted(bucket), null, """
+                  Test1
+                """);
+
+        Assertions.assertEquals(200, response.status());
+
+        response = send(HttpMethod.PUT, "/v1/applications/%s/test_app_dup".formatted(bucket), null, """
+                  {
+                      "displayName": "test_app_dup",
+                      "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_application_type",
+                      "applicationProperties": {
+                        "property1": "test property1",
+                        "property2": "test property2",
+                        "property3": [
+                                "files/%s/screenshot.png",
+                                "files/%s/screenshot.png"
+                        ]
+                       },
+                       "userRoles": [
+                            "Admin"
+                       ],
+                       "forwardAuthToken": true,
+                       "iconUrl": "https://mydial.somewhere.com/app-icon.svg",
+                       "description": "My application description"
+                  }
+                """.formatted(bucket, bucket));
+        Assertions.assertEquals(200, response.status());
+
+        response = operationRequest("/v1/ops/publication/create", """
+                {
+                      "name": "Publication of my application",
+                      "targetFolder": "public/folder/",
+                      "resources": [
+                        {
+                          "action": "ADD",
+                          "sourceUrl": "applications/%s/test_app_dup",
+                          "targetUrl": "applications/public/folder/with_apps/test_app_dup"
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "source": "roles",
+                          "function": "TRUE"
+                        }
+                      ]
+                    }
+                """.formatted(bucket));
+        Assertions.assertEquals(200, response.status());
+
+        // Before the fix: 400 "Can't copy source file: ..." (second identical copyResource call fails
+        // because the same file URL is collected twice from the schema and the second copy hits an
+        // already-existing destination).
+        response = operationRequest("/v1/ops/publication/approve", PUBLICATION_URL, "authorization", "admin");
+        verify(response, 200);
+    }
+
+    @Test
     void testApplicationWithTypeSchemaPublish_Ok_FolderWithSubfolder() throws JsonProcessingException {
 
         List<String> filePaths =

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -564,6 +564,26 @@ public class ApplicationSchemaServiceTest {
     }
 
     @Test
+    public void getFiles_dedupsDuplicateFileReferences() {
+        when(configStore.get()).thenReturn(config);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+
+        String sharedUrl = "files/public/valid-file-path/valid-sub-path/valid%20file%20name1.ext";
+        Map<String, Object> duplicateProperties = new HashMap<>();
+        duplicateProperties.put("clientFile", sharedUrl);
+        duplicateProperties.put("serverFile", sharedUrl);
+        application.setApplicationProperties(duplicateProperties);
+
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+        when(resourceService.hasResource(any())).thenReturn(true);
+
+        List<ResourceDescriptor> result = service.getFiles(application);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(sharedUrl, result.get(0).getUrl());
+    }
+
+    @Test
     public void getServerFiles_returnsListOfServerFiles_whenSchemaExists() {
         when(configStore.get()).thenReturn(config);
         application.setApplicationTypeSchemaId(URI.create("schemaId"));

--- a/server/src/test/java/com/epam/aidial/core/server/validation/ListCollectorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/validation/ListCollectorTest.java
@@ -1,0 +1,19 @@
+package com.epam.aidial.core.server.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class ListCollectorTest {
+
+    @Test
+    void combine_dedupsWhilePreservingInsertionOrder() {
+        ListCollector<String> collector = new ListCollector<>();
+        collector.combine(List.of("a"));
+        collector.combine(List.of("b"));
+        collector.combine(List.of("a"));
+
+        Assertions.assertEquals(List.of("a", "b"), collector.collect());
+    }
+}


### PR DESCRIPTION
Fixes a publish-approval failure for schema-rich ("Quick App 2.0") applications that have attached Context files: approving the publication threw "Can't copy source file: ..." because the same attachment was discovered twice by the app-schema resource collector and copied twice, with the second copy failing against an already-existing destination.

### Applicable issues

- fixes #1732

### Description of changes

- `ListCollector` now deduplicates collected resource URLs (backed by a `LinkedHashSet` instead of a plain `ArrayList`), so an attachment referenced more than once via schema combinators (`oneOf`/`anyOf`) is only copied once during publish approval.
- `ApplicationService.copyApplication` now reports the actual attachment file's URL in the "Can't copy source file" error instead of the application's own URL, which previously made the error message misleading (it looked like DIAL Core was trying to copy the application resource itself).
- Added `ListCollectorTest` (unit test for the dedup behavior), `ApplicationSchemaServiceTest#getFiles_dedupsDuplicateFileReferences`, and `PublicationApiTest#testApplicationWithTypeSchemaPublish_Ok_DuplicateFileReference` (end-to-end reproduction of the issue).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.