### PR TITLE
fix: canonical deployment id denied through interceptor #1804

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -326,7 +326,7 @@ public class ApplicationController {
         if (appName != null && appName.equals(context.getDecodedSourceDeployment())) {
             return true;
         }
-        if (appName != null) {
+        if (appName != null && context.getConfig().selectDeployment(appName) == null) {
             try {
                 ResourceDescriptor resource = ResourceDescriptorFactory.fromAnyUrl(appName, encryptionService);
                 if (resource.getType() == ResourceTypes.APPLICATION) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -326,7 +326,9 @@ public class ApplicationController {
         if (appName != null && appName.equals(context.getDecodedSourceDeployment())) {
             return true;
         }
-        if (appName != null && context.getConfig().selectDeployment(appName) == null) {
+        // Config-registered deployments (bare name or canonical id) are role-based, not governed
+        // by the resource-sharing ACL below - fall through to the admin check instead.
+        if (appName != null && !context.getConfig().isDeploymentExists(appName)) {
             try {
                 ResourceDescriptor resource = ResourceDescriptorFactory.fromAnyUrl(appName, encryptionService);
                 if (resource.getType() == ResourceTypes.APPLICATION) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/route/ApplicationRouteController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/route/ApplicationRouteController.java
@@ -49,7 +49,9 @@ public class ApplicationRouteController extends BaseRouteController {
 
     @Override
     protected Future<Boolean> hasRequiredPermissions(Set<ResourceAccessType> permissions) {
-        if (context.getConfig().selectDeployment(deploymentId) != null) {
+        // Config-registered deployments (bare name or canonical id) are role-based, not governed
+        // by the resource-sharing ACL looked up below.
+        if (context.getConfig().isDeploymentExists(deploymentId)) {
             return Future.succeededFuture(true);
         }
         ResourceDescriptor appResource;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/route/ApplicationRouteController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/route/ApplicationRouteController.java
@@ -49,6 +49,9 @@ public class ApplicationRouteController extends BaseRouteController {
 
     @Override
     protected Future<Boolean> hasRequiredPermissions(Set<ResourceAccessType> permissions) {
+        if (context.getConfig().selectDeployment(deploymentId) != null) {
+            return Future.succeededFuture(true);
+        }
         ResourceDescriptor appResource;
         try {
             String encodedPath = UrlUtil.encodePath(deploymentId);

--- a/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
@@ -31,7 +31,10 @@ public class AutoShareDeploymentFn extends BaseRequestFunction<RequestObject> {
     public Boolean apply(RequestObject tree) {
         try {
             String initialDeployment = context.getInitialDeployment();
-            if (initialDeployment == null || context.getConfig().selectDeployment(initialDeployment) != null) {
+            // Config-registered deployments (bare name or canonical id) are governed by role-based
+            // access, not the resource-sharing ACL below - skip straight past it, same as the
+            // bare-name form already does today.
+            if (initialDeployment == null || context.getConfig().isDeploymentExists(initialDeployment)) {
                 return false;
             }
             ResourceDescriptor descriptor = toResourceDescriptor(initialDeployment);

--- a/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
@@ -31,7 +31,7 @@ public class AutoShareDeploymentFn extends BaseRequestFunction<RequestObject> {
     public Boolean apply(RequestObject tree) {
         try {
             String initialDeployment = context.getInitialDeployment();
-            if (context.getConfig().selectDeployment(initialDeployment) != null) {
+            if (initialDeployment == null || context.getConfig().selectDeployment(initialDeployment) != null) {
                 return false;
             }
             ResourceDescriptor descriptor = toResourceDescriptor(initialDeployment);

--- a/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
@@ -31,6 +31,9 @@ public class AutoShareDeploymentFn extends BaseRequestFunction<RequestObject> {
     public Boolean apply(RequestObject tree) {
         try {
             String initialDeployment = context.getInitialDeployment();
+            if (context.getConfig().selectDeployment(initialDeployment) != null) {
+                return false;
+            }
             ResourceDescriptor descriptor = toResourceDescriptor(initialDeployment);
             if (descriptor == null || descriptor.isPublic()) {
                 return false;

--- a/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.core.server.function;
 
 import com.epam.aidial.core.config.Config;
-import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -128,7 +127,7 @@ public class AutoShareDeploymentFnTest {
     public void testApply_WhenInitialDeploymentIsBareNameModel() {
         when(context.getConfig()).thenReturn(config);
         when(context.getInitialDeployment()).thenReturn("gpt-5-2025-08-07");
-        when(config.selectDeployment("gpt-5-2025-08-07")).thenReturn(new Model());
+        when(config.isDeploymentExists("gpt-5-2025-08-07")).thenReturn(true);
 
         assertFalse(fn.apply(EMPTY_OBJECT));
         assertTrue(proxyApiKeyData.getAttachedDeployments().isEmpty());
@@ -138,7 +137,7 @@ public class AutoShareDeploymentFnTest {
     public void testApply_WhenInitialDeploymentIsCanonicalIdModel() {
         when(context.getConfig()).thenReturn(config);
         when(context.getInitialDeployment()).thenReturn("models/platform/gpt-5-2025-08-07");
-        when(config.selectDeployment("models/platform/gpt-5-2025-08-07")).thenReturn(new Model());
+        when(config.isDeploymentExists("models/platform/gpt-5-2025-08-07")).thenReturn(true);
 
         assertFalse(fn.apply(EMPTY_OBJECT));
         assertTrue(proxyApiKeyData.getAttachedDeployments().isEmpty());

--- a/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 
@@ -61,7 +62,7 @@ public class AutoShareDeploymentFnTest {
     @BeforeEach
     public void beforeEach() {
         proxyApiKeyData = new ApiKeyData();
-        when(context.getConfig()).thenReturn(config);
+        lenient().when(context.getConfig()).thenReturn(config);
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 
@@ -62,7 +61,6 @@ public class AutoShareDeploymentFnTest {
     @BeforeEach
     public void beforeEach() {
         proxyApiKeyData = new ApiKeyData();
-        lenient().when(context.getConfig()).thenReturn(config);
     }
 
     @Test
@@ -73,6 +71,7 @@ public class AutoShareDeploymentFnTest {
 
     @Test
     public void testApply_WhenInitialDeploymentIsPublicResource() {
+        when(context.getConfig()).thenReturn(config);
         when(context.getInitialDeployment()).thenReturn("applications/public/my-app");
 
         assertFalse(fn.apply(EMPTY_OBJECT));
@@ -81,6 +80,7 @@ public class AutoShareDeploymentFnTest {
 
     @Test
     public void testApply_WhenInitialDeploymentIsForbidden() {
+        when(context.getConfig()).thenReturn(config);
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/user/");
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getAccessService()).thenReturn(accessService);
@@ -93,6 +93,7 @@ public class AutoShareDeploymentFnTest {
 
     @Test
     public void testApply_WhenInitialDeploymentIdContainsSpace() {
+        when(context.getConfig()).thenReturn(config);
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/user/");
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getAccessService()).thenReturn(accessService);
@@ -109,6 +110,7 @@ public class AutoShareDeploymentFnTest {
 
     @Test
     public void testApply_WhenInitialDeploymentIsApp() {
+        when(context.getConfig()).thenReturn(config);
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/user/");
         when(proxy.getEncryptionService()).thenReturn(encryptionService);
         when(proxy.getAccessService()).thenReturn(accessService);
@@ -124,6 +126,7 @@ public class AutoShareDeploymentFnTest {
 
     @Test
     public void testApply_WhenInitialDeploymentIsBareNameModel() {
+        when(context.getConfig()).thenReturn(config);
         when(context.getInitialDeployment()).thenReturn("gpt-5-2025-08-07");
         when(config.selectDeployment("gpt-5-2025-08-07")).thenReturn(new Model());
 
@@ -133,6 +136,7 @@ public class AutoShareDeploymentFnTest {
 
     @Test
     public void testApply_WhenInitialDeploymentIsCanonicalIdModel() {
+        when(context.getConfig()).thenReturn(config);
         when(context.getInitialDeployment()).thenReturn("models/platform/gpt-5-2025-08-07");
         when(config.selectDeployment("models/platform/gpt-5-2025-08-07")).thenReturn(new Model());
 

--- a/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/AutoShareDeploymentFnTest.java
@@ -1,5 +1,7 @@
 package com.epam.aidial.core.server.function;
 
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -38,6 +40,9 @@ public class AutoShareDeploymentFnTest {
     private ProxyContext context;
 
     @Mock
+    private Config config;
+
+    @Mock
     private EncryptionService encryptionService;
 
     @Mock
@@ -56,6 +61,7 @@ public class AutoShareDeploymentFnTest {
     @BeforeEach
     public void beforeEach() {
         proxyApiKeyData = new ApiKeyData();
+        when(context.getConfig()).thenReturn(config);
     }
 
     @Test
@@ -113,5 +119,23 @@ public class AutoShareDeploymentFnTest {
         assertFalse(fn.apply(EMPTY_OBJECT));
         assertFalse(proxyApiKeyData.getAttachedDeployments().isEmpty());
         assertEquals(ResourceAccessType.READ_ONLY, proxyApiKeyData.getAttachedDeployments().get("applications/123/my-app").accessTypes());
+    }
+
+    @Test
+    public void testApply_WhenInitialDeploymentIsBareNameModel() {
+        when(context.getInitialDeployment()).thenReturn("gpt-5-2025-08-07");
+        when(config.selectDeployment("gpt-5-2025-08-07")).thenReturn(new Model());
+
+        assertFalse(fn.apply(EMPTY_OBJECT));
+        assertTrue(proxyApiKeyData.getAttachedDeployments().isEmpty());
+    }
+
+    @Test
+    public void testApply_WhenInitialDeploymentIsCanonicalIdModel() {
+        when(context.getInitialDeployment()).thenReturn("models/platform/gpt-5-2025-08-07");
+        when(config.selectDeployment("models/platform/gpt-5-2025-08-07")).thenReturn(new Model());
+
+        assertFalse(fn.apply(EMPTY_OBJECT));
+        assertTrue(proxyApiKeyData.getAttachedDeployments().isEmpty());
     }
 }


### PR DESCRIPTION
Fixes false-positive "Access denied" errors when a config-based deployment (Model, static/platform Application, ToolSet, Interceptor) is addressed by its canonical id instead of its bare name.

### Applicable issues

- fixes #1804

### Description of changes

- `AutoShareDeploymentFn.apply`: short-circuit with `context.getConfig().selectDeployment(initialDeployment) != null`, mirroring the existing bare-name behavior, before ever building a `ResourceDescriptor` or running the ownership ACL check.
- `ApplicationRouteController.hasRequiredPermissions`: widened the existing "not a custom application" fallback to also trigger for ids resolvable via `Config.selectDeployment`.
- `ApplicationController.hasWriteAccess`: widened the existing fallthrough-to-admin-check to also trigger for ids resolvable via `Config.selectDeployment`.
- Extended `AutoShareDeploymentFnTest` with bare-name and canonical-id model coverage.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.