### PR TITLE
fix: stabilize flaky ResponsesControllerTest deep-stub race

### DIFF
--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
@@ -17,6 +17,7 @@ import com.epam.aidial.core.server.data.ResponseMapping;
 import com.epam.aidial.core.server.limiter.RateLimitResult;
 import com.epam.aidial.core.server.security.ApiKeyStore;
 import com.epam.aidial.core.server.service.ConsentService;
+import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.service.PermissionDeniedException;
 import com.epam.aidial.core.server.service.ResponseMappingService;
 import com.epam.aidial.core.server.token.PromptTokensDetails;
@@ -972,6 +973,9 @@ public class ResponsesControllerTest {
         when(context.getApiKeyData()).thenReturn(apiKeyData);
         when(context.getInterceptors()).thenReturn(apiKeyData.getInterceptors());
         when(context.getConfig()).thenReturn(config);
+        // Resolved up front: the controller is still running on a Vert.x thread when await() returns,
+        // and resolving a deep stub on `proxy` from two threads at once corrupts its stubbing container.
+        DeploymentService deploymentService = proxy.getDeploymentService();
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
         when(proxy.getTokenStatsTracker().startSpan(context)).thenReturn(Future.succeededFuture());
         when(proxy.getClient()).thenReturn(httpClient);
@@ -989,7 +993,7 @@ public class ResponsesControllerTest {
 
         await(testContext);
 
-        verify(proxy.getDeploymentService(), never()).findDeployment(any(), any());
+        verify(deploymentService, never()).findDeployment(any(), any());
         verify(context).setProxyApiKeyData(argThat(data -> data.getInterceptorIndex() == 1));
         verify(httpClient).request(argThat(opts ->
                 "interceptor2".equals(opts.getHost())
@@ -1019,7 +1023,8 @@ public class ResponsesControllerTest {
         when(request.method()).thenReturn(HttpMethod.POST);
         when(context.getRequest()).thenReturn(request);
         when(context.getApiKeyData()).thenReturn(apiKeyData);
-        when(proxy.getDeploymentService().findDeployment(context, "actual-model")).thenReturn(deployment);
+        DeploymentService deploymentService = proxy.getDeploymentService();
+        when(deploymentService.findDeployment(context, "actual-model")).thenReturn(deployment);
         when(proxy.getRateLimiter().limit(context, deployment)).thenReturn(Future.succeededFuture(RateLimitResult.SUCCESS));
         when(proxy.getTokenStatsTracker().startSpan(context)).thenReturn(Future.succeededFuture());
         when(proxy.getUpstreamRouteProvider().get(eq(deployment), isNull(), any(), isNull())).thenReturn(upstreamRoute);
@@ -1043,8 +1048,8 @@ public class ResponsesControllerTest {
 
         await(textContext);
 
-        verify(proxy.getDeploymentService()).findDeployment(context, "actual-model");
-        verify(proxy.getDeploymentService(), never()).findDeployment(any(), eq("ignored"));
+        verify(deploymentService).findDeployment(context, "actual-model");
+        verify(deploymentService, never()).findDeployment(any(), eq("ignored"));
         verify(httpClient).request(argThat(opts ->
                 "actual-model".equals(opts.getHost())
                 && "/responses".equals(opts.getURI().toString())));


### PR DESCRIPTION
`ResponsesControllerTest.testInterceptorReentryDispatchesToNextInterceptor` fails intermittently in CI with `WrongTypeOfReturnValue: TokenStatsTracker cannot be returned by getDeploymentService()`. It is a test-only race, unrelated to any production change — it most recently reddened a docs-only PR.

### Applicable issues

- N/A (CI flake)

### Description of changes

- The two interceptor-reentry tests complete the `VertxTestContext` from inside the `httpClient.request(...)` answer, so `await()` returns while the controller is still running its error path on a Vert.x thread.
- The test thread then evaluated `verify(proxy.getDeploymentService(), ...)`, resolving a `RETURNS_DEEP_STUBS` child mock on the `proxy` mock concurrently with the controller resolving `proxy.getTokenStatsTracker()`. Deep-stub resolution mutates the mock's invocation container, so the concurrent lookup returned the wrong child mock.
- Fix: resolve `proxy.getDeploymentService()` once during setup, before `controller.handle()`, and verify against that instance. The deep stub is then created while only the test thread is running, and the Vert.x thread only reads existing stubbings.
- Test-only change; no production code touched.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.