### PR TITLE
chore: add debug diagnostics for client-channel pub/sub delivery

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ClientChannelController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ClientChannelController.java
@@ -385,6 +385,7 @@ public class ClientChannelController {
     }
 
     private void handleRpcError(Throwable error) {
+        log.warn("RPC error on client-channel interact", error);
         ErrorMessage errorMessage = new ErrorMessage(-32000, error.getMessage(), null);
         RpcResponse message = new RpcResponse(errorMessage);
         HttpServerResponse httpServerResponse = context.getResponse();

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ClientChannelController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ClientChannelController.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 
 @Slf4j
 public class ClientChannelController {
@@ -209,7 +210,7 @@ public class ClientChannelController {
         setupEventStreamResponse(response);
         String channelId = context.getRequest().getHeader(Proxy.HEADER_CLIENT_CHANNEL_ID);
         if (channelId == null) {
-            handleRpcError(new HttpException(HttpStatus.BAD_REQUEST, "Channel ID is missed"));
+            handleRpcError(new HttpException(HttpStatus.BAD_REQUEST, "Channel ID is missed"), null);
             return Future.succeededFuture();
         }
         context.getRequest()
@@ -227,7 +228,7 @@ public class ClientChannelController {
                         }
                     });
                 })
-                .onFailure(this::handleRpcError);
+                .onFailure(error -> handleRpcError(error, channelId));
 
         return Future.succeededFuture();
     }
@@ -384,8 +385,8 @@ public class ClientChannelController {
         }
     }
 
-    private void handleRpcError(Throwable error) {
-        log.warn("RPC error on client-channel interact", error);
+    private void handleRpcError(Throwable error, @Nullable String channelId) {
+        log.warn("RPC error on client-channel {} interact", channelId, error);
         ErrorMessage errorMessage = new ErrorMessage(-32000, error.getMessage(), null);
         RpcResponse message = new RpcResponse(errorMessage);
         HttpServerResponse httpServerResponse = context.getResponse();

--- a/server/src/main/java/com/epam/aidial/core/server/service/clientchannel/RpcRequestTopic.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/clientchannel/RpcRequestTopic.java
@@ -25,9 +25,9 @@ public class RpcRequestTopic {
     }
 
     public void publish(PubSubRequest request) {
-        log.debug("Publish RPC request {} to Redis topic RPC Requests. Channel ID {}",
-                request.getRequest().getId().asText(), request.getChannelId());
-        topic.publish(request);
+        long receivers = topic.publish(request);
+        log.debug("Publish RPC request {} to Redis topic RPC Requests. Channel ID {}. Receivers: {}",
+                request.getRequest().getId().asText(), request.getChannelId(), receivers);
     }
 
     public RpcRequestSubscription subscribe(String channelId, Consumer<RpcRequest> subscriber) {
@@ -40,11 +40,15 @@ public class RpcRequestTopic {
             subs.add(subscription);
             return subs;
         });
+        log.debug("Registered local subscription for channel {}. Local subscriber count: {}",
+                channelId, subscriptions.getOrDefault(channelId, Set.of()).size());
         return subscription;
     }
 
     private void handle(PubSubRequest pubSubRequest) {
         Set<RpcRequestSubscription> subs = subscriptions.getOrDefault(pubSubRequest.getChannelId(), Set.of());
+        log.debug("Handling published RPC request for channel {}. Local subscriber count: {}",
+                pubSubRequest.getChannelId(), subs.size());
         for (RpcRequestSubscription subscription : subs) {
             log.debug("Received RPC request ID {} to Redis topic RPC Requests. Channel ID {}",
                     pubSubRequest.getRequest().getId(), pubSubRequest.getChannelId());

--- a/server/src/main/java/com/epam/aidial/core/server/service/clientchannel/RpcResponseTopic.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/clientchannel/RpcResponseTopic.java
@@ -25,9 +25,9 @@ public class RpcResponseTopic {
     }
 
     public void publish(PubSubResponse response) {
-        log.debug("Publish RPC response {} to Redis topic RPC Responses. Channel ID {}",
-                response.getResponse().getId().asText(), response.getChannelId());
-        topic.publish(response);
+        long receivers = topic.publish(response);
+        log.debug("Publish RPC response {} to Redis topic RPC Responses. Channel ID {}. Receivers: {}",
+                response.getResponse().getId().asText(), response.getChannelId(), receivers);
     }
 
     public RpcResponseSubscription subscribe(String channelId, String requestId, Consumer<RpcResponse> subscriber) {
@@ -41,6 +41,8 @@ public class RpcResponseTopic {
             subs.add(subscription);
             return subs;
         });
+        log.debug("Registered local subscription for channel {} request {}. Local subscriber count: {}",
+                channelId, requestId, subscriptions.getOrDefault(key, Set.of()).size());
         return subscription;
     }
 
@@ -49,6 +51,8 @@ public class RpcResponseTopic {
         String requestId = pubSubResponse.getResponse().getId().asText();
         Key key = new Key(channelId, requestId);
         Set<RpcResponseSubscription> subs = subscriptions.getOrDefault(key, Set.of());
+        log.debug("Handling published RPC response for channel {} request {}. Local subscriber count: {}",
+                channelId, requestId, subs.size());
         for (RpcResponseSubscription subscription : subs) {
             log.debug("Received RPC response ID {} to Redis topic RPC Responses. Channel ID {}",
                     pubSubResponse.getResponse().getId(), pubSubResponse.getChannelId());


### PR DESCRIPTION
## Summary
- Log the Redis publish receiver count and local subscription registration/dispatch (debug level) in `RpcRequestTopic`/`RpcResponseTopic`, to help diagnose a reported issue where events sent via `/interact` aren't reaching a subscribed client's SSE stream in some environments.
- Add a `log.warn` in `ClientChannelController.handleRpcError()`, which previously converted any `/interact`-side error into a JSON-RPC error frame on the caller's own stream with zero server-side log trace.

## Test plan
- [x] `./gradlew :server:test --tests "com.epam.aidial.core.server.ClientChannelApiTest"` passes
- [x] `./gradlew :server:test` full suite passes, no regressions
- [x] `./gradlew checkstyleMain checkstyleTest` clean
- [ ] Deploy and re-run the production repro; the new debug logs (once enabled) should show whether `publish()` sees any receivers and whether the subscribing instance's local dispatch fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)