### PR TITLE
feat: support CatalogSchema in /v1/admin/apply and /v1/admin/validate

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/config/MergedConfigStore.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/MergedConfigStore.java
@@ -881,6 +881,7 @@ public final class MergedConfigStore implements ConfigStore {
         next.setKeys(base.getKeys());
         next.setRoutes(base.getRoutes());
         next.setApplicationTypeSchemas(base.getApplicationTypeSchemas());
+        next.setCatalogSchemas(base.getCatalogSchemas());
         next.setApplications(base.getApplications());
         next.setToolsets(base.getToolsets());
         next.setRetriableErrorCodes(base.getRetriableErrorCodes());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/AdminApplyController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/AdminApplyController.java
@@ -65,6 +65,7 @@ public class AdminApplyController {
     static final Map<String, Integer> DEPENDENCY_ORDER = Map.of(
             "Settings", 0,
             "Schema", 1,
+            "CatalogSchema", 1,
             "Interceptor", 2,
             "Role", 3,
             "Key", 4,
@@ -76,6 +77,7 @@ public class AdminApplyController {
     static final Map<String, String> KIND_URL_SEGMENT = Map.of(
             "Settings", "settings",
             "Schema", "schemas",
+            "CatalogSchema", "catalog_schemas",
             "Interceptor", "interceptors",
             "Role", "roles",
             "Key", "keys",
@@ -269,6 +271,7 @@ public class AdminApplyController {
             scratch.setModels(new HashMap<>(live.getModels()));
             scratch.setInterceptors(new HashMap<>(live.getInterceptors()));
             scratch.setApplicationTypeSchemas(new HashMap<>(live.getApplicationTypeSchemas()));
+            scratch.setCatalogSchemas(new HashMap<>(live.getCatalogSchemas()));
             scratch.setApplications(new HashMap<>(live.getApplications()));
             scratch.setToolsets(new HashMap<>(live.getToolsets()));
             scratch.setRoles(new HashMap<>(live.getRoles()));
@@ -328,6 +331,11 @@ public class AdminApplyController {
                         return new ValidationResult(id, ValidationStatus.FAILED, "Schema spec must be a JSON object");
                     }
                 }
+                case "CatalogSchema" -> {
+                    if (!entry.spec().isObject()) {
+                        return new ValidationResult(id, ValidationStatus.FAILED, "CatalogSchema spec must be a JSON object");
+                    }
+                }
                 default -> {
                     return new ValidationResult(id, ValidationStatus.FAILED, "Unknown kind: " + entry.kind());
                 }
@@ -348,7 +356,8 @@ public class AdminApplyController {
         }
         return switch (entry.kind()) {
             case "Settings" -> applySettings(entry, id, parsed);
-            case "Schema" -> applySchema(entry, id, parsed, pending);
+            case "Schema" -> applySchema(entry, id, parsed, pending, ResourceTypes.APP_TYPE_SCHEMA);
+            case "CatalogSchema" -> applySchema(entry, id, parsed, pending, ResourceTypes.CATALOG_SCHEMA);
             case "Interceptor" -> applyManagedEntity(entry, id, parsed, ResourceTypes.INTERCEPTOR, Interceptor.class, pending);
             case "Role" -> applyManagedEntity(entry, id, parsed, ResourceTypes.ROLE, Role.class, pending);
             case "Route" -> applyManagedEntity(entry, id, parsed, ResourceTypes.ROUTE, Route.class, pending);
@@ -372,12 +381,13 @@ public class AdminApplyController {
         return new EntityResult(id, AdminApplyStatus.APPLIED, null);
     }
 
-    private EntityResult applySchema(AdminManifest entry, String id, ParsedName parsed, List<EntityChange> pending) {
+    private EntityResult applySchema(AdminManifest entry, String id, ParsedName parsed, List<EntityChange> pending,
+                                     ResourceTypes type) {
         if (!entry.spec().isObject()) {
             return new EntityResult(id, AdminApplyStatus.FAILED, "Schema spec must be a JSON object");
         }
         ResourceDescriptor descriptor = ResourceDescriptorFactory.fromDecoded(
-                ResourceTypes.APP_TYPE_SCHEMA, parsed.bucket(), parsed.location(), parsed.name());
+                type, parsed.bucket(), parsed.location(), parsed.name());
         String blobBody;
         try {
             blobBody = ProxyUtil.BLOB_MAPPER.writeValueAsString(entry.spec());
@@ -387,7 +397,7 @@ public class AdminApplyController {
             return new EntityResult(id, AdminApplyStatus.FAILED, "Failed to serialize schema for " + id);
         }
         resourceService.putResource(descriptor, blobBody, EtagHeader.ANY);
-        pending.add(new EntityChange(ResourceTypes.APP_TYPE_SCHEMA, MergedConfigStore.canonicalId(descriptor), entry.spec()));
+        pending.add(new EntityChange(type, MergedConfigStore.canonicalId(descriptor), entry.spec()));
         return new EntityResult(id, AdminApplyStatus.APPLIED, null);
     }
 
@@ -545,6 +555,15 @@ public class AdminApplyController {
                         return;
                     }
                     scratch.getApplicationTypeSchemas().put(entry.name(), json);
+                }
+                case "CatalogSchema" -> {
+                    String json;
+                    try {
+                        json = ProxyUtil.BLOB_MAPPER.writeValueAsString(entry.spec());
+                    } catch (JsonProcessingException e) {
+                        return;
+                    }
+                    scratch.getCatalogSchemas().put(entry.name(), json);
                 }
                 default -> { /* unknown kinds never reach this code path */ }
             }

--- a/server/src/main/java/com/epam/aidial/core/server/security/EntityBucketBinding.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/EntityBucketBinding.java
@@ -28,6 +28,7 @@ public class EntityBucketBinding {
             Map.entry("applications", Set.of(ResourceDescriptor.PUBLIC_BUCKET, PLATFORM_BUCKET)),
             Map.entry("toolsets", Set.of(ResourceDescriptor.PUBLIC_BUCKET, PLATFORM_BUCKET)),
             Map.entry("schemas", Set.of(PLATFORM_BUCKET)),
+            Map.entry("catalog_schemas", Set.of(PLATFORM_BUCKET)),
             Map.entry(ResourceTypes.FILE.group(), Set.of(ResourceDescriptor.PUBLIC_BUCKET, USER_BUCKET_WILDCARD)),
             Map.entry(ResourceTypes.PROMPT.group(), Set.of(ResourceDescriptor.PUBLIC_BUCKET, USER_BUCKET_WILDCARD)),
             Map.entry(ResourceTypes.CONVERSATION.group(), Set.of(ResourceDescriptor.PUBLIC_BUCKET, USER_BUCKET_WILDCARD)),

--- a/server/src/test/java/com/epam/aidial/core/server/AdminApplyApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/AdminApplyApiTest.java
@@ -365,6 +365,52 @@ public class AdminApplyApiTest extends ResourceBaseTest {
 
     @Test
     @SneakyThrows
+    void testApplyCatalogSchemaSurvivesUnrelatedApply() {
+        // Regression for MergedConfigStore#shallowClone: partial-update writes (applyBatch et al.)
+        // clone the merged Config off a fresh `new Config()`. Any Config map not explicitly carried
+        // over in shallowClone reverts to its field-initializer default on the very next unrelated
+        // admin write, silently wiping previously-applied entries of that type.
+        String catalogSchemaBody = """
+                {
+                  "manifests": [
+                    {
+                      "kind": "CatalogSchema",
+                      "name": "catalog_schemas/platform/apply-catalog-schema-survive",
+                      "spec": {
+                        "$schema": "https://dial.epam.com/catalog_schemas/schema#",
+                        "$id": "https://dial.epam.com/catalog-schemas/apply-survive-model",
+                        "dial:catalogEntityType": "model",
+                        "dial:catalogDisplayName": "Model",
+                        "type": "object"
+                      }
+                    }
+                  ]
+                }
+                """;
+        verify(send(HttpMethod.POST, "/v1/admin/apply", null, catalogSchemaBody, "authorization", "admin"), 200);
+        verify(send(HttpMethod.GET, "/v1/catalog_schemas/platform/apply-catalog-schema-survive", null, "",
+                "authorization", "admin"), 200);
+
+        String unrelatedBody = """
+                {
+                  "manifests": [
+                    {
+                      "kind": "Interceptor",
+                      "name": "interceptors/platform/apply-catalog-unrelated-int",
+                      "spec": {"endpoint": "http://localhost:4088/api/v1/interceptor/handle"}
+                    }
+                  ]
+                }
+                """;
+        verify(send(HttpMethod.POST, "/v1/admin/apply", null, unrelatedBody, "authorization", "admin"), 200);
+
+        // The unrelated write must not have dropped the previously-applied catalog schema.
+        verify(send(HttpMethod.GET, "/v1/catalog_schemas/platform/apply-catalog-schema-survive", null, "",
+                "authorization", "admin"), 200);
+    }
+
+    @Test
+    @SneakyThrows
     void testApplyCatalogSchemaPublicBucketRejected() {
         String body = """
                 {

--- a/server/src/test/java/com/epam/aidial/core/server/AdminApplyApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/AdminApplyApiTest.java
@@ -336,6 +336,55 @@ public class AdminApplyApiTest extends ResourceBaseTest {
 
     @Test
     @SneakyThrows
+    void testApplyCatalogSchema() {
+        String body = """
+                {
+                  "manifests": [
+                    {
+                      "kind": "CatalogSchema",
+                      "name": "catalog_schemas/platform/apply-catalog-schema-1",
+                      "spec": {
+                        "$schema": "https://dial.epam.com/catalog_schemas/schema#",
+                        "$id": "https://dial.epam.com/catalog-schemas/apply-model",
+                        "dial:catalogEntityType": "model",
+                        "dial:catalogDisplayName": "Model",
+                        "type": "object"
+                      }
+                    }
+                  ]
+                }
+                """;
+        Response response = send(HttpMethod.POST, "/v1/admin/apply", null, body, "authorization", "admin");
+        verify(response, 200);
+        JsonNode parsed = ProxyUtil.MAPPER.readTree(response.body());
+        assertEquals(1, parsed.get("applied").asInt(), () -> "Body: " + response.body());
+        assertEquals(0, parsed.get("failed").asInt());
+        verify(send(HttpMethod.GET, "/v1/catalog_schemas/platform/apply-catalog-schema-1", null, "",
+                "authorization", "admin"), 200);
+    }
+
+    @Test
+    @SneakyThrows
+    void testApplyCatalogSchemaPublicBucketRejected() {
+        String body = """
+                {
+                  "manifests": [
+                    {
+                      "kind": "CatalogSchema",
+                      "name": "catalog_schemas/public/apply-catalog-schema-public",
+                      "spec": {"type": "object"}
+                    }
+                  ]
+                }
+                """;
+        Response response = send(HttpMethod.POST, "/v1/admin/apply", null, body, "authorization", "admin");
+        verify(response, 422);
+        JsonNode parsed = ProxyUtil.MAPPER.readTree(response.body());
+        assertEquals("FAILED", parsed.get("results").get(0).get("status").asText(), () -> "Body: " + response.body());
+    }
+
+    @Test
+    @SneakyThrows
     void testApplyApplicationAndToolSet() {
         String body = """
                 {

--- a/server/src/test/java/com/epam/aidial/core/server/AdminValidateApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/AdminValidateApiTest.java
@@ -64,6 +64,17 @@ public class AdminValidateApiTest extends ResourceBaseTest {
                       "spec": {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object"}
                     },
                     {
+                      "kind": "CatalogSchema",
+                      "name": "catalog_schemas/platform/validate-catalog-schema",
+                      "spec": {
+                        "$schema": "https://dial.epam.com/catalog_schemas/schema#",
+                        "$id": "https://dial.epam.com/catalog-schemas/validate-model",
+                        "dial:catalogEntityType": "model",
+                        "dial:catalogDisplayName": "Model",
+                        "type": "object"
+                      }
+                    },
+                    {
                       "kind": "Interceptor",
                       "name": "interceptors/platform/validate-int",
                       "spec": {"endpoint": "http://localhost:4088/api/v1/interceptor/handle"}
@@ -111,13 +122,15 @@ public class AdminValidateApiTest extends ResourceBaseTest {
         Response response = send(HttpMethod.POST, "/v1/admin/validate", null, body, "authorization", "admin");
         verify(response, 200);
         JsonNode parsed = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(9, parsed.get("valid").asInt(), () -> "Body: " + response.body());
+        assertEquals(10, parsed.get("valid").asInt(), () -> "Body: " + response.body());
         assertEquals(0, parsed.get("failed").asInt());
         for (JsonNode r : parsed.get("results")) {
             assertEquals("VALID", r.get("status").asText(), () -> "Body: " + response.body());
         }
         // None of these were written.
         verify(send(HttpMethod.GET, "/v1/schemas/platform/validate-schema", null, "",
+                "authorization", "admin"), 404);
+        verify(send(HttpMethod.GET, "/v1/catalog_schemas/platform/validate-catalog-schema", null, "",
                 "authorization", "admin"), 404);
         verify(send(HttpMethod.GET, "/v1/interceptors/platform/validate-int", null, "",
                 "authorization", "admin"), 404);
@@ -423,6 +436,31 @@ public class AdminValidateApiTest extends ResourceBaseTest {
         assertEquals("FAILED", parsed.get("results").get(0).get("status").asText());
         verify(send(HttpMethod.GET, "/v1/models/platform/validate-jackson-bad", null, "",
                 "authorization", "admin"), 404);
+    }
+
+    @Test
+    @SneakyThrows
+    void testV15bCatalogSchemaNonObjectSpecFails() {
+        String body = """
+                {
+                  "precheck": false,
+                  "manifests": [
+                    {
+                      "kind": "CatalogSchema",
+                      "name": "catalog_schemas/platform/validate-catalog-schema-bad",
+                      "spec": "not-an-object"
+                    }
+                  ]
+                }
+                """;
+        Response response = send(HttpMethod.POST, "/v1/admin/validate", null, body, "authorization", "admin");
+        verify(response, 200);
+        JsonNode parsed = ProxyUtil.MAPPER.readTree(response.body());
+        assertEquals(0, parsed.get("valid").asInt(), () -> "Body: " + response.body());
+        assertEquals(1, parsed.get("failed").asInt());
+        JsonNode result = parsed.get("results").get(0);
+        assertEquals("FAILED", result.get("status").asText());
+        assertEquals("CatalogSchema spec must be a JSON object", result.get("error").asText());
     }
 
     @Test


### PR DESCRIPTION
## Applicable issues
- fixes #1746

## Summary
- `CatalogSchema` (added in #1749) was missing from `AdminApplyController`'s dependency ordering, URL-segment map, scratch-config seeding, and per-entity handlers (`validateOnly`/`applySingle`/`mutateScratch`), so it could not be applied or validated through the batch admin endpoints (`POST /v1/admin/apply`, `POST /v1/admin/validate`).
- Also fixes a related gap discovered while verifying end-to-end: `EntityBucketBinding`'s platform-bucket allowlist never got a `catalog_schemas` entry, so `GET /v1/catalog_schemas/platform/...` 404'd unconditionally regardless of how the entity was written.
- Also fixes a more severe latent bug found while auditing for similar misses: `MergedConfigStore#shallowClone` never carried `catalogSchemas` over from the base `Config`. Since `shallowClone` backs every partial-update write path (`applyBatch`, single-entity PUT/DELETE, settings write/delete), **any** admin write — not just catalog-schema ones — silently wiped all catalog schemas from the live merged config. `rebuild()` already copied the map correctly; only `shallowClone` had fallen out of sync since `catalog_schemas` was introduced in #1749.

## Test plan
- [x] `./gradlew :server:test --tests "com.epam.aidial.core.server.AdminApplyApiTest"` — passing, includes new `testApplyCatalogSchema`, `testApplyCatalogSchemaPublicBucketRejected`, and `testApplyCatalogSchemaSurvivesUnrelatedApply` (regression for the `shallowClone` fix — verified it fails without the fix)
- [x] `./gradlew :server:test --tests "com.epam.aidial.core.server.AdminValidateApiTest"` — passing, includes new `testV15bCatalogSchemaNonObjectSpecFails` and `CatalogSchema` added to the existing "all kinds" round-trip test
- [x] `./gradlew checkstyleMain checkstyleTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)