### PR TITLE
feat: expose resolved user id in GET /v1/user/info #1735

### DIFF
--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -14372,6 +14372,9 @@ components:
         project:
           type: string
           description: Present only if authenticated via an API Key. Represents the target project scope.
+        userId:
+          type: string
+          description: The user id as DIAL resolves it from the identity provider configuration (not necessarily the token's sub claim). Present only for user-based session authentication. Use this value as owner_user_id when retrieving credentials on behalf of the user.
         userClaims:
           type: object
           additionalProperties:

--- a/server/src/main/java/com/epam/aidial/core/server/controller/UserInfoController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/UserInfoController.java
@@ -39,6 +39,9 @@ public class UserInfoController implements Controller {
         if (context.getKey() != null) {
             response.put("project", context.getKey().getProject());
         } else {
+            // The user id as DIAL resolves it from the identity provider configuration (userIdPath) — the value
+            // integrations must pass as owner_user_id on the on-behalf-of credentials path.
+            response.put("userId", context.getExtractedClaims().userId());
             ObjectNode claims = normalize(context.getExtractedClaims().userClaims());
             response.put("userClaims", claims);
         }

--- a/server/src/test/java/com/epam/aidial/core/server/UserInfoApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/UserInfoApiTest.java
@@ -22,6 +22,6 @@ public class UserInfoApiTest extends ResourceBaseTest {
 
         assertEquals(200, resp.status());
         assertEquals("""
-                {"roles":["user"],"userClaims":{"title":["Manager"]}}""", resp.body());
+                {"roles":["user"],"userId":"user","userClaims":{"title":["Manager"]}}""", resp.body());
     }
 }


### PR DESCRIPTION
Adds a `userId` field to the `GET /v1/user/info` response for user-based (JWT) sessions. The value is the user id as DIAL resolves it from the identity provider configuration (`userIdPath`), which is not necessarily the token's `sub` claim. This lets integrations capture the caller's id during a live session and reuse it later — e.g. as `owner_user_id` in the on-behalf-of credentials API — without knowing or duplicating DIAL's identity configuration.

### Applicable issues

- fixes #1735

### Description of changes

- `UserInfoController`: the JWT branch now includes `userId` (from the resolved extracted claims) alongside `roles`/`userClaims`. The API-key branch is unchanged (it still returns `project`).
- `docs/open_api_core.yaml`: added `userId` to the `UserInfoResponse` schema (regenerated via the OpenAPI generator).
- `UserInfoApiTest`: updated the user-session expectation to include `userId`.

Related: #1736 (renames the OBO field to `owner_user_id` — separate PR).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.