### PR TITLE
fix: resolve correct upstream endpoint for interfaces-based deployments called through an interceptor

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -9,11 +9,16 @@ import lombok.EqualsAndHashCode;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public abstract class Deployment extends RoleBasedEntity {
+
+    private static final Pattern DEPLOYMENT_SEGMENT = Pattern.compile("/deployments/[^/]+/");
+
     private String endpoint;
     private String responsesEndpoint;
     /**
@@ -170,24 +175,26 @@ public abstract class Deployment extends RoleBasedEntity {
             return getLegacyEndpoint(type) + (query == null ? "" : "?" + query);
         }
         String targetDeploymentName = getInterfaceDeploymentName(type);
-        return baseUrl + (targetDeploymentName == null
-                ? ingressUri
-                : rewriteDeploymentPathSegment(ingressUri, getName(), targetDeploymentName));
+        return baseUrl + rewriteDeploymentPathSegment(
+                ingressUri,
+                targetDeploymentName == null ? getName() : targetDeploymentName
+        );
     }
 
     /**
-     * Rewrites the {@code /deployments/{name}/} ingress path segment to a different deployment id, so an
-     * alias deployment whose base_url loops back to Core lands on the aliased deployment instead of itself.
-     * No-op for interfaces whose ingress path carries no deployment segment (openaiResponses and
-     * anthropicMessages resolve the deployment from the request body instead, so the caller overrides the
-     * body's model field there rather than the path).
+     * Rewrites the {@code /deployments/{id}/} ingress path segment to the target deployment id, whatever id
+     * it currently carries. Two cases need this: an alias deployment whose base_url loops back to Core must
+     * land on the aliased deployment instead of itself, and a request forwarded through an interceptor
+     * carries the literal pseudo id {@code interceptor} in the path (see
+     * {@code DeploymentPostController#handle}) rather than this deployment's own name. No-op for interfaces
+     * whose ingress path carries no deployment segment (openaiResponses and anthropicMessages resolve the
+     * deployment from the request body instead, so the caller overrides the body's model field there rather
+     * than the path).
      */
-    private static String rewriteDeploymentPathSegment(String path, String currentName, String targetName) {
-        String marker = "/deployments/" + currentName + "/";
-        int index = path.indexOf(marker);
-        if (index < 0) {
-            return path;
-        }
-        return path.substring(0, index) + "/deployments/" + targetName + "/" + path.substring(index + marker.length());
+    private static String rewriteDeploymentPathSegment(String path, String targetName) {
+        Matcher matcher = DEPLOYMENT_SEGMENT.matcher(path);
+        return matcher.find()
+                ? matcher.replaceFirst(Matcher.quoteReplacement("/deployments/" + targetName + "/"))
+                : path;
     }
 }

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -103,6 +103,20 @@ public class DeploymentTest {
     }
 
     @Test
+    void resolveRequestUriRewritesInterceptorPseudoDeploymentSegment() {
+        // When a deployment has interceptors configured, the interceptor calls back into Core using the
+        // literal pseudo deployment id "interceptor" in the path instead of the real deployment name.
+        Model model = new Model();
+        model.setName("essay-assistant-gpt");
+        model.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface("http://localhost:5025")));
+
+        assertEquals("http://localhost:5025/openai/deployments/essay-assistant-gpt/chat/completions?api-version=2024-08-06",
+                model.resolveRequestUri(OPENAI_CHAT_COMPLETIONS,
+                        "/openai/deployments/interceptor/chat/completions?api-version=2024-08-06", "api-version=2024-08-06"));
+    }
+
+    @Test
     void resolveRequestUriLeavesPathAloneWhenNoDeploymentSegment() {
         Model model = new Model();
         model.setName("als-2");


### PR DESCRIPTION
### Applicable issues

- feat #1618

### Description of changes

Deployments configured with the new `interfaces.openaiChatCompletions.base_url` (instead of the legacy `endpoint` field) returned 404 from the upstream whenever the deployment also had `interceptors` configured. After the interceptor chain finished, Core built the final upstream URL by appending the *inbound request's raw URI* to `base_url`. That inbound request is the interceptor's callback into Core, whose path carries the literal pseudo deployment id `interceptor` (`/openai/deployments/interceptor/chat/completions`) rather than the real deployment name, so Core dialed `base_url + /openai/deployments/interceptor/chat/completions` instead of the deployment's actual path. Legacy `endpoint`-configured deployments were unaffected because that flow ignores the inbound path entirely and uses the configured absolute URL as-is.

`Deployment.rewriteDeploymentPathSegment` only rewrote the `/deployments/{id}/` path segment when an explicit `deployment_name` alias was configured, and even then it matched against the deployment's own name — which never appears in the interceptor callback path. The fix makes the rewrite unconditional: it now always normalizes whatever id sits between `/deployments/` and the next `/` to the correct target deployment (alias if declared, otherwise the deployment's own name), using a regex match-and-replace instead of manual index arithmetic. This mirrors the equivalent rewrite already used for the Core-to-interceptor hop in `ChatCompletionInterceptorController`.

### Checklist

- [x] Title of the pull request                                                                                                                                                                                
  follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (DeploymentTest 16/16 incl. new regression test, ChatCompletionInterceptorControllerTest, ResponsesInterceptorControllerTest, ResponsesControllerTest, DeploymentPostControllerTest, checkstyle clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.