### PR TITLE
chore: send x-dial-deployment-features to Anthropic translating adapters #1618

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/Proxy.java
+++ b/server/src/main/java/com/epam/aidial/core/server/Proxy.java
@@ -125,6 +125,7 @@ public class Proxy implements Handler<HttpServerRequest> {
     public static final String HEADER_OVERRIDE_NAME = "X-DIAL-OVERRIDE-NAME";
     public static final String HEADER_CLIENT_CHANNEL_ID = "X-DIAL-CLIENT-CHANNEL-ID";
     public static final String HEADER_DEPLOYMENT_ID = "X-DIAL-DEPLOYMENT-ID";
+    public static final String HEADER_DEPLOYMENT_FEATURES = "X-DIAL-DEPLOYMENT-FEATURES";
 
     public static final Set<HttpMethod> ALLOWED_HTTP_METHODS = Set.of(HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT,
             HttpMethod.DELETE, HttpMethod.HEAD, HttpMethod.PATCH);

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -9,6 +9,7 @@ import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.controller.BaseDeploymentPostController;
 import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.data.FeaturesData;
 import com.epam.aidial.core.server.function.BaseRequestFunction;
 import com.epam.aidial.core.server.function.CollectDeploymentsFn;
 import com.epam.aidial.core.server.function.CollectRequestApplicationFilesFn;
@@ -45,6 +46,12 @@ import java.util.List;
  */
 @Slf4j
 abstract class MessagesBaseController extends BaseDeploymentPostController {
+
+    /**
+     * Path markers an adapter's {@code base_url} carries when it translates the Anthropic Messages request
+     * into another API.
+     */
+    private static final List<String> TRANSLATION_MARKERS = List.of("to-chat-completions", "to-responses");
 
     protected final List<BaseRequestFunction<RequestObject>> enhancementFunctions;
 
@@ -190,11 +197,25 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
 
     /**
      * The body's {@code model} may have been replaced by {@code overrideName}, so the deployment id is
-     * carried to the adapter out of band.
+     * carried to the adapter out of band. Translating adapters additionally receive the deployment features,
+     * which tell them which parameters the target API accepts.
      */
     @Override
     protected void enrichProxyRequestHeaders(HttpClientRequest proxyRequest) {
         proxyRequest.putHeader(Proxy.HEADER_DEPLOYMENT_ID, deploymentId);
+
+        if (isTranslatingUpstream(context.getProxyRequestUri())) {
+            proxyRequest.putHeader(Proxy.HEADER_DEPLOYMENT_FEATURES,
+                    ProxyUtil.convertToString(FeaturesData.createDeploymentFeatures(context.getDeployment())));
+        }
+    }
+
+    /**
+     * A translating adapter converts the Anthropic Messages request into another API before calling the
+     * upstream; it is recognized by the translation marker its {@code base_url} carries.
+     */
+    private static boolean isTranslatingUpstream(String uri) {
+        return uri != null && TRANSLATION_MARKERS.stream().anyMatch(uri::contains);
     }
 
     private void handleProxyResponse(HttpClientResponse proxyResponse) {

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server;
 
+import com.epam.aidial.core.server.data.FeaturesData;
 import com.epam.aidial.core.server.data.LimitStats;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import io.vertx.core.http.HttpMethod;
@@ -18,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -236,6 +238,61 @@ public class MessagesApiTest extends ResourceBaseTest {
 
             assertEquals(200, response.status());
             assertEquals("claude-count", captured.get().getHeader("X-DIAL-DEPLOYMENT-ID"));
+        }
+    }
+
+    @Test
+    public void testDeploymentFeaturesHeaderSentToTranslatingAdapter() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, "/to-chat-completions" + MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            // a client-supplied value must not survive: the header is set by the core, not forwarded
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-to-chat-completions", false),
+                    "api-key", "proxyKey1", "X-DIAL-DEPLOYMENT-FEATURES", "spoofed");
+
+            assertEquals(200, response.status());
+            FeaturesData features = ProxyUtil.convertToObject(
+                    captured.get().getHeader("X-DIAL-DEPLOYMENT-FEATURES"), FeaturesData.class);
+            assertNotNull(features);
+            assertFalse(features.isMaxTokensSupported());
+            assertFalse(features.isCustomTemperatureSupported());
+            assertTrue(features.isTools());
+        }
+    }
+
+    @Test
+    public void testDeploymentFeaturesHeaderSentToResponsesTranslatingAdapter() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, "/to-responses" + MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-to-responses", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            assertNotNull(captured.get().getHeader("X-DIAL-DEPLOYMENT-FEATURES"));
+        }
+    }
+
+    @Test
+    public void testDeploymentFeaturesHeaderOmittedForPassThroughAdapter() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-ns", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            assertNull(captured.get().getHeader("X-DIAL-DEPLOYMENT-FEATURES"));
         }
     }
 

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -225,6 +225,19 @@
     "claude-no-iface": {
       "type": "chat",
       "endpoint": "http://localhost:4848/v1/chat/completions"
+    },
+    "claude-to-chat-completions": {
+      "type": "chat",
+      "features": {
+        "max_tokens_supported": false,
+        "custom_temperature_supported": false,
+        "tools_supported": true
+      },
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848/to-chat-completions"} }
+    },
+    "claude-to-responses": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848/to-responses"} }
     }
   },
   "toolsets": {
@@ -313,7 +326,9 @@
         "claude-limited": {"minute": "10", "day": "10"},
         "claude-upstream": {"minute": "100000", "day": "10000000"},
         "claude-override": {"minute": "100000", "day": "10000000"},
-        "claude-no-iface": {"minute": "100000", "day": "10000000"}
+        "claude-no-iface": {"minute": "100000", "day": "10000000"},
+        "claude-to-chat-completions": {"minute": "100000", "day": "10000000"},
+        "claude-to-responses": {"minute": "100000", "day": "10000000"}
       }
     },
     "vstore_user": {


### PR DESCRIPTION
### Applicable issues

- feat #1618

### Description of changes

- Anthropic Messages requests routed to a translating adapter (`base_url` containing `to-chat-completions` or `to-responses`) now carry an `X-DIAL-DEPLOYMENT-FEATURES` header with the deployment features as JSON, so the translator can drop parameters the target API does not support.

### Checklist

- [x] Title of the pull request
  follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (MessagesApiTest 15/15, checkstyle clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
