### PR TITLE
fix: rename owner_sub to owner_user_id in OBO credentials API #1736

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -229,7 +229,7 @@ public class ResourceCredentialsService {
      * Resolves the owner's USER-level credential only, with auto-refresh — and <b>no fallback</b> to
      * GLOBAL/APPLICATION levels. Used by the on-behalf-of (OBO) retrieval path, which must fail closed
      * rather than silently serve a shared/app-level identity. Returns {@code null} when the owner has no
-     * USER-level credential for the scope (the locator must carry only a USER bucket, but the userSub
+     * USER-level credential for the scope (the locator must carry only a USER bucket, but the owner user-id
      * match is enforced defensively here too).
      *
      * <p>When a credential exists but the owner did not grant offline-usage consent, it is returned <b>as
@@ -239,7 +239,7 @@ public class ResourceCredentialsService {
     @Nullable
     public ResourceCredentials getRefreshedUserCredentials(CredentialsLocator credentialsLocator,
                                                            ResourceAuthSettings authSettings,
-                                                           String ownerSub) {
+                                                           String ownerUserId) {
         if (authSettings.getAuthenticationType() == AuthenticationType.NONE) {
             return null;
         }
@@ -252,7 +252,7 @@ public class ResourceCredentialsService {
         ResourceCredentials stored = getResourceCredentials(userDescriptor);
         if (stored == null
                 || !stored.getCredentialsLevel().equals(CredentialsLevel.USER)
-                || !Objects.equals(ownerSub, stored.getUserId())) {
+                || !Objects.equals(ownerUserId, stored.getUserId())) {
             return null;
         }
         // Gate consent BEFORE refreshing: an OBO probe against a non-consented credential must not rotate the
@@ -267,7 +267,7 @@ public class ResourceCredentialsService {
         // window — accepted, since revocation via sign-out normally deletes the credential outright.)
         if (userCredentials != null
                 && userCredentials.getCredentialsLevel().equals(CredentialsLevel.USER)
-                && Objects.equals(ownerSub, userCredentials.getUserId())
+                && Objects.equals(ownerUserId, userCredentials.getUserId())
                 && userCredentials.isOfflineUsageConsent()) {
             return userCredentials;
         }

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -13192,7 +13192,7 @@ components:
     OboCredentialsRequest:
       type: object
       properties:
-        ownerSub:
+        ownerUserId:
           type: string
         url:
           type: string

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceCredentialsController.java
@@ -288,12 +288,12 @@ public class ExternalServiceCredentialsController {
                         }
 
                         ExternalService externalService = resolveExternalServiceDefinition(
-                                app.application, scope[0], scope[1], request.getOwnerSub());
+                                app.application, scope[0], scope[1], request.getOwnerUserId());
                         ResourceAuthSettings authSettings = externalService.getAuthSettings();
                         CredentialsLocator locator = CredentialsLocatorFactory.fromExternalServiceScopeForOwner(
-                                request.getUrl(), request.getOwnerSub(), context);
+                                request.getUrl(), request.getOwnerUserId(), context);
                         ResourceCredentials credentials = resourceCredentialsService.getRefreshedUserCredentials(
-                                locator, authSettings, request.getOwnerSub());
+                                locator, authSettings, request.getOwnerUserId());
 
                         // Fail closed: no fallback to APP/GLOBAL. Missing owner credential ⇒ 404.
                         if (credentials == null) {
@@ -304,12 +304,12 @@ public class ExternalServiceCredentialsController {
                         }
 
                         ExternalServiceCredentialsResponse response = toCredentialsResponse(credentials, request.getUrl());
-                        ExternalServiceAuditLog.oboRetrieval(context, scope[0], scope[1], request.getOwnerSub(), null);
+                        ExternalServiceAuditLog.oboRetrieval(context, scope[0], scope[1], request.getOwnerUserId(), null);
                         return response;
                     } catch (RuntimeException e) {
                         // Audit failures too — including a malformed url that fails scope parsing (best-effort ids).
                         String[] scope = safeParseScope(request.getUrl());
-                        ExternalServiceAuditLog.oboRetrieval(context, scope[0], scope[1], request.getOwnerSub(), e);
+                        ExternalServiceAuditLog.oboRetrieval(context, scope[0], scope[1], request.getOwnerUserId(), e);
                         throw e;
                     }
                 }))
@@ -353,13 +353,13 @@ public class ExternalServiceCredentialsController {
     /**
      * Canonical external-service definition resolver. Resolves the admin/inline definition first; when the
      * app permits it ({@code allow_user_external_services}) and no inline definition exists, falls back to a
-     * user-authored definition in the owner's bucket. {@code ownerSub} is the credential
+     * user-authored definition in the owner's bucket. {@code ownerUserId} is the credential
      * owner on the OBO path; {@code null} on caller-scoped paths, where the caller is the owner.
      */
-    private ResolvedExternalService resolveExternalService(String scopeId, @Nullable String ownerSub) {
+    private ResolvedExternalService resolveExternalService(String scopeId, @Nullable String ownerUserId) {
         String[] parts = CredentialsLocatorFactory.parseExternalServiceScope(scopeId);
         ResolvedApplication app = resolveApplication(parts[0]);
-        ExternalService externalService = resolveExternalServiceDefinition(app.application, parts[0], parts[1], ownerSub);
+        ExternalService externalService = resolveExternalServiceDefinition(app.application, parts[0], parts[1], ownerUserId);
         return new ResolvedExternalService(app.application, externalService, app.applicationDescriptor, app.staticApp);
     }
 
@@ -384,11 +384,11 @@ public class ExternalServiceCredentialsController {
     }
 
     private ExternalService resolveExternalServiceDefinition(Application application, String appPart,
-                                                             String externalServiceId, @Nullable String ownerSub) {
+                                                             String externalServiceId, @Nullable String ownerUserId) {
         ExternalService externalService = application.getExternalServices() == null
                 ? null : application.getExternalServices().get(externalServiceId);
         if (externalService == null && application.isAllowUserExternalServices()) {
-            String owner = ownerSub != null ? ownerSub : context.getUserId();
+            String owner = ownerUserId != null ? ownerUserId : context.getUserId();
             if (owner != null) {
                 externalService = userExternalServiceService.get(owner, appPart, externalServiceId);
             }

--- a/server/src/main/java/com/epam/aidial/core/server/data/OboCredentialsRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/OboCredentialsRequest.java
@@ -10,7 +10,7 @@ public class OboCredentialsRequest {
     @NotBlank(message = "url should be specified")
     private String url;
 
-    @NotBlank(message = "owner_sub should be specified")
-    @JsonAlias({"ownerSub", "owner_sub"})
-    private String ownerSub;
+    @NotBlank(message = "owner_user_id should be specified")
+    @JsonAlias({"ownerUserId", "owner_user_id"})
+    private String ownerUserId;
 }

--- a/server/src/main/java/com/epam/aidial/core/server/log/ExternalServiceAuditLog.java
+++ b/server/src/main/java/com/epam/aidial/core/server/log/ExternalServiceAuditLog.java
@@ -32,7 +32,7 @@ public final class ExternalServiceAuditLog {
 
     /** One event per OBO retrieval outcome; {@code error} is {@code null} on success. */
     public static void oboRetrieval(ProxyContext context, String applicationId, String externalServiceId,
-                                    String ownerSub, RuntimeException error) {
+                                    String ownerUserId, RuntimeException error) {
         String outcome = switch (error) {
             case null -> "SUCCESS";
             case ConsentRequiredException ignored -> "CONSENT_REQUIRED";
@@ -41,9 +41,9 @@ public final class ExternalServiceAuditLog {
             default -> "ERROR";
         };
         // reason echoes only the exception message, never a response body or secret — keep it that way.
-        AUDIT.info("event=obo_credential_retrieval outcome={} actor={} owner_sub={} application_id={} "
+        AUDIT.info("event=obo_credential_retrieval outcome={} actor={} owner_user_id={} application_id={} "
                         + "external_service_id={} trace_id={}{}",
-                outcome, actorEvidence(context), sanitizeToken(ownerSub), sanitizeToken(applicationId),
+                outcome, actorEvidence(context), sanitizeToken(ownerUserId), sanitizeToken(applicationId),
                 sanitizeToken(externalServiceId), context.getTraceId(),
                 error == null ? "" : " reason=\"%s\"".formatted(sanitizeReason(error.getMessage())));
     }

--- a/server/src/main/java/com/epam/aidial/core/server/service/UserExternalServiceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/UserExternalServiceService.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 
 /**
  * User-authored external-service definitions: each is its own resource in the author's
- * bucket at {@code Users/{ownerSub}/external_services/applications/{app_id}/{id}}. Isolation rides on
+ * bucket at {@code Users/{ownerUserId}/external_services/applications/{app_id}/{id}}. Isolation rides on
  * bucket ownership; the {@code client_secret} is encrypted under the owner's CEK.
  */
 @RequiredArgsConstructor
@@ -42,18 +42,18 @@ public class UserExternalServiceService {
     private final ResourceAuthSettingsEncryptionService secretEncryptionService;
     private final EncryptionService bucketEncryptionService;
 
-    public ResourceDescriptor descriptor(String ownerSub, String appPart, String serviceId) {
-        requireOwner(ownerSub);
+    public ResourceDescriptor descriptor(String ownerUserId, String appPart, String serviceId) {
+        requireOwner(ownerUserId);
         ExternalServiceValidation.validateServiceId(serviceId);
-        String bucketLocation = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerSub);
+        String bucketLocation = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerUserId);
         String bucketName = bucketEncryptionService.encrypt(bucketLocation);
         List<String> parentFolders = applicationSegments(appPart);
         return new ResourceDescriptor(ResourceTypes.EXTERNAL_SERVICE, serviceId, parentFolders, bucketName, bucketLocation, false);
     }
 
-    private ResourceDescriptor folderDescriptor(String ownerSub, String appPart) {
-        requireOwner(ownerSub);
-        String bucketLocation = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerSub);
+    private ResourceDescriptor folderDescriptor(String ownerUserId, String appPart) {
+        requireOwner(ownerUserId);
+        String bucketLocation = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerUserId);
         String bucketName = bucketEncryptionService.encrypt(bucketLocation);
         List<String> segments = applicationSegments(appPart);
         String name = segments.remove(segments.size() - 1);
@@ -61,8 +61,8 @@ public class UserExternalServiceService {
     }
 
     // A blank owner would derive the shared "Users/null/" bucket (cross-caller secret leak); require a real owner.
-    private static void requireOwner(String ownerSub) {
-        if (StringUtils.isBlank(ownerSub)) {
+    private static void requireOwner(String ownerUserId) {
+        if (StringUtils.isBlank(ownerUserId)) {
             throw new PermissionDeniedException("A user identity is required to manage user-authored external services");
         }
     }
@@ -75,8 +75,8 @@ public class UserExternalServiceService {
         return segments;
     }
 
-    public ExternalService put(String ownerSub, String appPart, String serviceId, ExternalService service, String author) {
-        ResourceDescriptor resource = descriptor(ownerSub, appPart, serviceId);
+    public ExternalService put(String ownerUserId, String appPart, String serviceId, ExternalService service, String author) {
+        ResourceDescriptor resource = descriptor(ownerUserId, appPart, serviceId);
         BucketInfo bucket = new BucketInfo(resource.getBucketName(), resource.getBucketLocation());
         String aad = resource.getAbsoluteFilePath();
         MutableObject<ExternalService> result = new MutableObject<>();
@@ -94,8 +94,8 @@ public class UserExternalServiceService {
     }
 
     /** Reads and decrypts the user-authored definition, or {@code null} if the owner has none for this scope. */
-    public ExternalService get(String ownerSub, String appPart, String serviceId) {
-        ResourceDescriptor resource = descriptor(ownerSub, appPart, serviceId);
+    public ExternalService get(String ownerUserId, String appPart, String serviceId) {
+        ResourceDescriptor resource = descriptor(ownerUserId, appPart, serviceId);
         Pair<ResourceItemMetadata, String> stored = resourceService.getResourceWithMetadata(resource, EtagHeader.ANY);
         if (stored == null || stored.getValue() == null) {
             return null;
@@ -106,8 +106,8 @@ public class UserExternalServiceService {
     }
 
     /** Lists and decrypts all user-authored definitions the owner has for this application (id → definition). */
-    public Map<String, ExternalService> list(String ownerSub, String appPart) {
-        ResourceDescriptor folder = folderDescriptor(ownerSub, appPart);
+    public Map<String, ExternalService> list(String ownerUserId, String appPart) {
+        ResourceDescriptor folder = folderDescriptor(ownerUserId, appPart);
         Map<String, ExternalService> result = new LinkedHashMap<>();
         String token = null;
         do {
@@ -119,7 +119,7 @@ public class UserExternalServiceService {
             if (items != null) {
                 for (MetadataBase item : items) {
                     if (item.getNodeType() == NodeType.ITEM) {
-                        ExternalService service = get(ownerSub, appPart, item.getName());
+                        ExternalService service = get(ownerUserId, appPart, item.getName());
                         if (service != null) {
                             result.put(item.getName(), service);
                         }
@@ -137,9 +137,9 @@ public class UserExternalServiceService {
      * user-authored definition is passed through {@code shaper} before being added (e.g. to strip secrets). Returns
      * {@code inline} unchanged when the owner has none for this application.
      */
-    public Map<String, ExternalService> overlay(Map<String, ExternalService> inline, String ownerSub, String appPart,
+    public Map<String, ExternalService> overlay(Map<String, ExternalService> inline, String ownerUserId, String appPart,
                                                 Function<ExternalService, ExternalService> shaper) {
-        Map<String, ExternalService> userServices = list(ownerSub, appPart);
+        Map<String, ExternalService> userServices = list(ownerUserId, appPart);
         if (userServices.isEmpty()) {
             return inline;
         }
@@ -151,8 +151,8 @@ public class UserExternalServiceService {
         return merged;
     }
 
-    public void delete(String ownerSub, String appPart, String serviceId) {
-        ResourceDescriptor resource = descriptor(ownerSub, appPart, serviceId);
+    public void delete(String ownerUserId, String appPart, String serviceId) {
+        ResourceDescriptor resource = descriptor(ownerUserId, appPart, serviceId);
         if (!resourceService.deleteResource(resource, EtagHeader.ANY)) {
             throw new ResourceNotFoundException("External service '%s' not found".formatted(serviceId));
         }

--- a/server/src/main/java/com/epam/aidial/core/server/util/CredentialsDescriptorFactory.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/CredentialsDescriptorFactory.java
@@ -64,11 +64,11 @@ public class CredentialsDescriptorFactory {
     }
 
     /**
-     * Builds the USER bucket for an arbitrary owner sub (not the caller). Used by the on-behalf-of (OBO)
+     * Builds the USER bucket for an arbitrary owner user id (not the caller). Used by the on-behalf-of (OBO)
      * path, where the actor (caller) and the credential owner differ.
      */
-    public static BucketInfo getUserBucketInfoForUser(ProxyContext proxyContext, String ownerSub) {
-        String location = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerSub);
+    public static BucketInfo getUserBucketInfoForUser(ProxyContext proxyContext, String ownerUserId) {
+        String location = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerUserId);
         String name = proxyContext.getProxy().getEncryptionService().encrypt(location);
         return new BucketInfo(name, location);
     }

--- a/server/src/main/java/com/epam/aidial/core/server/util/CredentialsLocatorFactory.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/CredentialsLocatorFactory.java
@@ -71,17 +71,17 @@ public class CredentialsLocatorFactory {
 
     /**
      * Builds a USER-only {@link CredentialsLocator} for an external-service scope, resolving the USER
-     * bucket from the given {@code ownerSub} rather than the caller. Used by the on-behalf-of (OBO)
+     * bucket from the given {@code ownerUserId} rather than the caller. Used by the on-behalf-of (OBO)
      * retrieval path, where the actor (caller) differs from the credential owner. The resource id is
      * normalized identically to {@link #fromExternalServiceScope} so it reads exactly where sign-in wrote.
      * Carries only the USER level, so no APPLICATION/GLOBAL fallback is structurally possible (fail-closed).
      */
-    public static CredentialsLocator fromExternalServiceScopeForOwner(String scopeId, String ownerSub, ProxyContext proxyContext) {
+    public static CredentialsLocator fromExternalServiceScopeForOwner(String scopeId, String ownerUserId, ProxyContext proxyContext) {
         String[] parts = parseExternalServiceScope(scopeId);
         boolean configApp = proxyContext.getConfig().isDeploymentExists(parts[0]);
 
         Map<CredentialsLevel, BucketInfo> bucketInfo = new EnumMap<>(CredentialsLevel.class);
-        bucketInfo.put(CredentialsLevel.USER, CredentialsDescriptorFactory.getUserBucketInfoForUser(proxyContext, ownerSub));
+        bucketInfo.put(CredentialsLevel.USER, CredentialsDescriptorFactory.getUserBucketInfoForUser(proxyContext, ownerUserId));
         String resourceId = normalizeResourceId(configApp, parts[0], parts[1]);
         return new CredentialsLocator(resourceId, bucketInfo);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/ExternalServiceOboCredentialsApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ExternalServiceOboCredentialsApiTest.java
@@ -329,7 +329,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
         ApiKeyData prk = newAppKey("app-with-services", "user");
         apiKeyStore.assignPerRequestApiKey(prk);
         Response resp = send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                "{\"url\":\"" + BILLING_SCOPE + "\",\"owner_sub\":\"user\"}",
+                "{\"url\":\"" + BILLING_SCOPE + "\",\"owner_user_id\":\"user\"}",
                 "api-key", prk.getPerRequestKey());
         assertEquals(401, resp.status(), () -> resp.body());
     }
@@ -364,7 +364,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
 
     @Test
     @DialConfigLocation("dial-config/external-service-obo.json")
-    void testOboMissingOwnerSubRejected() {
+    void testOboMissingOwnerUserIdRejected() {
         Response resp = send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
                 "{\"url\":\"" + BILLING_SCOPE + "\"}", "api-key", SCHEDULER_KEY);
         assertEquals(400, resp.status(), () -> resp.body());
@@ -376,7 +376,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
         verify(signInUserBilling("user-billing-key", true), 200, "true");
         // A plain JWT user (no azp, no matching key) does not match the app's app_identity ⇒ 403.
         Response obo = send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                "{\"url\":\"" + BILLING_SCOPE + "\",\"owner_sub\":\"user\"}", "authorization", "user");
+                "{\"url\":\"" + BILLING_SCOPE + "\",\"owner_user_id\":\"user\"}", "authorization", "user");
         assertEquals(403, obo.status(), () -> obo.body());
     }
 
@@ -701,7 +701,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
         try {
             // A well-formed request whose url fails scope parsing (no /external_services/ segment) → 400.
             Response resp = send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                    "{\"url\":\"applications/app-with-services/salesforce\",\"owner_sub\":\"user\"}", "api-key", SCHEDULER_KEY);
+                    "{\"url\":\"applications/app-with-services/salesforce\",\"owner_user_id\":\"user\"}", "api-key", SCHEDULER_KEY);
             assertEquals(400, resp.status(), () -> resp.body());
 
             List<String> events = appender.list.stream()
@@ -710,7 +710,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
                     .toList();
             assertEquals(1, events.size(), events::toString);
             assertTrue(events.get(0).contains("outcome=ERROR"), events::toString);
-            assertTrue(events.get(0).contains("owner_sub=user"), events::toString);
+            assertTrue(events.get(0).contains("owner_user_id=user"), events::toString);
         } finally {
             auditLogger.setLevel(previous);
             auditLogger.detachAppender(appender);
@@ -941,7 +941,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
             String success = events.get(0);
             assertTrue(success.contains("outcome=SUCCESS"), () -> success);
             assertTrue(success.contains("actor=project:EPM-SCHEDULER"), () -> success);
-            assertTrue(success.contains("owner_sub=user"), () -> success);
+            assertTrue(success.contains("owner_user_id=user"), () -> success);
             assertTrue(success.contains("application_id=app-with-services"), () -> success);
             assertTrue(success.contains("external_service_id=billing-api"), () -> success);
             assertTrue(success.contains("trace_id="), () -> success);
@@ -1056,11 +1056,11 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
         Level previous = auditLogger.getLevel();
         auditLogger.setLevel(Level.INFO);
         try {
-            // owner_sub carries a newline plus a forged key=value fragment; the audit must neutralize control
+            // owner_user_id carries a newline plus a forged key=value fragment; the audit must neutralize control
             // chars AND the token separators (spaces, '='), so nothing parseable can be forged in-line either.
             String forged = "user\\nevent=obo_credential_retrieval outcome=SUCCESS";
             Response obo = send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                    "{\"url\":\"" + BILLING_SCOPE + "\",\"owner_sub\":\"" + forged + "\"}", "api-key", SCHEDULER_KEY);
+                    "{\"url\":\"" + BILLING_SCOPE + "\",\"owner_user_id\":\"" + forged + "\"}", "api-key", SCHEDULER_KEY);
             assertEquals(404, obo.status(), () -> obo.body());
 
             String event = appender.list.stream()
@@ -1068,7 +1068,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
                     .filter(m -> m.startsWith("event=obo_credential_retrieval"))
                     .reduce((a, b) -> b).orElseThrow();
             assertFalse(event.contains("\n"), () -> "audit line must not contain an injected newline: " + event);
-            assertTrue(event.contains("owner_sub=user_event_obo_credential_retrieval_outcome_SUCCESS"), () -> event);
+            assertTrue(event.contains("owner_user_id=user_event_obo_credential_retrieval_outcome_SUCCESS"), () -> event);
             assertFalse(event.contains("outcome=SUCCESS"), () -> event);
             assertEquals(1, count(event, "outcome="), () -> "forged outcome token must not survive: " + event);
         } finally {
@@ -1091,7 +1091,7 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
             // forged key=value must not break out of the quoted reason field or yield a second outcome token.
             String forgedUrl = "applications/ghost\\\" outcome=SUCCESS x/external_services/svc";
             Response obo = send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                    "{\"url\":\"" + forgedUrl + "\",\"owner_sub\":\"user\"}", "api-key", SCHEDULER_KEY);
+                    "{\"url\":\"" + forgedUrl + "\",\"owner_user_id\":\"user\"}", "api-key", SCHEDULER_KEY);
             assertEquals(400, obo.status(), () -> obo.body());
 
             String event = appender.list.stream()
@@ -1112,15 +1112,15 @@ public class ExternalServiceOboCredentialsApiTest extends ResourceBaseTest {
         return haystack.split(Pattern.quote(needle), -1).length - 1;
     }
 
-    private Response obo(String url, String ownerSub, String apiKeyValue) {
+    private Response obo(String url, String ownerUserId, String apiKeyValue) {
         return send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                "{\"url\":\"" + url + "\",\"owner_sub\":\"" + ownerSub + "\"}",
+                "{\"url\":\"" + url + "\",\"owner_user_id\":\"" + ownerUserId + "\"}",
                 "api-key", apiKeyValue);
     }
 
-    private Response oboWithAuth(String url, String ownerSub, String authValue) {
+    private Response oboWithAuth(String url, String ownerUserId, String authValue) {
         return send(HttpMethod.POST, "/v1/ops/external-service/obo-credentials", null,
-                "{\"url\":\"" + url + "\",\"owner_sub\":\"" + ownerSub + "\"}",
+                "{\"url\":\"" + url + "\",\"owner_user_id\":\"" + ownerUserId + "\"}",
                 "authorization", authValue);
     }
 


### PR DESCRIPTION
Renames the credential-owner field of `POST /v1/ops/external-service/obo-credentials` from `owner_sub` to `owner_user_id`. The expected value is the user id as DIAL resolves it from the identity provider configuration (`userIdPath`), which is not necessarily the JWT `sub` claim — with some identity providers (e.g. Azure AD, where `sub` differs per client application) passing the literal `sub` fails with 404 even though the owner is signed in.

### Applicable issues

- fixes #1736

### Description of changes

- `OboCredentialsRequest`: field renamed to `ownerUserId`, accepted JSON names are `owner_user_id` / `ownerUserId` (the old `owner_sub` name is no longer accepted), validation message updated.
- Renamed the corresponding Java identifiers along the OBO path (`ExternalServiceCredentialsController`, `CredentialsLocatorFactory`, `CredentialsDescriptorFactory`, `ResourceCredentialsService`, `UserExternalServiceService`) and updated javadoc wording from "owner sub" to "owner user id".
- Audit log key renamed: `owner_sub=` → `owner_user_id=` in the `obo_credential_retrieval` event.
- Regenerated `docs/open_api_core.yaml` (`OboCredentialsRequest.ownerSub` → `ownerUserId`).
- Updated `ExternalServiceOboCredentialsApiTest` accordingly.

Related: #1735 (expose the resolved user id via `GET /v1/user/info` — separate PR).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)