### PR TITLE
feat: support deployment_name alias for interfaces base_url routing

### DIFF
--- a/config/build.gradle
+++ b/config/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:${jackson_core_version}")
     implementation("com.networknt:json-schema-validator:${networknt_version}")
     implementation("org.hibernate.validator:hibernate-validator:${hibernate_validator_version}")
+    compileOnly("com.google.code.findbugs:jsr305:3.0.2")
 
     // Test dependencies
     testImplementation platform("org.junit:junit-bom:${junit_version}")

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -115,6 +115,15 @@ public abstract class Deployment extends RoleBasedEntity {
     }
 
     /**
+     * Deployment id this interface should route to instead of this deployment's own id, or null when not
+     * declared. Only meaningful alongside {@link #getInterfaceBaseUrl}.
+     */
+    public String getInterfaceDeploymentName(InterfaceType type) {
+        DeploymentInterface deploymentInterface = interfaces == null ? null : interfaces.get(type.getValue());
+        return deploymentInterface == null ? null : deploymentInterface.getDeploymentName();
+    }
+
+    /**
      * Legacy fully-qualified endpoint configured for the type, or null.
      */
     public String getLegacyEndpoint(InterfaceType type) {

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -118,6 +119,7 @@ public abstract class Deployment extends RoleBasedEntity {
      * Deployment id this interface should route to instead of this deployment's own id, or null when not
      * declared. Only meaningful alongside {@link #getInterfaceBaseUrl}.
      */
+    @Nullable
     public String getInterfaceDeploymentName(InterfaceType type) {
         DeploymentInterface deploymentInterface = interfaces == null ? null : interfaces.get(type.getValue());
         return deploymentInterface == null ? null : deploymentInterface.getDeploymentName();

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -20,15 +20,31 @@ public class DeploymentInterface {
     @JsonProperty("base_url")
     private String baseUrl;
 
+    /**
+     * Deployment id to route to instead of the deployment declaring this interface. Restores the legacy
+     * alias pattern (a deployment whose {@code endpoint} pointed at another deployment's route) for the
+     * base_url flow, where the request otherwise carries the alias's own id back to {@code base_url}.
+     */
+    @JsonProperty("deployment_name")
+    private String deploymentName;
+
+    public DeploymentInterface(String baseUrl) {
+        this(baseUrl, null);
+    }
+
     @JsonCreator
     public DeploymentInterface(
             @JsonProperty(value = "base_url", required = true)
             @JsonAlias({"baseUrl", "base_url"})
-            String baseUrl
+            String baseUrl,
+            @JsonProperty("deployment_name")
+            @JsonAlias({"deploymentName", "deployment_name"})
+            String deploymentName
     ) {
         if (baseUrl == null || baseUrl.isEmpty()) {
             throw new IllegalArgumentException("baseUrl cannot be null or empty");
         }
         this.baseUrl = baseUrl;
+        this.deploymentName = deploymentName;
     }
 }

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -150,9 +150,12 @@ Applications support only one interface type:
 
 > The Responses API (`openaiResponses`) and any other interface types are **not** supported for applications. If declared, they are dropped on config read with a warning.
 
-Each value is an object with a single field:
+Each value is an object with the following fields:
 
 * `base_url`: The application adapter root that the matching ingress path is appended to.
+* `deployment_name` (optional): Routes the request as if it had been sent to a different deployment name, instead of the name this application was actually called by. The `{name}` segment of the ingress path (`/openai/deployments/{name}/...`) is rewritten to `deployment_name` before it's appended to `base_url`. This restores the "alias deployment" pattern from before `interfaces` existed — a lightweight, catalog-facing application name that just forwards to another, "real" deployment — without it looping back onto itself when `base_url` points back at DIAL Core.
+
+  DIAL Core does not currently detect or reject self-referencing or cyclic `deployment_name` values, so avoid pointing one back at itself (directly or through another alias).
 
 **Example**
 
@@ -161,6 +164,12 @@ Each value is an object with a single field:
     "app-via-interfaces": {
         "interfaces": {
             "openaiChatCompletions": { "base_url": "http://localhost:7005" }
+        }
+    },
+    "app-alias": {
+        "displayName": "App (friendly alias)",
+        "interfaces": {
+            "openaiChatCompletions": { "base_url": "http://localhost:8080", "deployment_name": "app-via-interfaces" }
         }
     }
 }

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -152,10 +152,18 @@ Supported interface types for models:
 
 * `openaiChatCompletions`: the OpenAI deployments POST family (`chat/completions`, `completions`, `embeddings`). Peer of `endpoint`.
 * `openaiResponses`: the OpenAI Responses API. Peer of `responsesEndpoint`.
+* `anthropicMessages`: the Anthropic Messages API (`/anthropic/v1/messages`, `/anthropic/v1/messages/count_tokens`).
 
-Each value is an object with a single field:
+Each value is an object with the following fields:
 
 * `base_url`: The model adapter root that the matching ingress path is appended to.
+* `deployment_name` (optional): Routes the request as if it had been sent to a different deployment name, instead of the name this model was actually called by. This restores the "alias deployment" pattern from before `interfaces` existed — a lightweight, catalog-facing model name (its own `displayName`, `iconUrl`, etc.) that just forwards to another, "real" model — without it looping back onto itself.
+
+  How the rewrite is applied depends on how the interface locates the deployment in the forwarded request:
+  * `openaiChatCompletions` carries the deployment name in the ingress path (`/openai/deployments/{name}/...`), so DIAL Core rewrites that path segment to `deployment_name` before appending it to `base_url`.
+  * `openaiResponses` and `anthropicMessages` carry the deployment name in the request body's `model` field instead, so DIAL Core rewrites `model` to `deployment_name` there before forwarding.
+
+  Without `deployment_name`, an alias whose `base_url` points back at DIAL Core itself would forward the request under its own name again, causing an infinite loop. DIAL Core does not currently detect or reject self-referencing or cyclic `deployment_name` values, so avoid pointing one back at itself (directly or through another alias).
 
 **Example**
 
@@ -166,6 +174,13 @@ Each value is an object with a single field:
         "interfaces": {
             "openaiChatCompletions": { "base_url": "http://localhost:7005" },
             "openaiResponses": { "base_url": "http://localhost:7005" }
+        }
+    },
+    "gpt-4-alias": {
+        "type": "chat",
+        "displayName": "GPT-4 (friendly alias)",
+        "interfaces": {
+            "openaiChatCompletions": { "base_url": "http://localhost:8080", "deployment_name": "gpt-4-via-interfaces" }
         }
     }
 }

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -12850,6 +12850,8 @@ components:
       properties:
         base_url:
           type: string
+        deployment_name:
+          type: string
     Embedding:
       required:
       - embedding

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -11,6 +11,7 @@ import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.data.ErrorData;
 import com.epam.aidial.core.server.function.CollectResponseAttachmentsFn;
+import com.epam.aidial.core.server.function.request.RequestObject;
 import com.epam.aidial.core.server.log.AnalyticsLogContext;
 import com.epam.aidial.core.server.token.TokenUsage;
 import com.epam.aidial.core.server.token.TokenUsageParser;
@@ -234,13 +235,54 @@ public class BaseDeploymentPostController {
         HttpServerRequest request = context.getRequest();
         Deployment deployment = context.getDeployment();
         String baseUrl = deployment.getInterfaceBaseUrl(type);
-        String uri = baseUrl != null
-                // New flow: base_url + exact ingress path. request.uri() already includes path + query.
-                ? baseUrl + request.uri()
-                // Legacy flow: verbatim endpoint + original query — byte-identical to today.
-                : deployment.getLegacyEndpoint(type)
-                        + (request.query() == null ? "" : "?" + request.query());
+        String uri;
+        if (baseUrl != null) {
+            // New flow: base_url + exact ingress path. request.uri() already includes path + query.
+            String path = request.uri();
+            String targetDeploymentName = deployment.getInterfaceDeploymentName(type);
+            if (targetDeploymentName != null) {
+                path = rewriteDeploymentPathSegment(path, deployment.getName(), targetDeploymentName);
+            }
+            uri = baseUrl + path;
+        } else {
+            // Legacy flow: verbatim endpoint + original query — byte-identical to today.
+            uri = deployment.getLegacyEndpoint(type)
+                    + (request.query() == null ? "" : "?" + request.query());
+        }
         return createProxyRequest(uri);
+    }
+
+    /**
+     * Rewrites the {@code /deployments/{name}/} ingress path segment to a different deployment id, so an
+     * alias deployment whose base_url loops back to Core lands on the aliased deployment instead of itself.
+     * No-op for interfaces whose ingress path carries no deployment segment (openaiResponses,
+     * anthropicMessages resolve the deployment from the request body instead — see
+     * {@link #applyInterfaceDeploymentNameOverride}).
+     */
+    private static String rewriteDeploymentPathSegment(String path, String currentName, String targetName) {
+        String marker = "/deployments/" + currentName + "/";
+        int index = path.indexOf(marker);
+        if (index < 0) {
+            return path;
+        }
+        return path.substring(0, index) + "/deployments/" + targetName + "/" + path.substring(index + marker.length());
+    }
+
+    /**
+     * Rewrites the request's {@code model} field to the interface's configured alias target, when declared.
+     * For interfaces that resolve the deployment from the request body (openaiResponses, anthropicMessages)
+     * rather than the ingress path, this is what makes an alias deployment's base_url loop back onto the
+     * aliased deployment instead of itself.
+     */
+    protected void applyInterfaceDeploymentNameOverride(RequestObject request, InterfaceType type) {
+        Deployment deployment = context.getDeployment();
+        if (deployment.getInterfaceBaseUrl(type) == null) {
+            return;
+        }
+        String targetDeploymentName = deployment.getInterfaceDeploymentName(type);
+        if (targetDeploymentName != null) {
+            request.setModel(targetDeploymentName);
+        }
     }
 
     protected Future<HttpClientResponse> sendProxyRequest(

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -190,6 +190,7 @@ public class ResponsesController extends BaseDeploymentPostController {
         context.setStoreResponse(request.isStore());
         context.setBackgroundJob(request.isBackground());
         ProxyUtil.processChain(request, enhancementFunctions);
+        applyInterfaceDeploymentNameOverride(request, InterfaceType.OPENAI_RESPONSES);
         // Enhancement functions update the api key, and it should be saved after that
         if (request.isBackground()) {
             Duration jobTtl = Duration.ofMillis(proxy.getBackgroundJobService().getJobTtlMs());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -151,6 +151,7 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
         ApiKeyData.initFromContext(proxyApiKeyData, context);
 
         ProxyUtil.processChain(request, enhancementFunctions);
+        applyInterfaceDeploymentNameOverride(request, InterfaceType.ANTHROPIC_MESSAGES);
         // Enhancement functions update the api key, and it should be saved after that
         proxy.getApiKeyStore().assignPerRequestApiKey(proxyApiKeyData);
 

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
@@ -167,6 +167,34 @@ public class DeploymentPostApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testDeploymentNameAliasRewritesIngressPathSegment() {
+        MutableObject<String> capturedPath = new MutableObject<>();
+        try (TestWebServer server = new TestWebServer(4848)) {
+            // chat-alias declares deployment_name=gpt-3-turbo: without it, base_url + the exact ingress
+            // path would forward "/openai/deployments/chat-alias/chat/completions" verbatim, which is
+            // the infinite-loop shape reported when an alias's base_url pointed back at Core itself.
+            server.map(HttpMethod.POST, "/openai/deployments/gpt-3-turbo/chat/completions", request -> {
+                capturedPath.setValue(request.getPath());
+                return new MockResponse().setResponseCode(200).setBody("""
+                        {"id":"id1","object":"chat.completion","created":1,"model":"gpt-35-turbo",
+                         "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"ok"}}],
+                         "usage":{"completion_tokens":1,"prompt_tokens":1,"total_tokens":2}}
+                        """);
+            });
+
+            Response response = send(HttpMethod.POST,
+                    "/openai/deployments/chat-alias/chat/completions", null,
+                    """
+                    {"model":"chat-alias","messages":[{"role":"user","content":"hi"}]}
+                    """,
+                    "content-type", Proxy.HEADER_CONTENT_TYPE_APPLICATION_JSON);
+
+            verify(response, 200);
+            assertEquals("/openai/deployments/gpt-3-turbo/chat/completions", capturedPath.getValue());
+        }
+    }
+
+    @Test
     public void testAutoShareAnnotationCitationAttachment() {
         // Register a public application that internally calls gpt-3-turbo.
         // Auto-sharing of annotation citation attachments only activates when the

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -240,6 +240,25 @@ public class MessagesApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testDeploymentNameAliasRewritesBodyModel() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            // claude-alias declares deployment_name=claude-ns: the ingress path carries no deployment
+            // segment for this interface, so the alias must rewrite the outgoing body's "model" instead
+            // (mirrors the legacy endpoint-loopback alias, without landing back on itself).
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-alias", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            assertTrue(captured.get().getBody().readUtf8().contains("\"model\":\"claude-ns\""));
+        }
+    }
+
+    @Test
     public void testUnsupportedInterfaceReturns503() throws IOException {
         try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
             Response response = post(client, MESSAGES_PATH, requestBody("claude-no-iface", false), "api-key", "proxyKey1");

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -546,6 +546,48 @@ public class DeploymentPostControllerTest {
     }
 
     @Test
+    public void testHandleRequestBody_InterfacesBaseUrl_DeploymentNameAlias() {
+        when(context.getRequest()).thenReturn(request);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        when(upstreamRoute.next()).thenReturn(new Upstream());
+        when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
+        HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
+        when(context.getRequest()).thenReturn(request);
+        when(request.uri()).thenReturn("/openai/deployments/als-1/chat/completions");
+        HttpClient httpClient = mock(HttpClient.class, RETURNS_DEEP_STUBS);
+        when(proxy.getClient()).thenReturn(httpClient);
+        when(proxy.getApiKeyStore()).thenReturn(mock(ApiKeyStore.class));
+        when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
+        ApiKeyData proxyApiKeyData = new ApiKeyData();
+        proxyApiKeyData.setInterceptorIndex(0);
+        when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
+
+        Model model = new Model();
+        model.setName("als-1");
+        model.setInterfaces(Map.of(
+                InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(),
+                new DeploymentInterface("http://host", "openai-gpt-5.4-mini")));
+        when(context.getDeployment()).thenReturn(model);
+        String body = """
+                {
+                    "model": "als-1",
+                    "messages": [],
+                    "stream": false
+                }
+                """;
+        Buffer requestBody = Buffer.buffer(body);
+
+        controller.handleRequestBody(requestBody);
+
+        ArgumentCaptor<RequestOptions> captor = ArgumentCaptor.forClass(RequestOptions.class);
+        verify(httpClient).request(captor.capture());
+        // deployment_name rewrites the ingress path's deployment segment, so the alias's own base_url
+        // (which may loop back to Core) lands on the aliased deployment instead of itself
+        assertEquals("/openai/deployments/openai-gpt-5.4-mini/chat/completions", captor.getValue().getURI());
+        assertEquals("host", captor.getValue().getHost());
+    }
+
+    @Test
     public void testHandleProxyRequest_PropagateAuthHeader() {
         when(context.getRequest()).thenReturn(request);
         Application application = new Application();

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
@@ -3,6 +3,8 @@ package com.epam.aidial.core.server.controller;
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.DeploymentInterface;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.config.Upstream;
@@ -370,6 +372,120 @@ public class ResponsesControllerTest {
                 eq(PER_REQUEST_KEY),
                 argThat(arg ->
                         ProxyUtil.convertToString(updatedApiKeyData).equals(arg.apply("{}"))));
+    }
+
+    @Test
+    public void testModelResponse_DeploymentNameAliasRewritesBodyModel(Vertx vertx, VertxTestContext textContext) throws Throwable {
+        Model deployment = new Model();
+        deployment.setName("als-1");
+        deployment.setInterfaces(Map.of(
+                InterfaceType.OPENAI_RESPONSES.getValue(),
+                new DeploymentInterface("http://adapter", "openai-gpt-5.4-mini")));
+        HttpClient httpClient = mock(HttpClient.class, RETURNS_DEEP_STUBS);
+        HttpClientRequest proxyRequest = mock(HttpClientRequest.class, RETURNS_DEEP_STUBS);
+        ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint");
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setSourceDeployment("test-deployment");
+        apiKeyData.setPerRequestKey(PER_REQUEST_KEY);
+        apiKeyData.setExecutionPath(List.of());
+
+        Buffer requestBody = Buffer.buffer(normalizeJson("""
+                {
+                    "model": "als-1",
+                    "input": []
+                }
+                """));
+        Buffer responseBody = Buffer.buffer(normalizeJson("""
+                {
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 1,
+                        "input_tokens_details": {
+                          "cached_tokens": 0
+                        },
+                        "output_tokens": 1,
+                        "output_tokens_details": {
+                          "reasoning_tokens": 0
+                        },
+                        "total_tokens": 2
+                    },
+                    "id": "dial_test_fixed-uuid-1234"
+                }
+                """));
+
+        when(request.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn(HEADER_CONTENT_TYPE_APPLICATION_JSON);
+        when(request.body()).thenReturn(Future.succeededFuture(requestBody));
+        when(request.headers()).thenReturn(new HeadersMultiMap());
+        when(request.uri()).thenReturn("/openai/v1/responses?arg=value");
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(upstreamRoute.next()).thenReturn(upstream);
+        when(upstreamRoute.get()).thenReturn(upstream);
+        when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
+        when(context.getRequest()).thenReturn(request);
+        when(context.getResponse()).thenReturn(response);
+        when(context.getConfig()).thenReturn(new Config());
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getUserId()).thenReturn("test-user");
+        when(proxyRequest.headers()).thenReturn(new HeadersMultiMap());
+        when(proxyRequest.send(any(Buffer.class))).thenReturn(Future.succeededFuture(proxyResponse));
+        when(proxyResponse.statusCode()).thenReturn(200);
+        when(proxyResponse.body()).thenReturn(Future.succeededFuture(responseBody));
+        when(response.getStatusCode()).thenReturn(200);
+        when(response.end(any(Buffer.class))).thenReturn(Future.succeededFuture());
+        when(proxy.getDeploymentService().findDeployment(context, "als-1"))
+                .thenReturn(deployment);
+        when(proxy.getRateLimiter().limit(context, deployment))
+                .thenReturn(Future.succeededFuture(RateLimitResult.SUCCESS));
+        when(proxy.getRateLimiter().increase(any(), any(), any(), any(), any()))
+                .thenReturn(Future.succeededFuture());
+        when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
+        when(proxy.getClient()).thenReturn(httpClient);
+        when(proxy.getClientOptions()).thenReturn(new HttpClientOptions());
+        when(httpClient.request(any())).thenReturn(Future.succeededFuture(proxyRequest));
+        when(proxy.getApiKeyStore()).thenReturn(apiKeyStore);
+        when(proxy.getGenerator().get()).thenReturn("fixed-uuid-1234");
+        when(proxy.getTokenStatsTracker().startSpan(context))
+                .thenReturn(Future.succeededFuture());
+
+        doAnswer(invocation -> {
+            ApiKeyData proxyApiKeyData = invocation.getArgument(0);
+            proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
+            return null;
+        }).when(apiKeyStore).assignPerRequestApiKey(any());
+        doAnswer(invocation -> {
+            textContext.completeNow();
+            return Future.succeededFuture(Boolean.TRUE);
+        }).when(apiKeyStore).invalidatePerRequestApiKey(any());
+        doCallRealMethod().when(context).setDeployment(any());
+        doCallRealMethod().when(context).getDeployment();
+        doCallRealMethod().when(context).setRequestBody(any());
+        doCallRealMethod().when(context).getRequestBody();
+        doCallRealMethod().when(context).setResponseBody(any());
+        doCallRealMethod().when(context).getResponseBody();
+        doCallRealMethod().when(context).setTokenUsage(any());
+        doCallRealMethod().when(context).getTokenUsage();
+        doCallRealMethod().when(context).setProxyApiKeyData(any());
+        doCallRealMethod().when(context).getProxyApiKeyData();
+        doCallRealMethod().when(context).setProxyResponse(any());
+        doCallRealMethod().when(context).getProxyResponse();
+
+        controller.handle();
+
+        await(textContext);
+
+        // base_url has no /deployments/{id}/ segment to rewrite for this interface — the alias instead
+        // rewrites the outgoing body's "model" so the loopback call resolves to the aliased deployment
+        verify(httpClient).request(argThat(req ->
+                "adapter".equals(req.getHost())
+                        && "/openai/v1/responses?arg=value".equals(req.getURI().toString())));
+        ArgumentCaptor<Buffer> bodyCaptor = ArgumentCaptor.forClass(Buffer.class);
+        verify(proxyRequest).send(bodyCaptor.capture());
+        JsonNode sentBody = ProxyUtil.MAPPER.readTree(bodyCaptor.getValue().getBytes());
+        assertEquals("openai-gpt-5.4-mini", sentBody.get("model").asText());
     }
 
     @Test

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -225,6 +225,18 @@
     "claude-no-iface": {
       "type": "chat",
       "endpoint": "http://localhost:4848/v1/chat/completions"
+    },
+    "claude-alias": {
+      "type": "chat",
+      "interfaces": {
+        "anthropicMessages": {"base_url": "http://localhost:4848", "deployment_name": "claude-ns"}
+      }
+    },
+    "chat-alias": {
+      "type": "chat",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "http://localhost:4848", "deployment_name": "gpt-3-turbo"}
+      }
     }
   },
   "toolsets": {
@@ -313,7 +325,9 @@
         "claude-limited": {"minute": "10", "day": "10"},
         "claude-upstream": {"minute": "100000", "day": "10000000"},
         "claude-override": {"minute": "100000", "day": "10000000"},
-        "claude-no-iface": {"minute": "100000", "day": "10000000"}
+        "claude-no-iface": {"minute": "100000", "day": "10000000"},
+        "claude-alias": {"minute": "100000", "day": "10000000"},
+        "chat-alias": {"minute": "100000", "day": "10000000"}
       }
     },
     "vstore_user": {


### PR DESCRIPTION
### Applicable issues

- 

### Description of changes

Before the `interfaces`/`base_url` routing model, admins could publish a lightweight "alias" deployment (its own displayName/description/iconUrl) whose `endpoint` pointed at a different, "real" deployment's fully-qualified route. Since `endpoint` is forwarded verbatim, this worked as a two-hop redirect.

The `interfaces` flow forwards to `base_url` + the exact ingress path instead, so an alias declared this way forwarded the request under its own deployment id again. When `base_url` pointed back at DIAL Core itself, this caused an infinite loop (Core kept re-resolving the alias and re-forwarding to itself).

Adds an optional `deployment_name` field to `interfaces.<type>` that routes the request as if it had been sent to a different deployment name:
- `openaiChatCompletions` carries the deployment id in the ingress path (`/openai/deployments/{name}/...`), so that path segment is rewritten to `deployment_name` before being appended to `base_url`.
- `openaiResponses` and `anthropicMessages` carry the deployment id in the request body's `model` field instead, so `model` is rewritten to `deployment_name` there before forwarding.

Supported for models and applications (chat completions only for applications, matching their existing interface support). Self-referencing/cyclic `deployment_name` values are not currently detected — documented as a known limitation, not addressed by this PR.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.