### PR TITLE
feat: share a skill as a whole #1641

### DIFF
--- a/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
@@ -552,6 +552,77 @@ public class SkillResourceApiTest extends ResourceBaseTest {
         verify(listMetadata("shared-group", "Api-key", "proxyKey2"), 200);
     }
 
+    @Test
+    void testRevokeSharedAccess() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+        verify(uploadSkill("/revoke-skill", files), 200);
+
+        // before sharing, the other user has no access
+        assertEquals(403, downloadSkill("/revoke-skill", "Api-key", "proxyKey2").status());
+
+        // share the skill itself (the whole resource, not just its containing folder)
+        Response share = operationRequest("/v1/ops/resource/share/create", """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    { "url": "skills/%s/revoke-skill" }
+                  ]
+                }
+                """.formatted(bucket));
+        verify(share, 200);
+        InvitationLink invitationLink = ProxyUtil.convertToObject(share.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        verify(send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey2"), 200);
+
+        // access is granted after accepting the invitation
+        assertEquals(200, downloadSkill("/revoke-skill", "Api-key", "proxyKey2").status());
+
+        // explicitly revoke the share
+        Response revoke = operationRequest("/v1/ops/resource/share/revoke", """
+                {
+                  "resources": [
+                    { "url": "skills/%s/revoke-skill" }
+                  ]
+                }
+                """.formatted(bucket));
+        verify(revoke, 200);
+
+        // access to the skill and its files is removed after revoke
+        assertEquals(403, downloadSkill("/revoke-skill", "Api-key", "proxyKey2").status());
+        assertEquals(403, getSkillFile("/revoke-skill", "SKILL.md", "Api-key", "proxyKey2").status());
+    }
+
+    @Test
+    void testCleanUpShareAccessWhenOnResourceDeletion() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+        verify(uploadSkill("/delete-cleanup-skill", files), 200);
+
+        Response share = operationRequest("/v1/ops/resource/share/create", """
+                {
+                  "invitationType": "link",
+                  "resources": [
+                    { "url": "skills/%s/delete-cleanup-skill" }
+                  ]
+                }
+                """.formatted(bucket));
+        verify(share, 200);
+        InvitationLink invitationLink = ProxyUtil.convertToObject(share.body(), InvitationLink.class);
+        assertNotNull(invitationLink);
+
+        verify(send(HttpMethod.GET, invitationLink.invitationLink(), "accept=true", null, "Api-key", "proxyKey2"), 200);
+        assertEquals(200, downloadSkill("/delete-cleanup-skill", "Api-key", "proxyKey2").status());
+
+        // delete the shared skill
+        verify(deleteSkill("/delete-cleanup-skill"), 200);
+
+        // recreate a skill at the same path
+        verify(uploadSkill("/delete-cleanup-skill", files), 200);
+
+        // the other user no longer has access: whole-resource delete already cleaned up the share metadata
+        assertEquals(403, downloadSkill("/delete-cleanup-skill", "Api-key", "proxyKey2").status());
+    }
+
     private Response listMetadata(String relativePath, String... headers) {
         return send(HttpMethod.GET, "/v2/metadata/skills/" + bucket + "/" + relativePath, null, "", headers);
     }


### PR DESCRIPTION
Adds test coverage confirming that the SKILL resource type is fully integrated with the existing sharing mechanism: a skill can be shared as a whole unit, files beneath it inherit the granted access, and both explicit revocation and whole-resource deletion clean up the share metadata.

### Applicable issues

- fixes #1641

### Description of changes

- The core sharing support for `SKILL` (resource type registration, share-limits table entry, and the generic parent-folder permission inheritance used by `ShareService`/`AccessService`) already landed via prior work on the folder-as-resource epic (#1634, #1640).
- Added `SkillResourceApiTest.testRevokeSharedAccess`: shares a whole skill resource, accepts the invitation, verifies access, then explicitly revokes it via `/v1/ops/resource/share/revoke` and confirms access to the skill and its files is removed.
- Added `SkillResourceApiTest.testCleanUpShareAccessWhenOnResourceDeletion`: shares a skill, accepts, deletes it, recreates a skill at the same path, and confirms the previous share does not carry over — verifying the existing whole-resource DELETE cleanup (#1635) applies to SKILL.
- Verified checkstyle and the full test suite pass (with two full-suite failures traced to pre-existing, unrelated environment flakiness in shared test setup/teardown, not this change).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.