### PR TITLE
fix: deployments list interface_type=chat missing chat apps #1801

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -233,9 +233,11 @@ public class DeploymentController {
             Config config = context.getConfig();
             List<DeploymentData> deployments = new ArrayList<>();
             for (Application application : config.getApplications().values()) {
-                if (application.hasAccess(context.getUserRoles()) && match(filters, application)) {
-                    application = resolveLocalApplication(application);
-                    deployments.add(to(application));
+                if (application.hasAccess(context.getUserRoles())) {
+                    Application resolved = resolveLocalApplication(application);
+                    if (match(filters, resolved)) {
+                        deployments.add(to(resolved));
+                    }
                 }
             }
             List<Application> resourceApps = List.of();

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -23,28 +23,31 @@ public class DeploymentApiTest extends ResourceBaseTest {
         Response response = send(HttpMethod.GET, "/v1/deployments", null, null);
         verify(response, 200);
         JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(4, body.size());
+        assertEquals(5, body.size());
 
         // typed interface types are surfaced in the `interfaces` array next to the UI categories;
         // embedding models expose openaiChatCompletions since their endpoint lives under that key
         Map<String, Set<String>> interfacesById = collectInterfaces(body);
         assertEquals(Set.of("embedding", "openaiChatCompletions"), interfacesById.get("embedding-ada"));
         assertEquals(Set.of("chat", "openaiChatCompletions"), interfacesById.get("gpt-4"));
+        // schema-rich application declared directly in config: endpoint and mcp are resolved from its
+        // application type schema rather than set as literal fields, so they must be resolved before filtering
+        assertEquals(Set.of("chat", "mcp", "custom_ui", "openaiChatCompletions"), interfacesById.get("schema-app"));
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=all,mcp", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(4, body.size());
+        assertEquals(5, body.size());
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=mcp", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(1, body.size());
+        assertEquals(2, body.size());
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=mcp,embedding", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(2, body.size());
+        assertEquals(3, body.size());
 
         response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my%20app", null, """
                 {
@@ -64,22 +67,24 @@ public class DeploymentApiTest extends ResourceBaseTest {
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=mcp", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(2, body.size());
+        assertEquals(3, body.size());
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=chat", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(3, body.size());
+        assertEquals(4, body.size());
+        assertTrue(collectInterfaces(body).containsKey("schema-app"));
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=chat,mcp", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(4, body.size());
+        assertEquals(5, body.size());
 
         response = send(HttpMethod.GET, "/v1/deployments", "interface_type=custom_ui", null);
         verify(response, 200);
         body = ProxyUtil.MAPPER.readTree(response.body());
-        assertEquals(1, body.size());
+        assertEquals(2, body.size());
+        assertTrue(collectInterfaces(body).containsKey("schema-app"));
     }
 
     @DialConfigLocation("dial-config/deployment-interfaces-features.json")

--- a/server/src/test/resources/dial-config/deployment-interfaces-listing.json
+++ b/server/src/test/resources/dial-config/deployment-interfaces-listing.json
@@ -12,6 +12,13 @@
       },
       "viewer_url": "http://some-host",
       "editor_url": "http://some-host"
+    },
+    "schema-app": {
+      "application_type_schema_id": "https://mydial.somewhere.com/custom_application_schemas/specific_toolset_type",
+      "application_properties": {
+        "property1": "foo",
+        "property2": "bar"
+      }
     }
   },
   "models": {


### PR DESCRIPTION
`GET /v1/deployments?interface_type=chat` (and `mcp`/`custom_ui`) omitted schema-rich applications declared directly in config, even though they appeared in the unfiltered listing.

### Applicable issues

- fixes #1801

### Description of changes

- `DeploymentController.getApplications()` was filtering config-declared applications against their *raw*, unresolved fields before resolving schema-derived `endpoint`/`mcp`/`viewerUrl` for schema-rich apps (those with `applicationTypeSchemaId`). Since those fields come from the app's JSON schema rather than literal config, such apps looked like they supported nothing and were dropped from the `chat`/`mcp`/`custom_ui` filters.
- Reordered the loop to resolve the schema-rich application first, then apply the interface filters — matching the order already used for resource-stored custom applications (`ApplicationDeploymentExtractor`), which didn't have this bug.
- Added a schema-rich application fixture to `deployment-interfaces-listing.json` and extended `DeploymentApiTest.testListDeployments()` to cover it across `chat`, `mcp`, and `custom_ui` filters.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.