### PR TITLE
fix: release pooled ByteBuf in SseParser #1741

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/sse/SseParser.java
+++ b/server/src/main/java/com/epam/aidial/core/server/sse/SseParser.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server.sse;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.vertx.core.buffer.Buffer;
@@ -70,6 +71,18 @@ public class SseParser {
         } catch (Throwable error) {
             log.error("Error occurred at finishing SSE stream", error);
         }
+    }
+
+    /**
+     * Releases the pooled buffer backing this parser. Must be called exactly once when the parser is no longer used.
+     */
+    public void close() {
+        chunkBuffer.release();
+    }
+
+    @VisibleForTesting
+    int chunkBufferRefCnt() {
+        return chunkBuffer.refCnt();
     }
 
     private void processLine() {

--- a/server/src/main/java/com/epam/aidial/core/server/vertx/stream/BufferingReadStream.java
+++ b/server/src/main/java/com/epam/aidial/core/server/vertx/stream/BufferingReadStream.java
@@ -36,6 +36,7 @@ public class BufferingReadStream implements ReadStream<Buffer> {
     private Throwable error;
     private boolean ended;
     private boolean reset;
+    private boolean eventStreamParserClosed;
     private final SseParser eventStreamParser;
     private final BaseEventListener eventListener;
     // promise on input stream is completed
@@ -167,6 +168,7 @@ public class BufferingReadStream implements ReadStream<Buffer> {
             handleEndInternal(ignored);
         } else {
             eventStreamParser.finish();
+            closeEventStreamParser();
         }
     }
 
@@ -178,8 +180,16 @@ public class BufferingReadStream implements ReadStream<Buffer> {
     private synchronized void handleException(Throwable exception) {
         error = exception;
         ended = true;
+        closeEventStreamParser();
         endStream.tryFail(exception);
         notifyOnException(exception);
+    }
+
+    private void closeEventStreamParser() {
+        if (eventStreamParser != null && !eventStreamParserClosed) {
+            eventStreamParserClosed = true;
+            eventStreamParser.close();
+        }
     }
 
     private synchronized void notifyOnChunk(Buffer chunk) {

--- a/server/src/test/java/com/epam/aidial/core/server/sse/SseParserTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/sse/SseParserTest.java
@@ -1,9 +1,11 @@
 package com.epam.aidial.core.server.sse;
 
+import io.netty.util.IllegalReferenceCountException;
 import io.vertx.core.buffer.Buffer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SseParserTest {
 
@@ -131,5 +133,18 @@ public class SseParserTest {
                 
                 """;
         assertEquals(response, listener.response.toString());
+    }
+
+    @Test
+    public void testClose_releasesChunkBuffer() {
+        TestSseEventListener listener = new TestSseEventListener();
+        SseParser parser = new SseParser(128, listener);
+
+        parser.parse(Buffer.buffer("data: hi\n\n"));
+        parser.finish();
+        parser.close();
+
+        assertEquals(0, parser.chunkBufferRefCnt());
+        assertThrows(IllegalReferenceCountException.class, parser::close);
     }
 }


### PR DESCRIPTION
Fixes a Netty pooled `ByteBuf` leak in `SseParser` that caused unbounded `PoolChunk` growth under sustained SSE streaming traffic (chat completions, Responses API, Anthropic messages, MCP proxy, etc.).

### Applicable issues

- fixes #1741

### Description of changes

- `SseParser`: added a `close()` method that releases the internal pooled `chunkBuffer` (previously never released after allocation via `ByteBufAllocator.DEFAULT.heapBuffer(...)`).
- `BufferingReadStream`: calls `eventStreamParser.close()` on every path that ends the stream — after `finish()` in `handleEnd`, and in `handleException` — guarded by a flag so it fires exactly once regardless of how the stream terminates.
- `SseParserTest`: added a test verifying the buffer's ref count drops to 0 after `close()`, and that a second `close()` correctly throws `IllegalReferenceCountException`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.