### PR TITLE
feat: publish a skill as a whole (review -> public flow) #1642

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -287,10 +287,16 @@ public class AiDial {
             UpstreamCacheService upstreamCacheService = new UpstreamCacheService(redis, lockService, clock, storage.getPrefix());
             UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, Random::new, upstreamCacheService);
 
+            ComplexResourceService.Settings complexResourceSettings = Json.decodeValue(
+                    settings("complexResource").toBuffer(), ComplexResourceService.Settings.class);
+            ComplexResourceService complexResourceService = new ComplexResourceService(
+                    resourceService, lockService, storage, complexResourceSettings);
+
             ResourceOperationService resourceOperationService = new ResourceOperationService(applicationService,
-                    toolSetService, resourceService, invitationService, shareService, lockService);
+                    toolSetService, resourceService, invitationService, shareService, lockService, complexResourceService);
             PublicationService publicationService = new PublicationService(encryptionService, resourceService, accessService,
-                    ruleService, notificationService, applicationService, toolSetService, resourceOperationService, generator, clock);
+                    ruleService, notificationService, applicationService, toolSetService, resourceOperationService,
+                    complexResourceService, generator, clock);
 
             DeploymentService deploymentService = new DeploymentService(encryptionService, applicationService, accessService,
                     toolSetService, resourceService, applicationSchemaService);
@@ -311,10 +317,6 @@ public class AiDial {
             ResponseMappingService responseMappingService = new ResponseMappingService(vertx, generator, resourceService);
             responseMappingService.init(taskExecutor);
 
-            ComplexResourceService.Settings complexResourceSettings = Json.decodeValue(
-                    settings("complexResource").toBuffer(), ComplexResourceService.Settings.class);
-            ComplexResourceService complexResourceService = new ComplexResourceService(
-                    resourceService, lockService, shareService, invitationService, storage, complexResourceSettings);
             ComplexResourceSweepService.Settings complexResourceSweepSettings = Json.decodeValue(
                     settings("complexResourceSweep").toBuffer(), ComplexResourceSweepService.Settings.class);
             complexResourceSweepService = new ComplexResourceSweepService(timerService, storage, redis, lockService,

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceController.java
@@ -10,6 +10,7 @@ import com.epam.aidial.core.openapi.annotations.ParameterIn;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
+import com.epam.aidial.core.server.service.ResourceOperationService;
 import com.epam.aidial.core.server.service.resource.ComplexResourceHandler;
 import com.epam.aidial.core.server.service.resource.ComplexResourceService;
 import com.epam.aidial.core.server.service.resource.SkillHandler;
@@ -49,6 +50,7 @@ public class ComplexResourceController extends AccessControlBaseController {
             ResourceTypes.SKILL, new SkillHandler());
 
     private final ComplexResourceService complexResourceService;
+    private final ResourceOperationService resourceOperationService;
     // Relative path of a single file inside the resource; null for whole-resource operations.
     private final String filePath;
     // True for DIAL grouping-folder operations (trailing-slash route).
@@ -69,6 +71,7 @@ public class ComplexResourceController extends AccessControlBaseController {
     private ComplexResourceController(Proxy proxy, ProxyContext context, boolean isWriteAccess, String filePath, boolean folderOp) {
         super(proxy, context, isWriteAccess);
         this.complexResourceService = proxy.getComplexResourceService();
+        this.resourceOperationService = proxy.getResourceOperationService();
         this.filePath = filePath;
         this.folderOp = folderOp;
     }
@@ -343,11 +346,13 @@ public class ComplexResourceController extends AccessControlBaseController {
     )
     private Future<?> delete(ResourceDescriptor resource) {
         EtagHeader etag = ProxyUtil.etag(context.getRequest());
-        proxy.getTaskExecutor().submit(() -> {
-            complexResourceService.delete(resource, etag);
-            return null;
-        })
-                .compose(v -> context.respond(HttpStatus.OK).mapEmpty())
+        proxy.getTaskExecutor().submit(() -> resourceOperationService.deleteResource(context, resource, etag))
+                .compose(deleted -> {
+                    if (!deleted) {
+                        return context.respond(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl()).mapEmpty();
+                    }
+                    return context.respond(HttpStatus.OK).mapEmpty();
+                })
                 .recover(error -> {
                     log.warn("Failed to delete resource: {}", resource.getUrl(), error);
                     return context.respond(error, "Failed to delete resource: " + resource.getUrl()).mapEmpty();

--- a/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/PublicationService.java
@@ -11,6 +11,7 @@ import com.epam.aidial.core.server.data.ResourceUrl;
 import com.epam.aidial.core.server.data.Rule;
 import com.epam.aidial.core.server.security.AccessService;
 import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.service.resource.ComplexResourceService;
 import com.epam.aidial.core.server.util.BucketBuilder;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
@@ -57,7 +58,7 @@ public class PublicationService {
             ResourceTypes.PUBLICATION, ResourceDescriptor.PUBLIC_BUCKET, ResourceDescriptor.PUBLIC_LOCATION, PUBLICATIONS_NAME);
 
     private static final Set<ResourceType> ALLOWED_RESOURCES = Set.of(ResourceTypes.FILE, ResourceTypes.CONVERSATION,
-            ResourceTypes.PROMPT, ResourceTypes.APPLICATION, ResourceTypes.TOOL_SET);
+            ResourceTypes.PROMPT, ResourceTypes.APPLICATION, ResourceTypes.TOOL_SET, ResourceTypes.SKILL);
 
     private final EncryptionService encryption;
     private final ResourceService resourceService;
@@ -67,6 +68,7 @@ public class PublicationService {
     private final ApplicationService applicationService;
     private final ToolSetService toolSetService;
     private final ResourceOperationService resourceOperationService;
+    private final ComplexResourceService complexResourceService;
     private final Supplier<String> ids;
     private final LongSupplier clock;
 
@@ -268,7 +270,7 @@ public class PublicationService {
                 if (resource.getAction() == Publication.ResourceAction.ADD || resource.getAction() == Publication.ResourceAction.ADD_IF_ABSENT) {
                     if (existingResource == null) {
                         ResourceDescriptor from = ResourceDescriptorFactory.fromPrivateUrl(resource.getSourceUrl(), encryption);
-                        if (!resourceService.hasResource(from)) {
+                        if (!hasResource(from)) {
                             throw new IllegalArgumentException("Source resource does not exist: " + resource.getSourceUrl());
                         }
                         reviewResourcesToAdd.add(resource);
@@ -305,6 +307,8 @@ public class PublicationService {
                 ResourceDescriptor resource = ResourceDescriptorFactory.fromPrivateUrl(reviewResource.getReviewUrl(), encryption);
                 if (resource.getType() == ResourceTypes.TOOL_SET) {
                     toolSetService.deleteToolset(context, resource, EtagHeader.ANY);
+                } else if (resource.getType() == ResourceTypes.SKILL) {
+                    complexResourceService.delete(resource, EtagHeader.ANY);
                 } else {
                     resourceService.deleteResource(resource, EtagHeader.ANY);
                 }
@@ -549,11 +553,11 @@ public class PublicationService {
             throw new IllegalArgumentException("Source and target resource types do not match: " + targetUrl);
         }
 
-        if (isPublicationNew && !resourceService.hasResource(source)) {
+        if (isPublicationNew && !hasResource(source)) {
             throw new IllegalArgumentException("Source resource does not exist: " + sourceUrl);
         }
 
-        if (resource.getAction() == Publication.ResourceAction.ADD && resourceService.hasResource(target)) {
+        if (resource.getAction() == Publication.ResourceAction.ADD && hasResource(target)) {
             throw new IllegalArgumentException("Target resource already exists: " + targetUrl);
         }
 
@@ -602,7 +606,7 @@ public class PublicationService {
             throw new IllegalArgumentException("Target resources have duplicate urls: " + targetUrl);
         }
 
-        if (!resourceService.hasResource(target)) {
+        if (!hasResource(target)) {
             throw new IllegalArgumentException("Target resource does not exists: " + targetUrl);
         }
 
@@ -643,7 +647,7 @@ public class PublicationService {
             String url = resource.getReviewUrl();
             ResourceDescriptor descriptor = ResourceDescriptorFactory.fromPrivateUrl(url, encryption);
             verifyResourceType(descriptor);
-            if (!resourceService.hasResource(descriptor)) {
+            if (!hasResource(descriptor)) {
                 throw new IllegalArgumentException("Review resource does not exist: " + descriptor.getUrl());
             }
         }
@@ -655,11 +659,17 @@ public class PublicationService {
             ResourceDescriptor descriptor = ResourceDescriptorFactory.fromPublicUrl(url);
             verifyResourceType(descriptor);
 
-            if (resource.getAction() != Publication.ResourceAction.ADD_IF_ABSENT && resourceService.hasResource(descriptor) != exists) {
+            if (resource.getAction() != Publication.ResourceAction.ADD_IF_ABSENT && hasResource(descriptor) != exists) {
                 String errorMessage = exists ? "Target resource does not exists: " + url : "Target resource  exists: " + url;
                 throw new IllegalArgumentException(errorMessage);
             }
         }
+    }
+
+    private boolean hasResource(ResourceDescriptor descriptor) {
+        return descriptor.getType() == ResourceTypes.SKILL
+                ? complexResourceService.getMarker(descriptor) != null
+                : resourceService.hasResource(descriptor);
     }
 
     private void copySourceToReviewResources(ProxyContext context, List<Publication.Resource> resources) {
@@ -696,6 +706,10 @@ public class PublicationService {
                 Map<CredentialsLevel, Boolean> credentialsToCopy = getCredentialsLevelsToCopy(resource);
                 toolSetService.copyToolSet(context, from, to, null, false, credentialsToCopy,
                         toolSet -> toolSet.setIconUrl(replaceLink(replacementLinks, toolSet.getIconUrl())));
+            } else if (from.getType() == ResourceTypes.SKILL) {
+                if (!complexResourceService.copyResource(from, to, null, false)) {
+                    throw new IllegalStateException("Can't copy source resource from: " + from.getUrl() + " to review: " + to.getUrl());
+                }
             } else if (!resourceService.copyResource(from, to)) {
                 throw new IllegalStateException("Can't copy source resource from: " + from.getUrl() + " to review: " + to.getUrl());
             }
@@ -741,6 +755,14 @@ public class PublicationService {
                 Map<CredentialsLevel, Boolean> credentialsToCopy = getCredentialsLevelsToCopy(resource);
                 toolSetService.copyToolSet(context, from, to, publication.getDisplayAuthor(), false,
                         credentialsToCopy, toolSet -> toolSet.setIconUrl(replaceLink(replacementLinks, toolSet.getIconUrl())));
+            } else if (from.getType() == ResourceTypes.SKILL) {
+                // approvePublication is always invoked under the public bucket lock (see
+                // PublicationController#approvePublication), so the "already locked" variant is required
+                // here: taking the same bucket lock again would self-deadlock.
+                if (!complexResourceService.copyResourceLocked(from, to, publication.getDisplayAuthor(), false)
+                        && resource.getAction() != Publication.ResourceAction.ADD_IF_ABSENT) {
+                    throw new IllegalStateException("Can't copy source resource from: " + from.getUrl() + " to target: " + to.getUrl());
+                }
             } else {
                 UserMetadata userMetadata = new UserMetadata();
                 ResourceItemMetadata metadata = resourceService.getResourceMetadata(from);

--- a/server/src/main/java/com/epam/aidial/core/server/service/ResourceOperationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ResourceOperationService.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.service;
 import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.service.resource.ComplexResourceService;
 import com.epam.aidial.core.storage.data.ResourceEvent;
 import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpException;
@@ -26,12 +27,13 @@ import static com.epam.aidial.core.storage.resource.ResourceTypes.APPLICATION;
 import static com.epam.aidial.core.storage.resource.ResourceTypes.CONVERSATION;
 import static com.epam.aidial.core.storage.resource.ResourceTypes.FILE;
 import static com.epam.aidial.core.storage.resource.ResourceTypes.PROMPT;
+import static com.epam.aidial.core.storage.resource.ResourceTypes.SKILL;
 import static com.epam.aidial.core.storage.resource.ResourceTypes.TOOL_SET;
 
 @AllArgsConstructor
 public class ResourceOperationService {
     private static final Set<ResourceTypes> ALLOWED_RESOURCES = Set.of(FILE, CONVERSATION,
-            PROMPT, APPLICATION, TOOL_SET);
+            PROMPT, APPLICATION, TOOL_SET, SKILL);
 
     private final ApplicationService applicationService;
     private final ToolSetService toolSetService;
@@ -39,6 +41,7 @@ public class ResourceOperationService {
     private final InvitationService invitationService;
     private final ShareService shareService;
     private final LockService lockService;
+    private final ComplexResourceService complexResourceService;
 
     public ResourceTopic.Subscription subscribeResources(Collection<ResourceDescriptor> resources,
                                                          Consumer<ResourceEvent> subscriber) {
@@ -54,7 +57,7 @@ public class ResourceOperationService {
         String sourceResourceUrl = source.getUrl();
         String destinationResourceUrl = destination.getUrl();
 
-        if (!resourceService.hasResource(source)) {
+        if (!hasResource(source)) {
             throw new IllegalArgumentException("Source resource %s does not exist".formatted(sourceResourceUrl));
         }
 
@@ -76,6 +79,11 @@ public class ResourceOperationService {
             // TODO: support move for USER and APP credentials for public toolsets
             // TODO: support move for USER and APP credentials for shared toolsets (?)
             toolSetService.copyToolSet(context, source, destination, null, overwriteIfExists, credentialsToCopy);
+        } else if (destination.getType() == SKILL) {
+            if (!complexResourceService.copyResource(source, destination, null, overwriteIfExists)) {
+                throw new IllegalArgumentException("Can't move resource %s to %s, because destination resource already exists"
+                        .formatted(sourceResourceUrl, destinationResourceUrl));
+            }
         } else {
             boolean copied = resourceService.copyResource(source, destination, null, overwriteIfExists);
             if (!copied) {
@@ -103,6 +111,8 @@ public class ResourceOperationService {
             applicationService.deleteApplication(source, EtagHeader.ANY);
         } else if (destination.getType() == TOOL_SET) {
             toolSetService.deleteToolset(context, source, EtagHeader.ANY);
+        } else if (destination.getType() == SKILL) {
+            complexResourceService.delete(source, EtagHeader.ANY);
         } else {
             resourceService.deleteResource(source, EtagHeader.ANY);
         }
@@ -117,7 +127,7 @@ public class ResourceOperationService {
         String sourceResourceUrl = source.getUrl();
         String destinationResourceUrl = destination.getUrl();
 
-        if (!resourceService.hasResource(source)) {
+        if (!hasResource(source)) {
             throw new IllegalArgumentException("Source resource does not exist: " + sourceResourceUrl);
         }
 
@@ -135,6 +145,11 @@ public class ResourceOperationService {
             });
         } else if (destination.getType() == TOOL_SET) {
             toolSetService.copyToolSet(context, source, destination, null, overwriteIfExists, Map.of());
+        } else if (destination.getType() == SKILL) {
+            if (!complexResourceService.copyResource(source, destination, null, overwriteIfExists)) {
+                throw new IllegalArgumentException("Can't copy resource %s to %s, because destination resource already exists"
+                        .formatted(sourceResourceUrl, destinationResourceUrl));
+            }
         } else {
             boolean copied = resourceService.copyResource(source, destination, null, overwriteIfExists);
             if (!copied) {
@@ -142,6 +157,12 @@ public class ResourceOperationService {
                         .formatted(sourceResourceUrl, destinationResourceUrl));
             }
         }
+    }
+
+    private boolean hasResource(ResourceDescriptor resource) {
+        return resource.getType() == SKILL
+                ? complexResourceService.getMarker(resource) != null
+                : resourceService.hasResource(resource);
     }
 
     public boolean deleteResource(ProxyContext context, ResourceDescriptor resource, EtagHeader etag) {
@@ -166,7 +187,7 @@ public class ResourceOperationService {
     private static void verifyResourceToDelete(ResourceDescriptor resource) {
         ResourceType type = resource.getType();
         if (!(APPLICATION == type || FILE == type
-                || CONVERSATION == type || type == PROMPT || type == TOOL_SET)) {
+                || CONVERSATION == type || type == PROMPT || type == TOOL_SET || type == SKILL)) {
             throw new IllegalArgumentException("Unsupported resource type to delete: " + type.name());
         }
     }
@@ -182,9 +203,19 @@ public class ResourceOperationService {
         }
         if (resource.getType() == TOOL_SET) {
             return toolSetService.deleteToolset(context, resource, etag);
-        } else {
-            return resourceService.deleteResource(resource, etag);
         }
+        if (resource.getType() == SKILL) {
+            try {
+                complexResourceService.delete(resource, etag);
+            } catch (HttpException e) {
+                if (e.getStatus() == HttpStatus.NOT_FOUND) {
+                    return false;
+                }
+                throw e;
+            }
+            return true;
+        }
+        return resourceService.deleteResource(resource, etag);
     }
 
 }

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -2,8 +2,6 @@ package com.epam.aidial.core.server.service.resource;
 
 import com.epam.aidial.core.server.data.folder.ComplexResourceRef;
 import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
-import com.epam.aidial.core.server.service.InvitationService;
-import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.storage.blobstore.BlobStorage;
 import com.epam.aidial.core.storage.blobstore.BlobStorageUtil;
@@ -12,6 +10,7 @@ import com.epam.aidial.core.storage.data.MetadataBase;
 import com.epam.aidial.core.storage.data.NodeType;
 import com.epam.aidial.core.storage.data.ResourceFolderMetadata;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
+import com.epam.aidial.core.storage.data.UserMetadata;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
@@ -80,18 +79,13 @@ public class ComplexResourceService {
 
     private final ResourceService resourceService;
     private final LockService lockService;
-    private final ShareService shareService;
-    private final InvitationService invitationService;
     private final BlobStorage blobStorage;
     private final Settings settings;
 
     public ComplexResourceService(ResourceService resourceService, LockService lockService,
-                                 ShareService shareService, InvitationService invitationService,
                                  BlobStorage blobStorage, Settings settings) {
         this.resourceService = resourceService;
         this.lockService = lockService;
-        this.shareService = shareService;
-        this.invitationService = invitationService;
         this.blobStorage = blobStorage;
         this.settings = settings;
     }
@@ -179,6 +173,74 @@ public class ComplexResourceService {
                 }
             }
         });
+    }
+
+    /**
+     * Copies a whole resource across resource keys — used to move a complex resource between the private,
+     * review and public buckets during publication. The current version's files are copied server-side
+     * into a fresh {@code v/{versionId}/} prefix at the destination, then a marker is committed there that
+     * is freshly synthesized from the copy (a new {@code currentVersion}, an aggregate etag recomputed from
+     * the copied files, fresh {@code createdAt}/{@code updatedAt}/author) — the source marker document is
+     * never carried over as-is. The type-specific metadata (e.g. a skill's name/description) is preserved
+     * as-is since the file content is unchanged.
+     *
+     * @return {@code true} if copied; {@code false} if the destination already holds an active resource and
+     *         {@code overwrite} is {@code false} (mirrors {@link ResourceService#copyResource})
+     * @throws HttpException NOT_FOUND if the source resource is absent or in the {@code deleting} state
+     */
+    public boolean copyResource(ResourceDescriptor from, ResourceDescriptor to, String author, boolean overwrite) {
+        return lockService.underBucketLock(to.getBucketLocation(), () -> copyResourceLocked(from, to, author, overwrite));
+    }
+
+    /**
+     * Same as {@link #copyResource}, for a caller that already holds {@code to}'s bucket lock — e.g.
+     * publication approval, which locks the whole public bucket around the entire approve operation to
+     * serialize it against concurrent publish/rule writes. Taking the bucket lock again here would
+     * self-deadlock (the lock is a per-call spin lock, not reentrant across calls).
+     */
+    public boolean copyResourceLocked(ResourceDescriptor from, ResourceDescriptor to, String author, boolean overwrite) {
+        FolderResourceMarker source = getMarker(from);
+        if (source == null) {
+            throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + from.getUrl());
+        }
+
+        ResourceDescriptor marker = markerDescriptor(to);
+        String versionId = UUID.randomUUID().toString().replace("-", "");
+
+        ensureStructuralPath(to, ResourceKind.RESOURCE, author);
+
+        try (LockService.Lock ignore = resourceService.lockResource(marker)) {
+            FolderResourceMarker existing = readMarker(marker, false);
+            if (isActive(existing) && !overwrite) {
+                return false;
+            }
+
+            try {
+                Map<String, FolderResourceMarker.ResourceFileMetadata> fileMetadata = currentFileMetadata(from, source);
+                for (Map.Entry<String, FolderResourceMarker.ResourceFileMetadata> entry : fileMetadata.entrySet()) {
+                    ResourceDescriptor sourceFile = versionFile(from, source.getCurrentVersion(), entry.getKey());
+                    ResourceDescriptor destFile = versionFile(to, versionId, entry.getKey());
+                    UserMetadata fileMeta = new UserMetadata();
+                    fileMeta.setEtag(entry.getValue().getEtag());
+                    if (!resourceService.copyResource(sourceFile, destFile, fileMeta, false)) {
+                        throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR,
+                                "Can't copy resource file from: " + sourceFile.getUrl() + " to: " + destFile.getUrl());
+                    }
+                }
+                // Mirrors put(): an overwrite of an existing (even `deleting`) marker reuses its
+                // reference, which is keyed by URL, not by version.
+                if (existing == null) {
+                    writeReference(to);
+                }
+                commitMarker(marker, to, versionId, aggregateEtag(fileMetadata), source.getMetadata(),
+                        fileMetadata, existing, author);
+                return true;
+            } catch (Exception e) {
+                // Nothing is observable until the marker is committed; drop the orphan version files.
+                deleteVersion(versionFolder(to, versionId));
+                throw e;
+            }
+        }
     }
 
     /**
@@ -715,13 +777,16 @@ public class ComplexResourceService {
 
     /**
      * Tombstones the resource by flipping the {@code .dial-resource} marker to {@code state: deleting} and
-     * stamping {@code deletedAt}, then (for a private resource) cleans up its invitation links and shares.
-     * The version tree, the marker file itself and its {@code complex_resource_refs} pointer are <b>not</b>
-     * touched here: they are reclaimed later, once {@code gracePeriod} has elapsed, by
-     * {@code ComplexResourceSweepService} via {@link #reclaimDeletingResource}.
+     * stamping {@code deletedAt}. The version tree, the marker file itself and its
+     * {@code complex_resource_refs} pointer are <b>not</b> touched here: they are reclaimed later, once
+     * {@code gracePeriod} has elapsed, by {@code ComplexResourceSweepService} via
+     * {@link #reclaimDeletingResource}.
      *
      * <p>The tombstone write (via {@link ResourceService#computeResource}) is the linearization point:
-     * once committed, all read paths return 404 even if the version tree still physically exists.
+     * once committed, all read paths return 404 even if the version tree still physically exists. This
+     * resource-level lock (held internally by {@code computeResource}) is the only locking done here;
+     * bucket-level locking and invitation/share cleanup are the caller's responsibility (see
+     * {@code ResourceOperationService#deleteResource}).
      *
      * @throws HttpException NOT_FOUND if the resource does not exist or is already {@code deleting};
      *                       PRECONDITION_FAILED if the {@code If-Match} header does not match
@@ -729,29 +794,18 @@ public class ComplexResourceService {
     public void delete(ResourceDescriptor resource, EtagHeader etag) {
         ResourceDescriptor marker = markerDescriptor(resource);
 
-        // use bucket lock since the operation involves updating multiple resources
-        lockService.underBucketLock(resource.getBucketLocation(), () -> {
-            resourceService.computeResource(marker, json -> {
-                if (json == null) {
-                    throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
-                }
-                FolderResourceMarker current = ProxyUtil.convertToObject(json, FolderResourceMarker.class);
-                if (!isActive(current)) {
-                    throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
-                }
-                etag.validate(current.getEtag());
-                current.setState(STATE_DELETING);
-                current.setDeletedAt(System.currentTimeMillis());
-                return Objects.requireNonNull(ProxyUtil.convertToString(current));
-            });
-
-            if (resource.isPrivate()) {
-                String bucketName = resource.getBucketName();
-                String bucketLocation = resource.getBucketLocation();
-                invitationService.cleanUpResourceLink(bucketName, bucketLocation, resource);
-                shareService.revokeSharedResource(bucketName, bucketLocation, resource);
+        resourceService.computeResource(marker, json -> {
+            if (json == null) {
+                throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
             }
-            return null;
+            FolderResourceMarker current = ProxyUtil.convertToObject(json, FolderResourceMarker.class);
+            if (!isActive(current)) {
+                throw new HttpException(HttpStatus.NOT_FOUND, "Resource not found: " + resource.getUrl());
+            }
+            etag.validate(current.getEtag());
+            current.setState(STATE_DELETING);
+            current.setDeletedAt(System.currentTimeMillis());
+            return Objects.requireNonNull(ProxyUtil.convertToString(current));
         });
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -148,6 +148,12 @@ public class ComplexResourceService {
                 etag.validate(readAggregateEtag(marker));
 
                 try {
+                    FolderResourceMarker existing = readMarker(marker, false);
+                    if (existing == null) {
+                        // First creation only: an overwrite of an existing (even `deleting`) marker reuses
+                        // its reference, which is keyed by URL, not by version.
+                        writeReference(resource);
+                    }
                     Map<String, FolderResourceMarker.ResourceFileMetadata> fileMetadata = new TreeMap<>();
                     for (Map.Entry<String, byte[]> entry : files.entrySet()) {
                         String relativePath = entry.getKey();
@@ -157,12 +163,6 @@ public class ComplexResourceService {
                                 BlobStorageUtil.getContentType(relativePath), author);
                         fileMetadata.put(relativePath,
                                 new FolderResourceMarker.ResourceFileMetadata(content.length, written.getEtag()));
-                    }
-                    FolderResourceMarker existing = readMarker(marker, false);
-                    if (existing == null) {
-                        // First creation only: an overwrite of an existing (even `deleting`) marker reuses
-                        // its reference, which is keyed by URL, not by version.
-                        writeReference(resource);
                     }
                     return commitMarker(marker, resource, versionId, aggregateEtag(fileMetadata),
                             handler.buildMarkerMetadata(files), fileMetadata, existing, author);
@@ -216,6 +216,11 @@ public class ComplexResourceService {
             }
 
             try {
+                // Mirrors put(): an overwrite of an existing (even `deleting`) marker reuses its
+                // reference, which is keyed by URL, not by version.
+                if (existing == null) {
+                    writeReference(to);
+                }
                 Map<String, FolderResourceMarker.ResourceFileMetadata> fileMetadata = currentFileMetadata(from, source);
                 for (Map.Entry<String, FolderResourceMarker.ResourceFileMetadata> entry : fileMetadata.entrySet()) {
                     ResourceDescriptor sourceFile = versionFile(from, source.getCurrentVersion(), entry.getKey());
@@ -226,11 +231,6 @@ public class ComplexResourceService {
                         throw new HttpException(HttpStatus.INTERNAL_SERVER_ERROR,
                                 "Can't copy resource file from: " + sourceFile.getUrl() + " to: " + destFile.getUrl());
                     }
-                }
-                // Mirrors put(): an overwrite of an existing (even `deleting`) marker reuses its
-                // reference, which is keyed by URL, not by version.
-                if (existing == null) {
-                    writeReference(to);
                 }
                 commitMarker(marker, to, versionId, aggregateEtag(fileMetadata), source.getMetadata(),
                         fileMetadata, existing, author);

--- a/server/src/test/java/com/epam/aidial/core/server/SkillPublicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillPublicationApiTest.java
@@ -1,0 +1,216 @@
+package com.epam.aidial.core.server;
+
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vertx.core.http.HttpMethod;
+import lombok.SneakyThrows;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers publishing a whole skill (folder-as-resource) through the review -&gt; public flow: the copy at
+ * each hop must be independently readable and byte-identical, and reject/withdraw must clean up the review
+ * copy the same way other resource types do.
+ */
+class SkillPublicationApiTest extends ResourceBaseTest {
+
+    private static final String MANIFEST = """
+            ---
+            name: Publishable Skill
+            description: A skill used to test the publication lifecycle
+            version: 1.0.0
+            ---
+            # Publishable Skill
+            """;
+
+    @Test
+    void testPublishAndApproveSkillCopiesWholeTreeAtEachHop() {
+        Map<String, byte[]> files = new LinkedHashMap<>();
+        files.put("SKILL.md", MANIFEST.getBytes(StandardCharsets.UTF_8));
+        files.put("scripts/run.sh", "echo hi".getBytes(StandardCharsets.UTF_8));
+
+        Response uploaded = uploadSkill("/pub-skill", files);
+        verify(uploaded, 200);
+        String sourceEtag = uploaded.headers().get("etag");
+
+        Response create = operationRequest("/v1/ops/publication/create", """
+                {
+                  "name": "Publish skill",
+                  "targetFolder": "public/folder/",
+                  "resources": [
+                    {"action":"ADD","sourceUrl":"skills/%s/pub-skill","targetUrl":"skills/public/folder/pub-skill"}
+                  ],
+                  "rules": [{"source":"roles","function":"TRUE"}]
+                }
+                """.formatted(bucket));
+        verify(create, 200);
+        String reviewBucketSegment = reviewBucketSegment(create);
+
+        // the review copy is a fresh, independent tree: readable and byte-identical to the source
+        BinaryResponse review = downloadSkill(reviewBucketSegment, "/pub-skill");
+        assertEquals(200, review.status());
+        assertEquals(files.keySet(), unzip(review.body()).keySet());
+        assertEquals(sourceEtag, review.headers().get("etag"));
+
+        Response approve = operationRequest("/v1/ops/publication/approve", """
+                {"url":"publications/%s/0123"}
+                """.formatted(bucket), "authorization", "admin");
+        verify(approve, 200);
+
+        // approved: readable at the public location, byte-identical to the source...
+        BinaryResponse published = downloadSkill("public/folder", "/pub-skill");
+        assertEquals(200, published.status());
+        Map<String, byte[]> publishedFiles = unzip(published.body());
+        assertEquals(files.keySet(), publishedFiles.keySet());
+        for (Map.Entry<String, byte[]> entry : files.entrySet()) {
+            assertEquals(new String(entry.getValue(), StandardCharsets.UTF_8),
+                    new String(publishedFiles.get(entry.getKey()), StandardCharsets.UTF_8));
+        }
+        assertEquals(sourceEtag, published.headers().get("etag"));
+
+        // ...the review copy is cleaned up...
+        assertEquals(404, downloadSkill(reviewBucketSegment, "/pub-skill").status());
+
+        // ...and the original source skill is left untouched
+        BinaryResponse source = downloadSkill(bucket, "/pub-skill");
+        assertEquals(200, source.status());
+        assertEquals(sourceEtag, source.headers().get("etag"));
+    }
+
+    @Test
+    void testRejectSkillPublicationCleansUpReviewCopy() {
+        Map<String, byte[]> files = Map.of("SKILL.md", MANIFEST.getBytes(StandardCharsets.UTF_8));
+        verify(uploadSkill("/reject-skill", files), 200);
+
+        Response create = operationRequest("/v1/ops/publication/create", """
+                {
+                  "name": "Reject skill",
+                  "targetFolder": "public/folder/",
+                  "resources": [
+                    {"action":"ADD","sourceUrl":"skills/%s/reject-skill","targetUrl":"skills/public/folder/reject-skill"}
+                  ],
+                  "rules": [{"source":"roles","function":"TRUE"}]
+                }
+                """.formatted(bucket));
+        verify(create, 200);
+        String reviewBucketSegment = reviewBucketSegment(create);
+
+        assertEquals(200, downloadSkill(reviewBucketSegment, "/reject-skill").status());
+
+        Response reject = operationRequest("/v1/ops/publication/reject", """
+                {"url":"publications/%s/0123","comment":"no"}
+                """.formatted(bucket), "authorization", "admin");
+        verify(reject, 200);
+
+        // rejection behaves like other resource types: the review copy is gone, nothing landed in public,
+        // and the original source is untouched
+        assertEquals(404, downloadSkill(reviewBucketSegment, "/reject-skill").status());
+        assertEquals(404, downloadSkill("public/folder", "/reject-skill").status());
+        assertEquals(200, downloadSkill(bucket, "/reject-skill").status());
+    }
+
+    @Test
+    void testWithdrawPendingSkillPublicationCleansUpReviewCopy() {
+        Map<String, byte[]> files = Map.of("SKILL.md", MANIFEST.getBytes(StandardCharsets.UTF_8));
+        verify(uploadSkill("/withdraw-skill", files), 200);
+
+        Response create = operationRequest("/v1/ops/publication/create", """
+                {
+                  "name": "Withdraw skill",
+                  "targetFolder": "public/folder/",
+                  "resources": [
+                    {"action":"ADD","sourceUrl":"skills/%s/withdraw-skill","targetUrl":"skills/public/folder/withdraw-skill"}
+                  ],
+                  "rules": [{"source":"roles","function":"TRUE"}]
+                }
+                """.formatted(bucket));
+        verify(create, 200);
+        String reviewBucketSegment = reviewBucketSegment(create);
+
+        assertEquals(200, downloadSkill(reviewBucketSegment, "/withdraw-skill").status());
+
+        Response withdraw = operationRequest("/v1/ops/publication/delete", """
+                {"url":"publications/%s/0123"}
+                """.formatted(bucket));
+        verify(withdraw, 200);
+
+        // withdrawing a still-pending publication behaves like other resource types: the review copy is
+        // removed, and the original source is untouched
+        assertEquals(404, downloadSkill(reviewBucketSegment, "/withdraw-skill").status());
+        assertEquals(200, downloadSkill(bucket, "/withdraw-skill").status());
+    }
+
+    @SneakyThrows
+    private static String reviewBucketSegment(Response create) {
+        JsonNode publication = ProxyUtil.MAPPER.readTree(create.body());
+        String reviewUrl = publication.get("resources").get(0).get("reviewUrl").asText();
+        // "skills/{encryptedReviewBucket}/{name}" -> the encrypted bucket segment
+        return reviewUrl.substring("skills/".length(), reviewUrl.lastIndexOf('/'));
+    }
+
+    @SneakyThrows
+    private Response uploadSkill(String skillPath, Map<String, byte[]> files) {
+        String uri = "http://127.0.0.1:" + serverPort + "/v2/skills/" + bucket + skillPath;
+        HttpUriRequest request = new HttpUriRequestBase(HttpMethod.PUT.name(), URI.create(uri));
+        request.setHeader("api-key", "proxyKey1");
+
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        builder.setMode(HttpMultipartMode.LEGACY);
+        builder.setCharset(StandardCharsets.UTF_8);
+        for (Map.Entry<String, byte[]> entry : files.entrySet()) {
+            builder.addBinaryBody(entry.getKey(), entry.getValue(), ContentType.DEFAULT_BINARY, entry.getKey());
+        }
+        request.setEntity(builder.build());
+
+        return client.execute(request, ResourceBaseTest::toResponse);
+    }
+
+    @SneakyThrows
+    private BinaryResponse downloadSkill(String bucketSegment, String skillPath) {
+        String uri = "http://127.0.0.1:" + serverPort + "/v2/skills/" + bucketSegment + skillPath;
+        HttpUriRequest request = new HttpUriRequestBase(HttpMethod.GET.name(), URI.create(uri));
+        request.setHeader("api-key", "proxyKey1");
+
+        return client.execute(request, response -> {
+            int status = response.getCode();
+            byte[] body = response.getEntity() == null ? new byte[0] : EntityUtils.toByteArray(response.getEntity());
+            Map<String, String> responseHeaders = new HashMap<>();
+            for (Header header : response.getHeaders()) {
+                responseHeaders.put(header.getName(), header.getValue());
+            }
+            return new BinaryResponse(status, body, responseHeaders);
+        });
+    }
+
+    @SneakyThrows
+    private static Map<String, byte[]> unzip(byte[] archive) {
+        Map<String, byte[]> result = new LinkedHashMap<>();
+        try (ZipInputStream zip = new ZipInputStream(new java.io.ByteArrayInputStream(archive))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                result.put(entry.getName(), zip.readAllBytes());
+                zip.closeEntry();
+            }
+        }
+        return result;
+    }
+
+    private record BinaryResponse(int status, byte[] body, Map<String, String> headers) {
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceServiceTest.java
@@ -2,8 +2,6 @@ package com.epam.aidial.core.server.service.resource;
 
 import com.epam.aidial.core.server.FileUtil;
 import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
-import com.epam.aidial.core.server.service.InvitationService;
-import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.storage.blobstore.BlobStorage;
 import com.epam.aidial.core.storage.blobstore.Storage;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
@@ -37,6 +35,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -111,14 +110,12 @@ class ComplexResourceServiceTest {
             ResourceService.Settings settings = mapper.readValue(serviceConfig, ResourceService.Settings.class);
             resourceService = new ResourceService(timerService, redis, blobStorage, lockService, settings, null);
 
-            ShareService shareService = Mockito.mock(ShareService.class);
-            InvitationService invitationService = Mockito.mock(InvitationService.class);
             ComplexResourceService.Settings complexResourceSettings = new ComplexResourceService.Settings();
             complexResourceSettings.setMaxFiles(3);
             complexResourceSettings.setMaxTotalBytes(200);
             complexResourceSettings.setMaxFileSizeBytes(100);
             complexResourceService = new ComplexResourceService(
-                    resourceService, lockService, shareService, invitationService, blobStorage, complexResourceSettings);
+                    resourceService, lockService, blobStorage, complexResourceSettings);
         } catch (Throwable e) {
             destroy();
             throw e;
@@ -340,6 +337,69 @@ class ComplexResourceServiceTest {
         // rejected mutation must not have changed the resource
         FolderResourceMarker after = complexResourceService.readMarkerForSweep(resource);
         assertEquals(before.getEtag(), after.getEtag());
+    }
+
+    @Test
+    void testCopyResourceResynthesizesFreshMarker() throws InterruptedException {
+        ResourceDescriptor source = skill("source-skill");
+        Map<String, Buffer> uploads = Map.of(
+                "SKILL.md", Buffer.buffer(MANIFEST),
+                "scripts/run.sh", Buffer.buffer("echo hi"));
+        complexResourceService.put(source, handler, uploads, EtagHeader.ANY, "author1");
+        FolderResourceMarker sourceMarker = complexResourceService.readMarkerForSweep(source);
+
+        // updatedAt has millisecond resolution; force a visible difference at the destination.
+        Thread.sleep(5);
+
+        ResourceDescriptor destination = skill("dest-skill");
+        boolean copied = complexResourceService.copyResource(source, destination, "author2", false);
+        assertTrue(copied);
+
+        FolderResourceMarker destMarker = complexResourceService.readMarkerForSweep(destination);
+        assertNotNull(destMarker);
+
+        // the marker is re-synthesized, not carried over verbatim: fresh version, fresh timestamps/author...
+        assertNotEquals(sourceMarker.getCurrentVersion(), destMarker.getCurrentVersion());
+        assertNotEquals(sourceMarker.getCreatedAt(), destMarker.getCreatedAt());
+        assertNotEquals(sourceMarker.getUpdatedAt(), destMarker.getUpdatedAt());
+        assertEquals("author2", destMarker.getAuthor());
+        // ...but the aggregate etag is recomputed (not copied) from the copied files, which happen to be
+        // byte-identical to the source, and the type-specific metadata (parsed from SKILL.md) is unchanged.
+        assertEquals(sourceMarker.getEtag(), destMarker.getEtag());
+        assertEquals(sourceMarker.getMetadata(), destMarker.getMetadata());
+
+        // the destination's version tree is a real, independent copy of the files
+        ResourceItemMetadata manifest = resourceService.getResourceMetadata(
+                versionFile(destination, destMarker.getCurrentVersion(), "SKILL.md"));
+        assertNotNull(manifest);
+        ResourceItemMetadata script = resourceService.getResourceMetadata(
+                versionFile(destination, destMarker.getCurrentVersion(), "scripts/run.sh"));
+        assertNotNull(script);
+    }
+
+    @Test
+    void testCopyResourceSkipsWhenDestinationActiveAndNotOverwriting() {
+        ResourceDescriptor source = skill("source-skip");
+        putSkill(source, EtagHeader.ANY);
+        ResourceDescriptor destination = skill("dest-skip");
+        putSkill(destination, EtagHeader.ANY);
+        FolderResourceMarker destBefore = complexResourceService.readMarkerForSweep(destination);
+
+        assertFalse(complexResourceService.copyResource(source, destination, "author2", false));
+
+        FolderResourceMarker destAfter = complexResourceService.readMarkerForSweep(destination);
+        assertEquals(destBefore.getCurrentVersion(), destAfter.getCurrentVersion());
+    }
+
+    @Test
+    void testCopyResourceThrowsWhenSourceAbsent() {
+        ResourceDescriptor source = skill("never-existed-source");
+        ResourceDescriptor destination = skill("dest-for-absent-source");
+
+        HttpException e = assertThrows(HttpException.class,
+                () -> complexResourceService.copyResource(source, destination, "author2", false));
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+        assertNull(complexResourceService.readMarkerForSweep(destination));
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceSweepServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/resource/ComplexResourceSweepServiceTest.java
@@ -3,8 +3,6 @@ package com.epam.aidial.core.server.service.resource;
 import com.epam.aidial.core.server.FileUtil;
 import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
 import com.epam.aidial.core.server.security.EncryptionService;
-import com.epam.aidial.core.server.service.InvitationService;
-import com.epam.aidial.core.server.service.ShareService;
 import com.epam.aidial.core.storage.blobstore.BlobStorage;
 import com.epam.aidial.core.storage.blobstore.Storage;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
@@ -125,10 +123,8 @@ class ComplexResourceSweepServiceTest {
             ResourceService.Settings settings = mapper.readValue(serviceConfig, ResourceService.Settings.class);
             resourceService = new ResourceService(timerService, redis, blobStorage, lockService, settings, null);
 
-            ShareService shareService = Mockito.mock(ShareService.class);
-            InvitationService invitationService = Mockito.mock(InvitationService.class);
             complexResourceService = new ComplexResourceService(
-                    resourceService, lockService, shareService, invitationService, blobStorage, new ComplexResourceService.Settings());
+                    resourceService, lockService, blobStorage, new ComplexResourceService.Settings());
             encryptionService = new EncryptionService(new JsonObject().put("secret", "secret").put("key", "key"));
         } catch (Throwable e) {
             destroy();


### PR DESCRIPTION
Registers `SKILL` as a publishable resource type so publishing a skill goes through the existing review -> public flow, copying the whole skill tree at each hop and re-synthesizing a fresh marker rather than carrying the source marker forward.

### Applicable issues

- fixes #1642

### Description of changes

- `ComplexResourceService`: new `copyResource`/`copyResourceLocked` methods that copy a whole resource's version tree across buckets and commit a freshly-synthesized marker at the destination (new `currentVersion`, recomputed aggregate etag, fresh timestamps/author) instead of carrying the source marker verbatim.
- `ComplexResourceService#delete`: simplified to just flip the marker to `state: deleting`; the bucket-level lock and invitation/share cleanup were removed since `ResourceOperationService#delete` already covers both.
- `ComplexResourceController`: whole-resource DELETE now goes through `ResourceOperationService#deleteResource` (bucket lock + invitation/share cleanup + dispatch) instead of calling `ComplexResourceService#delete` directly.
- `PublicationService`: `SKILL` added to the publishable resource types; existence checks and source→review / review→public copies route through `ComplexResourceService`; reject/withdraw clean up the review copy the same way as other resource types.
- `ResourceOperationService`: `SKILL` support added to move/copy/delete so it participates in the same cleanup paths as other resource types.
- Tests: unit coverage for marker re-synthesis and copy semantics in `ComplexResourceServiceTest`, plus a new `SkillPublicationApiTest` covering the full HTTP publish → approve, reject, and withdraw lifecycles.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.