### PR TITLE
fix: chained agent cannot reach its own sub-deployments #1790

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -320,7 +320,7 @@ public class AccessService {
         }
 
         // Collecting declared resources re-validates the application against its schema, so ask only for the kinds actually requested.
-        List<ResourceDescriptor> declaredResources = new ArrayList<>();
+        Set<ResourceDescriptor> declaredResources = new HashSet<>();
         if (ownResources.stream().anyMatch(resource -> resource.getType() == ResourceTypes.FILE)) {
             declaredResources.addAll(applicationSchemaService.getFiles(application));
         }

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -18,6 +18,7 @@ import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.storage.data.MetadataBase;
 import com.epam.aidial.core.storage.data.ResourceFolderMetadata;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.resource.ResourceType;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.resource.ResourceUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -53,6 +54,8 @@ public class AccessService {
     private final List<String> createCodeAppRoles;
 
     private final ApplicationSchemaService applicationSchemaService;
+
+    private static final Set<ResourceType> DEPLOYMENT_TYPES = Set.of(ResourceTypes.APPLICATION, ResourceTypes.TOOL_SET);
 
     private final List<PermissionRule> permissionRules = List.of(
             AccessService::getOwnResourcesAccess,
@@ -305,19 +308,33 @@ public class AccessService {
 
     public Map<ResourceDescriptor, Set<ResourceAccessType>> getOwnResourcesAccessForChainedSchemaRichApplication(
             Set<ResourceDescriptor> resources, ProxyContext context) {
-        if (context.getDeployment() instanceof Application application && application.hasApplicationTypeSchemaId()) {
-            List<ResourceDescriptor> applicationFiles = applicationSchemaService.getFiles(application);
-            String location = BucketBuilder.buildInitiatorBucket(context);
-            Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
-            for (ResourceDescriptor resource : resources) {
-                if (resource.getBucketLocation().equals(location) && applicationFiles.contains(resource)) {
-                    result.put(resource, ResourceAccessType.READ_ONLY);
-                }
-            }
-            return result;
-        } else {
+        if (!(context.getDeployment() instanceof Application application) || !application.hasApplicationTypeSchemaId()) {
             return Map.of();
         }
+        String location = BucketBuilder.buildInitiatorBucket(context);
+        Set<ResourceDescriptor> ownResources = resources.stream()
+                .filter(resource -> resource.getBucketLocation().equals(location))
+                .collect(Collectors.toSet());
+        if (ownResources.isEmpty()) {
+            return Map.of();
+        }
+
+        // Collecting declared resources re-validates the application against its schema, so ask only for the kinds actually requested.
+        List<ResourceDescriptor> declaredResources = new ArrayList<>();
+        if (ownResources.stream().anyMatch(resource -> resource.getType() == ResourceTypes.FILE)) {
+            declaredResources.addAll(applicationSchemaService.getFiles(application));
+        }
+        if (ownResources.stream().anyMatch(resource -> DEPLOYMENT_TYPES.contains(resource.getType()))) {
+            declaredResources.addAll(applicationSchemaService.getDeployments(application));
+        }
+
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
+        for (ResourceDescriptor resource : ownResources) {
+            if (declaredResources.contains(resource)) {
+                result.put(resource, ResourceAccessType.READ_ONLY);
+            }
+        }
+        return result;
     }
 
     public static Map<ResourceDescriptor, Set<ResourceAccessType>> getAppResourceAccess(

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -1,6 +1,9 @@
 package com.epam.aidial.core.server;
 
 import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.ResourceAccessType;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.data.AutoSharedData;
 import com.epam.aidial.core.server.data.InvitationLink;
 import com.epam.aidial.core.server.util.JsonUtil;
 import com.epam.aidial.core.server.util.ProxyUtil;
@@ -20,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1258,6 +1264,59 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                   }
                 }
                 """);
+    }
+
+    /**
+     * Reproduces an orchestrator delegating to a schema-rich application that declares a private sub-deployment of its own:
+     * the second hop runs under a per-request key carrying only the parent, so the sub-deployment has to be resolved there.
+     */
+    @Test
+    void testChainedSchemaRichApplicationCanReachOwnDeployment() {
+        Response response = send(HttpMethod.GET, "/v1/bucket", null, "", "authorization", "user");
+        verify(response, 200);
+        String userBucket = new JsonObject(response.body()).getString("bucket");
+
+        String subAgentUrl = "applications/%s/sub_agent".formatted(userBucket);
+        String parentAgentUrl = "applications/%s/parent_agent".formatted(userBucket);
+
+        response = send(HttpMethod.PUT, "/v1/" + subAgentUrl, null, """
+                {
+                  "endpoint": "http://localhost:4848/chat/completions",
+                  "display_name": "Sub Agent",
+                  "display_version": "1.0"
+                }
+                """, "authorization", "user");
+        verify(response, 200);
+
+        response = send(HttpMethod.PUT, "/v1/" + parentAgentUrl, null, """
+                {
+                  "displayName": "Parent Agent",
+                  "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/chained_application_type",
+                  "applicationProperties": {
+                    "property1": "test property1",
+                    "deployments": ["%s"]
+                  }
+                }
+                """.formatted(subAgentUrl), "authorization", "user");
+        verify(response, 200);
+
+        // the key the parent receives from an orchestrator: the parent is attached, its own sub-agent is not
+        ApiKeyData appKey = createAppKey("user", Map.of(parentAgentUrl, new AutoSharedData(Set.of(ResourceAccessType.READ))));
+        appKey.setExecutionPath(List.of("orchestrator"));
+        apiKeyStore.assignPerRequestApiKey(appKey);
+
+        try (TestWebServer server = new TestWebServer(4848)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[]}"));
+
+            response = send(HttpMethod.POST, "/openai/deployments/%s/chat/completions".formatted(parentAgentUrl), null, """
+                    {"messages":[{"role":"user","content":"how are you?"}]}
+                    """, "api-key", appKey.getPerRequestKey(), "Content-Type", "application/json");
+
+            assertEquals(200, response.status());
+        }
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/security/AccessServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/security/AccessServiceTest.java
@@ -309,6 +309,134 @@ public class AccessServiceTest {
     }
 
     @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_DeclaredDeployment() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(true);
+        when(context.getDeployment()).thenReturn(application);
+
+        String initiatorBucket = "Users/user-sub-id/";
+        ResourceDescriptor subAgent =
+                new ResourceDescriptor(ResourceTypes.APPLICATION, "sub-agent__0.0.1", List.of(), "bucket", initiatorBucket, false);
+
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(applicationSchemaService.getDeployments(application)).thenReturn(List.of(subAgent));
+
+        try (MockedStatic<BucketBuilder> bucketBuilderMock = mockStatic(BucketBuilder.class)) {
+            bucketBuilderMock.when(() -> BucketBuilder.buildInitiatorBucket(context)).thenReturn(initiatorBucket);
+
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService(applicationSchemaService)
+                    .getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(subAgent), context);
+
+            assertEquals(ResourceAccessType.READ_ONLY, result.get(subAgent));
+        }
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_DeclaredToolSet() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(true);
+        when(context.getDeployment()).thenReturn(application);
+
+        String initiatorBucket = "Users/user-sub-id/";
+        ResourceDescriptor toolSet =
+                new ResourceDescriptor(ResourceTypes.TOOL_SET, "my-tool-set", List.of(), "bucket", initiatorBucket, false);
+
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(applicationSchemaService.getDeployments(application)).thenReturn(List.of(toolSet));
+
+        try (MockedStatic<BucketBuilder> bucketBuilderMock = mockStatic(BucketBuilder.class)) {
+            bucketBuilderMock.when(() -> BucketBuilder.buildInitiatorBucket(context)).thenReturn(initiatorBucket);
+
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService(applicationSchemaService)
+                    .getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(toolSet), context);
+
+            assertEquals(ResourceAccessType.READ_ONLY, result.get(toolSet));
+        }
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_DeploymentNotDeclared() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(true);
+        when(context.getDeployment()).thenReturn(application);
+
+        String initiatorBucket = "Users/user-sub-id/";
+        ResourceDescriptor subAgent =
+                new ResourceDescriptor(ResourceTypes.APPLICATION, "sub-agent__0.0.1", List.of(), "bucket", initiatorBucket, false);
+
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(applicationSchemaService.getDeployments(application)).thenReturn(List.of());
+
+        try (MockedStatic<BucketBuilder> bucketBuilderMock = mockStatic(BucketBuilder.class)) {
+            bucketBuilderMock.when(() -> BucketBuilder.buildInitiatorBucket(context)).thenReturn(initiatorBucket);
+
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService(applicationSchemaService)
+                    .getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(subAgent), context);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_DeploymentFromAnotherBucket() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(true);
+        when(context.getDeployment()).thenReturn(application);
+
+        ResourceDescriptor subAgent =
+                new ResourceDescriptor(ResourceTypes.APPLICATION, "sub-agent__0.0.1", List.of(), "bucket", "Users/another-user/", false);
+
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+
+        try (MockedStatic<BucketBuilder> bucketBuilderMock = mockStatic(BucketBuilder.class)) {
+            bucketBuilderMock.when(() -> BucketBuilder.buildInitiatorBucket(context)).thenReturn("Users/user-sub-id/");
+
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService(applicationSchemaService)
+                    .getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(subAgent), context);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    public void testGetOwnResourcesAccessForChainedSchemaRichApplication_FilesAndDeploymentsTogether() {
+        Application application = mock(Application.class);
+        when(application.hasApplicationTypeSchemaId()).thenReturn(true);
+        when(context.getDeployment()).thenReturn(application);
+
+        String initiatorBucket = "Users/user-sub-id/";
+        ResourceDescriptor file = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", initiatorBucket, false);
+        ResourceDescriptor subAgent =
+                new ResourceDescriptor(ResourceTypes.APPLICATION, "sub-agent__0.0.1", List.of(), "bucket", initiatorBucket, false);
+
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(applicationSchemaService.getFiles(application)).thenReturn(List.of(file));
+        when(applicationSchemaService.getDeployments(application)).thenReturn(List.of(subAgent));
+
+        try (MockedStatic<BucketBuilder> bucketBuilderMock = mockStatic(BucketBuilder.class)) {
+            bucketBuilderMock.when(() -> BucketBuilder.buildInitiatorBucket(context)).thenReturn(initiatorBucket);
+
+            Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService(applicationSchemaService)
+                    .getOwnResourcesAccessForChainedSchemaRichApplication(Set.of(file, subAgent), context);
+
+            assertEquals(ResourceAccessType.READ_ONLY, result.get(file));
+            assertEquals(ResourceAccessType.READ_ONLY, result.get(subAgent));
+        }
+    }
+
+    private AccessService accessService(ApplicationSchemaService applicationSchemaService) {
+        return new AccessService(encryptionService, shareService, ruleService, applicationSchemaService,
+                new JsonObject("""
+                        {
+                         "admin": {
+                            "rules": [{"source": "roles", "function": "EQUAL", "targets": ["admin"]}]
+                         },
+                         "createCodeAppRoles": ["admin"]
+                        }
+                        """));
+    }
+
+    @Test
     public void testGetAdminAccess_WhenPublicResource() {
         ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", "public/", false);
         ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -441,6 +441,38 @@
         "property1",
         "property2"
       ]
+    },
+    {
+      "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+      "$id": "https://mydial.somewhere.com/custom_application_schemas/chained_application_type",
+      "dial:applicationTypeEditorUrl": "https://mydial.somewhere.com/custom_application_schemas/schema",
+      "dial:applicationTypeViewerUrl": "https://mydial.somewhere.com/custom_application_schemas/viewer",
+      "dial:applicationTypeDisplayName": "Chained Application Type",
+      "dial:applicationTypeCompletionEndpoint": "http://localhost:4848/chat/completions",
+      "properties": {
+        "property1": {
+          "title": "Property 1",
+          "type": "string",
+          "dial:meta": {
+            "dial:propertyKind": "client",
+            "dial:propertyOrder": 1
+          }
+        },
+        "deployments": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "dial:resource": true
+          },
+          "dial:meta": {
+            "dial:propertyKind": "server",
+            "dial:propertyOrder": 2
+          }
+        }
+      },
+      "required": [
+        "property1"
+      ]
     }
   ]
 }


### PR DESCRIPTION
A schema-rich application could not reach the sub-agents and toolsets it declares once it was invoked by another agent rather than directly by the user. The access rule that exists for exactly this situation covered an application's declared files but never its declared deployments.

### Applicable issues

- fixes #1790

### Description of changes

- `AccessService.getOwnResourcesAccessForChainedSchemaRichApplication` now also consults `ApplicationSchemaService.getDeployments()`, not just `getFiles()`. The grant stays `READ_ONLY` and stays scoped to resources the application actually declares in the initiator's bucket, so nothing is widened beyond what the files path already allowed.
- Why the rule is the right place: on the second hop the request runs under a per-request key, so `BucketBuilder.buildUserBucket()` resolves to `Keys/<deployment>/` and the user's ownership of the sub-deployment becomes invisible. This rule is the one that uses `buildInitiatorBucket()` instead, which is why it already worked for files. It was added for chained schema-rich applications in #786 and deployments were simply left out of it.
- The per-hop key propagation itself is correct and unchanged: each hop populates the next hop's key with its own declared deployments, so the chain is unbounded in depth once the authorization step stops failing.
- Both `APPLICATION` and `TOOL_SET` are covered, mirroring what `getDeployments()` has always returned — a private declared toolset failed at depth two for the same reason a private sub-agent did.
- Collecting declared resources re-validates the application against its schema, so the rule now returns early when no requested resource lives in the initiator's bucket, and asks only for the resource kinds actually being looked up. This makes the common file lookup cheaper than before rather than more expensive.

### Tests

- Five unit tests in `AccessServiceTest`: declared sub-agent granted, declared toolset granted, undeclared deployment refused, deployment in another bucket refused, files and deployments together.
- New integration test `CustomApplicationApiTest.testChainedSchemaRichApplicationCanReachOwnDeployment` drives the real flow — a private sub-agent, a schema-rich parent declaring it, and a chat completion to the parent under a per-request key carrying only the parent. It returns 403 without the fix and 200 with it.
- This path had no integration coverage before: `CollectDeploymentsFnTest` stubs `hasReadAccess` to `true`, and the existing per-request-key tests inject an already-populated grant, so the authorization step in between was untested from both directions.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.