### PR TITLE
fix: honor configured MCP endpoint path instead of defaulting to /mcp #1768

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -190,8 +190,7 @@ public class ToolSetToolsController implements Controller {
         Objects.requireNonNull(upstream);
         Deployment deployment = context.getDeployment();
 
-        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-                .builder(upstream.getEndpoint())
+        HttpClientStreamableHttpTransport transport = McpClientUtils.transportBuilder(upstream.getEndpoint())
                 .clientBuilder(mcpHttpClientBuilderService.httpClientBuilder())
                 .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, endpoint, body, transportContext) ->

--- a/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
@@ -87,8 +87,7 @@ public class SecuredResourceService {
             return;
         }
 
-        HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-                .builder(endpoint)
+        HttpClientStreamableHttpTransport transport = McpClientUtils.transportBuilder(endpoint)
                 .clientBuilder(mcpHttpClientBuilderService.httpClientBuilder())
                 .jsonMapper(McpClientUtils.MCP_JSON_MAPPER)
                 .httpRequestCustomizer((builder, method, uri, body, transportContext) ->

--- a/server/src/main/java/com/epam/aidial/core/server/util/McpClientUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/McpClientUtils.java
@@ -6,12 +6,14 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import lombok.experimental.UtilityClass;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
 
 @UtilityClass
@@ -24,6 +26,25 @@ public class McpClientUtils {
     public static final McpJsonMapper MCP_JSON_MAPPER = createLenientMcpJsonMapper();
 
     private static final String ADDITIONAL_PROPERTIES_FIELD = "additionalProperties";
+
+    /**
+     * The SDK's transport builder defaults to endpoint "/mcp", and since it resolves as an absolute-path
+     * reference, it replaces (rather than appends to) the base URI's path - silently dropping any path
+     * configured on the endpoint. Splitting origin/path here and always setting endpoint(...) explicitly
+     * ensures the configured endpoint is what actually gets requested.
+     */
+    public static HttpClientStreamableHttpTransport.Builder transportBuilder(String endpoint) {
+        URI uri = URI.create(endpoint);
+        String path = uri.getRawPath();
+        if (path == null || path.isEmpty()) {
+            path = "/";
+        }
+        if (uri.getRawQuery() != null) {
+            path = path + "?" + uri.getRawQuery();
+        }
+        String origin = uri.getScheme() + "://" + uri.getRawAuthority();
+        return HttpClientStreamableHttpTransport.builder(origin).endpoint(path);
+    }
 
     private static McpJsonMapper createLenientMcpJsonMapper() {
         ObjectMapper mapper = new ObjectMapper();

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -2872,6 +2872,50 @@ public class ToolSetApiTest extends ResourceBaseTest {
         }
     }
 
+    // The SDK's transport defaults to endpoint("/mcp") and would otherwise silently replace any
+    // configured path; McpClientUtils#transportBuilder must always honor the configured path instead.
+    @Test
+    void testGetAllTools_ExplicitPathEndpointIsHonored() throws JsonProcessingException {
+        Response response = send(HttpMethod.PUT,
+                "/v1/toolsets/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my-endpoint-test", null, """
+                {
+                    "endpoint": "http://localhost:9876/call",
+                    "transport": "HTTP",
+                    "allowedTools": []
+                }
+                """);
+        verify(response, 200);
+
+        String mcpToolsListResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 2,
+                   "result": {
+                     "tools": [
+                       {"name": "tool1", "description": "Tool 1"}
+                     ]
+                   }
+                 }
+                """;
+        TestWebServer.Handler handler = mcpToolsHandler(mcpToolsListResponse);
+        // strict fallback: only "/call" is mapped, so a request wrongly sent to "/mcp" 404s
+        try (TestWebServer server = new TestWebServer(9876, request -> TestWebServer.createResponse(404, "not found"))) {
+            server.map(HttpMethod.GET, "/call", handler);
+            server.map(HttpMethod.POST, "/call", handler);
+
+            Response resp = send(HttpMethod.GET,
+                    "/v1/toolset/toolsets/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my-endpoint-test/tools");
+
+            assertEquals(200, resp.status());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            assertEquals(1, tools.size());
+            assertEquals("tool1", tools.get(0).get("name").asText());
+        }
+    }
+
     @Test
     void testGetAllTools_Pagination() throws JsonProcessingException {
         String page1Response = """


### PR DESCRIPTION
## Summary

Part of #1768. `HttpClientStreamableHttpTransport.Builder` defaults `.endpoint` to `"/mcp"`, and since it's resolved as an absolute-path reference, `URI#resolve` **replaces** (not appends to) the base URI's path. `ToolSetToolsController.fetchTools()` and `SecuredResourceService.validateApiKey()` both passed the whole configured endpoint as the transport's `baseUri` and never called `.endpoint(...)`, so any configured MCP endpoint whose path wasn't exactly `/mcp` was silently requested at `/mcp` instead.

- Added `McpClientUtils.transportBuilder(String endpoint)`, which splits the endpoint into origin + path/query and always sets `.endpoint(...)` explicitly, so the configured endpoint is what actually gets requested.
- Updated both call sites (`ToolSetToolsController`, `SecuredResourceService`) to use it.

## Not included in this PR

#1768 also describes a second, independent problem: `McpHttpClientBuilderService`'s `HttpClient.Builder` wrapper silently no-ops `followRedirects()` and `version()`, so 307/308 redirects (e.g. trailing-slash-normalizing servers like `markitdown-mcp`) still aren't followed, and the SDK's HTTP/1.1 preference is still discarded. That's a separate fix (touching the shared client builder's redirect policy) and is left for a follow-up — leaving #1768 open rather than closing it here.

## Test plan

- [x] Added `ToolSetApiTest.testGetAllTools_ExplicitPathEndpointIsHonored` — configures a toolset endpoint with an explicit non-`/mcp` path (`/call`) against a mock server with a strict fallback (404 for anything unmapped), proving the request lands on the configured path rather than `/mcp`.
- [x] `./gradlew :server:test --tests "com.epam.aidial.core.server.ToolSetApiTest"` and `--tests "com.epam.aidial.core.server.service.SecuredResourceServiceTest"`
- [x] `./gradlew :server:test` (full module): 1559 tests, 0 failures, 0 errors
- [x] `./gradlew checkstyleMain checkstyleTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)