### PR TITLE
feat: add offline credentials endpoints

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/ResourceCredentials.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/ResourceCredentials.java
@@ -23,6 +23,9 @@ public class ResourceCredentials {
     private String accessToken;
     @ToString.Exclude
     private String refreshToken;
+    /** Set only during sign-in so the caller can verify who the exchange was for; never returned to clients. */
+    @ToString.Exclude
+    private String idToken;
     private long createdAt;
     private long updatedAt;
     private Long expiresInSeconds;
@@ -31,4 +34,6 @@ public class ResourceCredentials {
     // Owner's recorded consent to offline (on-behalf-of) use of this credential. Legacy blobs deserialize as false.
     @JsonAlias({"offlineUsageConsent", "offline_usage_consent"})
     private boolean offlineUsageConsent;
+    /** Issuer, recorded at sign-in because a refresh runs with no caller token to derive it from. */
+    private String issuer;
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenResponse.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/data/credentials/TokenResponse.java
@@ -22,4 +22,8 @@ public class TokenResponse {
 
     @JsonProperty("expires_in")
     private Long expiresIn;
+
+    /** Present when {@code openid} was requested; only offline-credentials sign-in reads it. */
+    @JsonProperty("id_token")
+    private String idToken;
 }

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/factory/OauthResourceCredentialsFactory.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/factory/OauthResourceCredentialsFactory.java
@@ -28,6 +28,7 @@ public class OauthResourceCredentialsFactory implements ResourceCredentialsFacto
             .authenticationType(signInRequest.getAuthenticationType())
             .accessToken(tokenResponse.getAccessToken())
             .refreshToken(tokenResponse.getRefreshToken())
+            .idToken(tokenResponse.getIdToken())
             .expiresInSeconds(tokenResponse.getExpiresIn())
             .createdAt(currentTime)
             .updatedAt(currentTime)

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceAuthSettingsService.java
@@ -5,6 +5,7 @@ import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.ResourceAuthStatus;
 import com.epam.aidial.core.config.SecuredResource;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
 import com.epam.aidial.core.credentials.data.registration.ClientRegistration;
@@ -185,6 +186,15 @@ public class ResourceAuthSettingsService {
     private boolean hasUnexpiredApplicationCredentials(List<ResourceCredentials> all) {
         return all.stream().anyMatch(c -> c.getCredentialsLevel() == CredentialsLevel.APPLICATION
                 && hasUnexpiredToken(c));
+    }
+
+    /**
+     * Whether a single credentials record exists and is still usable. An expired access token counts as usable when
+     * a refresh token is present, which is the normal state of a long-lived offline credential.
+     */
+    public boolean hasUnexpiredCredentials(CredentialsDescriptor credentialsDescriptor) {
+        ResourceCredentials credentials = resourceCredentialsService.getResourceCredentials(credentialsDescriptor);
+        return credentials != null && hasUnexpiredToken(credentials);
     }
 
     private boolean hasUnexpiredToken(ResourceCredentials credentials) {

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -48,6 +49,18 @@ public class ResourceCredentialsService {
                                        ResourceAuthSettings resourceAuthSettings,
                                        ResourceSignInRequest resourceSignInRequest,
                                        String userId) {
+        addResourceCredentials(credentialsDescriptor, resourceAuthSettings, resourceSignInRequest, userId, credentials -> { });
+    }
+
+    /**
+     * As above, but runs {@code verifier} on the issued credentials <b>before</b> anything is stored, so a caller
+     * can refuse them. The ID token is verification material and is cleared rather than persisted.
+     */
+    public void addResourceCredentials(CredentialsDescriptor credentialsDescriptor,
+                                       ResourceAuthSettings resourceAuthSettings,
+                                       ResourceSignInRequest resourceSignInRequest,
+                                       String userId,
+                                       Consumer<ResourceCredentials> verifier) {
         log.info("Adding resource credentials for resourceId={}, bucket={}, credentialsLevel={}",
                 credentialsDescriptor.getResourceId(), credentialsDescriptor.getBucketName(), resourceSignInRequest.getCredentialsLevel());
         ResourceCredentialsFactory factory = resourceCredentialsFactoryProvider.getFactory(resourceSignInRequest.getAuthenticationType());
@@ -58,6 +71,9 @@ public class ResourceCredentialsService {
             // Offline-usage consent is per-user; record it so the on-behalf-of retrieval path can gate on it.
             resourceCredentials.setOfflineUsageConsent(resourceSignInRequest.isOfflineUsageConsent());
         }
+
+        verifier.accept(resourceCredentials);
+        resourceCredentials.setIdToken(null);
 
         byte[] encryptedBody = encrypt(credentialsDescriptor, resourceCredentials);
         resourceService.putResourceBytes(credentialsDescriptor.toResourceDescriptor(), encryptedBody, EtagHeader.ANY);
@@ -188,6 +204,13 @@ public class ResourceCredentialsService {
                 throw new IllegalArgumentException("Can't delete other user's personal credentials");
             }
         }
+    }
+
+    /** Deletes one record addressed directly, for records that are not app-scoped. */
+    public boolean deleteCredentialsRecord(CredentialsDescriptor credentialsDescriptor) {
+        log.info("Deleting resource credentials for resourceId={}, bucket={}",
+                credentialsDescriptor.getResourceId(), credentialsDescriptor.getBucketName());
+        return resourceService.deleteResource(credentialsDescriptor.toResourceDescriptor(), EtagHeader.ANY);
     }
 
     @Nullable
@@ -339,7 +362,11 @@ public class ResourceCredentialsService {
         resourceCredentials.setExpiresInSeconds(newAccessTokenResponse.getExpiresIn());
         resourceCredentials.setUpdatedAt(timeProvider.getCurrentTime());
         resourceCredentials.setAccessToken(newAccessTokenResponse.getAccessToken());
-        resourceCredentials.setRefreshToken(newAccessTokenResponse.getRefreshToken());
+        // RFC 6749 §6: no refresh token in the response leaves the existing one in force. Overwriting it with
+        // null would end offline access on providers that do not rotate.
+        if (newAccessTokenResponse.getRefreshToken() != null) {
+            resourceCredentials.setRefreshToken(newAccessTokenResponse.getRefreshToken());
+        }
         log.debug("Finished updating expired token for Resource: {}", resourceId);
     }
 

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/service/ResourceCredentialsService.java
@@ -213,11 +213,20 @@ public class ResourceCredentialsService {
         return resourceService.deleteResource(credentialsDescriptor.toResourceDescriptor(), EtagHeader.ANY);
     }
 
+    /**
+     * NONE has no credential by definition; DIAL_NATIVE has none <b>per service</b> — a record left from before a
+     * switch to either type must never be served, and APPLICATION-level purging cannot reach USER-level leftovers.
+     */
+    private static boolean hasNoServiceCredential(ResourceAuthSettings authSettings) {
+        AuthenticationType type = authSettings.getAuthenticationType();
+        return type == AuthenticationType.NONE || type == AuthenticationType.DIAL_NATIVE;
+    }
+
     @Nullable
     public ResourceCredentials getRefreshedResourceCredentials(CredentialsLocator credentialsLocator,
                                                                ResourceAuthSettings authSettings,
                                                                String userSub) {
-        if (authSettings.getAuthenticationType() == AuthenticationType.NONE) {
+        if (hasNoServiceCredential(authSettings)) {
             return null;
         }
 
@@ -263,7 +272,7 @@ public class ResourceCredentialsService {
     public ResourceCredentials getRefreshedUserCredentials(CredentialsLocator credentialsLocator,
                                                            ResourceAuthSettings authSettings,
                                                            String ownerUserId) {
-        if (authSettings.getAuthenticationType() == AuthenticationType.NONE) {
+        if (hasNoServiceCredential(authSettings)) {
             return null;
         }
 

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
@@ -391,7 +391,7 @@ class ResourceCredentialsServiceTest {
                 .thenReturn(oauthTokenRefreshStrategy);
         when(oauthTokenRefreshStrategy.requiresTokenRefresh(decryptedResourceCredentials)).thenReturn(true);
 
-        TokenResponse mockedTokenResponse = new TokenResponse("newAccessToken", "newRefreshToken", 3600L);
+        TokenResponse mockedTokenResponse = TokenResponse.builder().accessToken("newAccessToken").refreshToken("newRefreshToken").expiresIn(3600L).build();
         Mockito.when(tokenService.getToken("testResourceId", authSettings, "refreshTokenValue"))
                 .thenReturn(mockedTokenResponse);
         Mockito.doAnswer(invocation -> {
@@ -408,6 +408,58 @@ class ResourceCredentialsServiceTest {
         Assertions.assertEquals("newAccessToken", result.getAccessToken());
         Assertions.assertEquals("newRefreshToken", result.getRefreshToken());
         Mockito.verify(tokenService).getToken("testResourceId", authSettings, "refreshTokenValue");
+    }
+
+    @Test
+    void testGetAndRefreshCredentials_ResponseWithoutRefreshTokenKeepsTheExistingOne() {
+        // RFC 6749 §6: a refresh response that omits refresh_token leaves the existing one in force. Providers
+        // that do not rotate return exactly this, and dropping it would end offline access permanently.
+        CredentialsLocator credentialsLocator = Mockito.mock(CredentialsLocator.class);
+        CredentialsDescriptor credentialsDescriptor = Mockito.mock(CredentialsDescriptor.class);
+        Map<CredentialsLevel, CredentialsDescriptor> descriptors = new EnumMap<>(CredentialsLevel.class);
+        descriptors.put(CredentialsLevel.USER, credentialsDescriptor);
+        when(credentialsLocator.getCredentialsDescriptors()).thenReturn(descriptors);
+        ResourceAuthSettings authSettings = Mockito.mock(ResourceAuthSettings.class);
+        when(authSettings.getAuthenticationType()).thenReturn(AuthenticationType.OAUTH);
+
+        Mockito.when(credentialsDescriptor.getResourceId()).thenReturn("testResourceId");
+        Mockito.when(credentialsDescriptor.getBucketName()).thenReturn("testBucket");
+        Mockito.when(credentialsDescriptor.getFullPath()).thenReturn("path");
+        Mockito.when(credentialsDescriptor.toResourceDescriptor()).thenReturn(Mockito.mock(ResourceDescriptor.class));
+
+        byte[] encryptedBytes = "mockEncryptedData".getBytes(StandardCharsets.UTF_8);
+        byte[] decryptedBytes = """
+                {
+                    "resourceId": "testResourceId",
+                    "credentialsLevel": "USER",
+                    "userSub": "userSub",
+                    "authenticationType": "OAUTH",
+                    "accessToken": "expiredAccessToken",
+                    "refreshToken": "longLivedRefreshToken",
+                    "updatedAt": "1",
+                    "expiresInSeconds": "100"
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        Mockito.when(credentialEncryptionService.decrypt(any(), eq(encryptedBytes), any())).thenReturn(decryptedBytes);
+        ResourceCredentials decryptedResourceCredentials = JsonMapperUtil.convertToObject(decryptedBytes, ResourceCredentials.class);
+        when(tokenRefreshStrategyFactory.getTokenValidatorStrategy(AuthenticationType.OAUTH))
+                .thenReturn(oauthTokenRefreshStrategy);
+        when(oauthTokenRefreshStrategy.requiresTokenRefresh(decryptedResourceCredentials)).thenReturn(true);
+
+        Mockito.when(tokenService.getToken("testResourceId", authSettings, "longLivedRefreshToken"))
+                .thenReturn(TokenResponse.builder().accessToken("newAccessToken").expiresIn(3600L).build());
+        Mockito.doAnswer(invocation -> {
+            Function<byte[], byte[]> callbackFunction = invocation.getArgument(1);
+            callbackFunction.apply(encryptedBytes);
+            return new ResourceItemMetadata();
+        }).when(resourceService).computeResourceBytes(any(), any());
+
+        ResourceCredentials result = service.getRefreshedResourceCredentials(credentialsLocator, authSettings, "userSub");
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("newAccessToken", result.getAccessToken());
+        Assertions.assertEquals("longLivedRefreshToken", result.getRefreshToken());
     }
 
     @Test

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/ResourceCredentialsServiceTest.java
@@ -411,6 +411,28 @@ class ResourceCredentialsServiceTest {
     }
 
     @Test
+    void testGetRefreshedResourceCredentials_DialNativeNeverServesLeftoverRecords() {
+        // A USER-level record stored while the service was OAUTH/API_KEY survives a switch to DIAL_NATIVE
+        // (only APPLICATION-level records are purged), so retrieval must refuse by the *current* auth type.
+        ResourceAuthSettings authSettings = Mockito.mock(ResourceAuthSettings.class);
+        when(authSettings.getAuthenticationType()).thenReturn(AuthenticationType.DIAL_NATIVE);
+
+        Assertions.assertNull(service.getRefreshedResourceCredentials(
+                Mockito.mock(CredentialsLocator.class), authSettings, "userSub"));
+        Mockito.verifyNoInteractions(resourceService);
+    }
+
+    @Test
+    void testGetRefreshedUserCredentials_DialNativeNeverServesLeftoverRecords() {
+        ResourceAuthSettings authSettings = Mockito.mock(ResourceAuthSettings.class);
+        when(authSettings.getAuthenticationType()).thenReturn(AuthenticationType.DIAL_NATIVE);
+
+        Assertions.assertNull(service.getRefreshedUserCredentials(
+                Mockito.mock(CredentialsLocator.class), authSettings, "owner"));
+        Mockito.verifyNoInteractions(resourceService);
+    }
+
+    @Test
     void testGetAndRefreshCredentials_ResponseWithoutRefreshTokenKeepsTheExistingOne() {
         // RFC 6749 §6: a refresh response that omits refresh_token leaves the existing one in force. Providers
         // that do not rotate return exactly this, and dropping it would end offline access permanently.

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/service/TokenServiceTest.java
@@ -52,7 +52,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -83,7 +83,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -114,7 +114,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -145,7 +145,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -200,7 +200,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -236,7 +236,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -279,7 +279,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, signInRequest);
 
@@ -326,7 +326,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("new-access", "new-refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("new-access").refreshToken("new-refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, "old-refresh-token");
 
@@ -358,7 +358,7 @@ class TokenServiceTest {
                 .build();
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
-                .thenReturn(new TokenResponse("new-access", "new-refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("new-access").refreshToken("new-refresh").expiresIn(3600L).build());
 
         tokenService.getToken("resource-1", authSettings, "old-refresh-token");
 
@@ -382,7 +382,7 @@ class TokenServiceTest {
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_client", "Missing client_id"))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
                 ResourceSignInRequest.builder().code("auth-code").build());
@@ -410,7 +410,7 @@ class TokenServiceTest {
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenThrow(new HttpException(HttpStatus.UNAUTHORIZED, "Authorization server returns 401 error code", Map.of(), null))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
                 ResourceSignInRequest.builder().code("auth-code").build());
@@ -427,7 +427,7 @@ class TokenServiceTest {
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_grant",
                         "Client ID does not match the one used in the initial request."))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
                 ResourceSignInRequest.builder().code("auth-code").build());
@@ -442,7 +442,7 @@ class TokenServiceTest {
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_request", "client_id is required"))
-                .thenReturn(new TokenResponse("access", "refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("access").refreshToken("refresh").expiresIn(3600L).build());
 
         TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(),
                 ResourceSignInRequest.builder().code("auth-code").build());
@@ -506,7 +506,7 @@ class TokenServiceTest {
 
         when(resourceAuthorizationClient.executePost(any(), any(), any(), any(), any()))
                 .thenThrow(oauthError(HttpStatus.BAD_REQUEST, "invalid_client", "Missing client_id"))
-                .thenReturn(new TokenResponse("new-access", "new-refresh", 3600L));
+                .thenReturn(TokenResponse.builder().accessToken("new-access").refreshToken("new-refresh").expiresIn(3600L).build());
 
         TokenResponse response = tokenService.getToken("resource-1", basicAuthSettings(), "old-refresh-token");
 

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -11800,6 +11800,105 @@ paths:
       - lang: cURL
         label: Access Token
         source: "curl -X GET https://chat.<company>.com/v1/user/info \\\n  -H \"Authorization: Bearer YOUR_ACCESS_TOKEN\"          \n"
+  /v1/user/offline-credentials:
+    get:
+      tags:
+      - External Services
+      summary: /v1/user/offline-credentials
+      operationId: getOfflineCredentials
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OfflineCredentialsStatus"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "401":
+          description: Invalid Authentication
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: The server had an error while processing your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+  /v1/user/offline-credentials/signin:
+    post:
+      tags:
+      - External Services
+      summary: /v1/user/offline-credentials/signin
+      operationId: offlineCredentialsSignIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OfflineCredentialsSignInRequest"
+        required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: boolean
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "401":
+          description: Invalid Authentication
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: The server had an error while processing your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+  /v1/user/offline-credentials/signout:
+    post:
+      tags:
+      - External Services
+      summary: /v1/user/offline-credentials/signout
+      operationId: offlineCredentialsSignOut
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: boolean
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "401":
+          description: Invalid Authentication
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: The server had an error while processing your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
   /v1/{deployment_name}/rate:
     post:
       summary: "/v1/{deployment_name}/rate"
@@ -14545,6 +14644,35 @@ components:
           type: string
         url:
           type: string
+    OfflineCredentialsSignInRequest:
+      type: object
+      properties:
+        code:
+          type: string
+        redirectUri:
+          type: string
+    OfflineCredentialsStatus:
+      type: object
+      properties:
+        available:
+          type: boolean
+        connect:
+          $ref: "#/components/schemas/OfflineCredentialsStatusConnect"
+        connected:
+          type: boolean
+    OfflineCredentialsStatusConnect:
+      type: object
+      properties:
+        authorization_endpoint:
+          type: string
+        client_id:
+          type: string
+        redirect_uri:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
     Pattern:
       type: object
     PerRequestReceiver:

--- a/openapi-generator/src/main/java/com/epam/aidial/core/openapi/AnnotationEndpointCollector.java
+++ b/openapi-generator/src/main/java/com/epam/aidial/core/openapi/AnnotationEndpointCollector.java
@@ -33,6 +33,7 @@ import com.epam.aidial.core.server.controller.LimitController;
 import com.epam.aidial.core.server.controller.McpResourceController;
 import com.epam.aidial.core.server.controller.ModelController;
 import com.epam.aidial.core.server.controller.NotificationController;
+import com.epam.aidial.core.server.controller.OfflineCredentialsController;
 import com.epam.aidial.core.server.controller.PerRequestPermissionController;
 import com.epam.aidial.core.server.controller.PublicationController;
 import com.epam.aidial.core.server.controller.RateResponseController;
@@ -92,6 +93,7 @@ public final class AnnotationEndpointCollector {
             MessagesCountTokensController.class,
             ModelController.class,
             NotificationController.class,
+            OfflineCredentialsController.class,
             PerRequestPermissionController.class,
             PublicationController.class,
             RateResponseController.class,

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
@@ -207,6 +207,18 @@ public class ControllerSelector {
             return () -> controller.handle(deploymentId, getter, false);
         });
         get(RouteTemplate.USER_INFO, (proxy, context, pathMatcher) -> new UserInfoController(context));
+        get(RouteTemplate.OFFLINE_CREDENTIALS, (proxy, context, pathMatcher) -> {
+            OfflineCredentialsController controller = new OfflineCredentialsController(proxy, context);
+            return controller::getStatus;
+        });
+        post(RouteTemplate.OFFLINE_CREDENTIALS_OPERATIONS, (proxy, context, pathMatcher) -> {
+            OfflineCredentialsController controller = new OfflineCredentialsController(proxy, context);
+            return switch (pathMatcher.group(1)) {
+                case "signin" -> controller::signIn;
+                case "signout" -> controller::signOut;
+                default -> null;
+            };
+        });
         get(RouteTemplate.USER_CONSENT, (proxy, context, pathMatcher) -> {
             String deploymentId = UrlUtil.decodePath(pathMatcher.group(1));
             ConsentController controller = new ConsentController(context, proxy);

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceCredentialsController.java
@@ -13,7 +13,6 @@ import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
-import com.epam.aidial.core.credentials.exception.EncryptionException;
 import com.epam.aidial.core.credentials.service.AuthorizationHeaderProvider;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.openapi.annotations.ApiOperation;
@@ -47,7 +46,6 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
-import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
@@ -468,44 +466,7 @@ public class ExternalServiceCredentialsController {
     }
 
     private void respondError(String message, Throwable error) {
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-        String body = null;
-
-        switch (error) {
-            case HttpException e -> {
-                status = e.getStatus();
-                body = e.getMessage();
-            }
-            case ResourceNotFoundException resourceNotFoundException -> {
-                status = HttpStatus.NOT_FOUND;
-                body = resourceNotFoundException.getMessage();
-            }
-            case IllegalArgumentException illegalArgumentException -> {
-                status = HttpStatus.BAD_REQUEST;
-                body = illegalArgumentException.getMessage();
-            }
-            case ConstraintViolationException constraintViolationException -> {
-                status = HttpStatus.BAD_REQUEST;
-                body = constraintViolationException.getMessage();
-            }
-            case PermissionDeniedException permissionDeniedException -> {
-                status = HttpStatus.FORBIDDEN;
-                body = permissionDeniedException.getMessage();
-            }
-            case EncryptionException ignored -> {
-                // Never surface crypto internals to the caller.
-                status = HttpStatus.INTERNAL_SERVER_ERROR;
-                body = message;
-            }
-            case null, default -> body = message;
-        }
-
-        // Log server-side failures with the trace id; keep the client body generic.
-        if (status.is5xx()) {
-            log.warn("{} (trace_id={})", message, context.getTraceId(), error);
-        }
-
-        context.respond(status, body);
+        ExternalServiceErrorHandler.respond(context, message, error);
     }
 
     private record ResolvedExternalService(Application application,

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceErrorHandler.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceErrorHandler.java
@@ -1,0 +1,65 @@
+package com.epam.aidial.core.server.controller;
+
+import com.epam.aidial.core.credentials.exception.EncryptionException;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.service.PermissionDeniedException;
+import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import jakarta.validation.ConstraintViolationException;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+/** One error mapping for the external-service and offline-credentials endpoints, which each had their own. */
+@Slf4j
+@UtilityClass
+public class ExternalServiceErrorHandler {
+
+    public static void respond(ProxyContext context, String message, Throwable error) {
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        String body = message;
+
+        switch (error) {
+            case HttpException e -> {
+                status = e.getStatus();
+                body = e.getMessage();
+            }
+            case ResourceNotFoundException e -> {
+                status = HttpStatus.NOT_FOUND;
+                body = e.getMessage();
+            }
+            case PermissionDeniedException e -> {
+                status = HttpStatus.FORBIDDEN;
+                body = e.getMessage();
+            }
+            case IllegalArgumentException e -> {
+                status = HttpStatus.BAD_REQUEST;
+                body = e.getMessage();
+            }
+            case ConstraintViolationException e -> {
+                status = HttpStatus.BAD_REQUEST;
+                body = e.getMessage();
+            }
+            case EncryptionException ignored -> {
+                // Never surface crypto internals to the caller.
+                status = HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+            case null, default -> { }
+        }
+
+        // Log server-side failures with the trace id; keep the client body generic.
+        if (status.is5xx()) {
+            log.warn("{} (trace_id={})", message, context.getTraceId(), error);
+        }
+
+        context.respond(status, body);
+    }
+
+    /** Adapts a future's cause to what the audit log accepts, which classifies by exception type. */
+    public static RuntimeException asRuntime(Throwable error) {
+        if (error == null) {
+            return null;
+        }
+        return error instanceof RuntimeException e ? e : new IllegalStateException(error);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceManagementController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ExternalServiceManagementController.java
@@ -338,28 +338,7 @@ public class ExternalServiceManagementController {
     }
 
     private void respondError(String message, Throwable error) {
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-        String body = null;
-        switch (error) {
-            case HttpException e -> {
-                status = e.getStatus();
-                body = e.getMessage();
-            }
-            case ResourceNotFoundException e -> {
-                status = HttpStatus.NOT_FOUND;
-                body = e.getMessage();
-            }
-            case PermissionDeniedException e -> {
-                status = HttpStatus.FORBIDDEN;
-                body = e.getMessage();
-            }
-            case IllegalArgumentException e -> {
-                status = HttpStatus.BAD_REQUEST;
-                body = e.getMessage();
-            }
-            case null, default -> log.warn(message, error);
-        }
-        context.respond(status, body);
+        ExternalServiceErrorHandler.respond(context, message, error);
     }
 
     private record ResolvedApp(Application application, ResourceDescriptor descriptor, String author, boolean staticApp) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/OfflineCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/OfflineCredentialsController.java
@@ -7,6 +7,7 @@ import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.service.ResourceAuthSettingsService;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
 import com.epam.aidial.core.openapi.annotations.ApiOperation;
 import com.epam.aidial.core.openapi.annotations.ApiResponse;
@@ -43,14 +44,14 @@ public class OfflineCredentialsController {
     private final ProxyContext context;
     private final AsyncTaskExecutor taskExecutor;
     private final ResourceCredentialsService resourceCredentialsService;
+    private final ResourceAuthSettingsService resourceAuthSettingsService;
     private final AccessTokenValidator tokenValidator;
-    private final Proxy proxy;
 
     public OfflineCredentialsController(Proxy proxy, ProxyContext context) {
-        this.proxy = proxy;
         this.context = context;
         this.taskExecutor = proxy.getTaskExecutor();
         this.resourceCredentialsService = proxy.getResourceCredentialsService();
+        this.resourceAuthSettingsService = proxy.getResourceAuthSettingsService();
         this.tokenValidator = proxy.getTokenValidator();
     }
 
@@ -74,7 +75,7 @@ public class OfflineCredentialsController {
         }
         taskExecutor.submit(() -> {
             // Same test the app listing uses, so the two endpoints cannot disagree about one user.
-            boolean connected = proxy.getResourceAuthSettingsService().hasUnexpiredCredentials(descriptor());
+            boolean connected = resourceAuthSettingsService.hasUnexpiredCredentials(descriptor());
             // Resolved only when not connected: a connected caller does not need it, and a provider that cannot
             // be resolved (or carries no offline client) is reported as unavailable rather than as an error —
             // sign-in is where refusing loudly matters.

--- a/server/src/main/java/com/epam/aidial/core/server/controller/OfflineCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/OfflineCredentialsController.java
@@ -1,0 +1,233 @@
+package com.epam.aidial.core.server.controller;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.CredentialsLevel;
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
+import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
+import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
+import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
+import com.epam.aidial.core.openapi.annotations.ApiOperation;
+import com.epam.aidial.core.openapi.annotations.ApiResponse;
+import com.epam.aidial.core.openapi.annotations.ApiSchema;
+import com.epam.aidial.core.openapi.annotations.OpenApiDescriptions;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.OfflineCredentialsSignInRequest;
+import com.epam.aidial.core.server.data.OfflineCredentialsStatus;
+import com.epam.aidial.core.server.log.ExternalServiceAuditLog;
+import com.epam.aidial.core.server.security.AccessTokenValidator;
+import com.epam.aidial.core.server.util.CredentialsDescriptorFactory;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.epam.aidial.core.server.validation.ValidationUtil;
+import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
+import com.epam.aidial.core.storage.http.HttpException;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+
+/**
+ * The user's own offline credentials: one refresh token per user, platform-wide, never handed to any application.
+ *
+ * <p>Deliberately not on the app-scoped external-service endpoints: those reach their blobs through
+ * {@code parseExternalServiceScope}, whose required shape these credentials sit outside.
+ */
+@Slf4j
+public class OfflineCredentialsController {
+
+    private final ProxyContext context;
+    private final AsyncTaskExecutor taskExecutor;
+    private final ResourceCredentialsService resourceCredentialsService;
+    private final AccessTokenValidator tokenValidator;
+    private final Proxy proxy;
+
+    public OfflineCredentialsController(Proxy proxy, ProxyContext context) {
+        this.proxy = proxy;
+        this.context = context;
+        this.taskExecutor = proxy.getTaskExecutor();
+        this.resourceCredentialsService = proxy.getResourceCredentialsService();
+        this.tokenValidator = proxy.getTokenValidator();
+    }
+
+    /** Status plus, when not connected, the parameters chat needs to build the authorization URL. */
+    @ApiOperation(
+            method = "GET",
+            path = "/v1/user/offline-credentials",
+            operationId = "getOfflineCredentials",
+            tags = {"External Services"},
+            responses = {
+                    @ApiResponse(code = 200, description = OpenApiDescriptions.RESPONSE_SUCCESS,
+                            body = @ApiSchema(implementation = OfflineCredentialsStatus.class)),
+                    @ApiResponse(code = 400),
+                    @ApiResponse(code = 401),
+                    @ApiResponse(code = 500)
+            }
+    )
+    public Future<?> getStatus() {
+        if (rejectNonUserCaller()) {
+            return Future.succeededFuture();
+        }
+        taskExecutor.submit(() -> {
+            // Same test the app listing uses, so the two endpoints cannot disagree about one user.
+            boolean connected = proxy.getResourceAuthSettingsService().hasUnexpiredCredentials(descriptor());
+            // Resolved only when not connected: a connected caller does not need it, and a provider that cannot
+            // be resolved (or carries no offline client) is reported as unavailable rather than as an error —
+            // sign-in is where refusing loudly matters.
+            return OfflineCredentialsStatus.of(connected, connected ? null : offlineClientOrNull());
+        })
+                .onSuccess(status -> context.respond(HttpStatus.OK, status))
+                .onFailure(error -> respondError("Can't read offline credentials", error));
+        return Future.succeededFuture();
+    }
+
+    /** Exchanges the authorization code and stores the refresh token in the caller's own bucket. */
+    @ApiOperation(
+            method = "POST",
+            path = "/v1/user/offline-credentials/signin",
+            operationId = "offlineCredentialsSignIn",
+            requestBody = @ApiSchema(implementation = OfflineCredentialsSignInRequest.class),
+            tags = {"External Services"},
+            responses = {
+                    @ApiResponse(code = 200, description = OpenApiDescriptions.RESPONSE_SUCCESS,
+                            body = @ApiSchema(implementation = Boolean.class)),
+                    @ApiResponse(code = 400),
+                    @ApiResponse(code = 401),
+                    @ApiResponse(code = 500)
+            }
+    )
+    public Future<?> signIn() {
+        if (rejectNonUserCaller()) {
+            return Future.succeededFuture();
+        }
+        context.getRequest()
+                .body()
+                .compose(body -> {
+                    OfflineCredentialsSignInRequest request =
+                            ProxyUtil.convertToObject(body, OfflineCredentialsSignInRequest.class);
+                    ValidationUtil.validate(request);
+                    return taskExecutor.submit(() -> {
+                        ResourceAuthSettings offlineClient = requireOfflineClient();
+
+                        ResourceSignInRequest signIn = ResourceSignInRequest.builder()
+                                .url(CredentialsDescriptorFactory.OFFLINE_CREDENTIALS_ID)
+                                .credentialsLevel(CredentialsLevel.USER)
+                                .authenticationType(AuthenticationType.OAUTH)
+                                .code(request.getCode())
+                                .redirectUri(request.getRedirectUri())
+                                .offlineUsageConsent(true)
+                                .build();
+
+                        resourceCredentialsService.addResourceCredentials(
+                                descriptor(), offlineClient, signIn, context.getUserId(), this::verifyIssuedForCaller);
+                        return true;
+                    });
+                })
+                .onComplete(audited("SIGN_IN"))
+                .onSuccess(added -> context.respond(HttpStatus.OK, added))
+                .onFailure(error -> respondError("Can't sign in for offline credentials", error));
+        return Future.succeededFuture();
+    }
+
+    /** Deletes the credentials — every scheduled run for this user stops, in every application. */
+    @ApiOperation(
+            method = "POST",
+            path = "/v1/user/offline-credentials/signout",
+            operationId = "offlineCredentialsSignOut",
+            tags = {"External Services"},
+            responses = {
+                    @ApiResponse(code = 200, description = OpenApiDescriptions.RESPONSE_SUCCESS,
+                            body = @ApiSchema(implementation = Boolean.class)),
+                    @ApiResponse(code = 400),
+                    @ApiResponse(code = 401),
+                    @ApiResponse(code = 500)
+            }
+    )
+    public Future<?> signOut() {
+        if (rejectNonUserCaller()) {
+            return Future.succeededFuture();
+        }
+        taskExecutor.submit(() -> resourceCredentialsService.deleteCredentialsRecord(descriptor()))
+                .onComplete(audited("SIGN_OUT"))
+                .onSuccess(deleted -> context.respond(HttpStatus.OK, deleted))
+                .onFailure(error -> respondError("Can't sign out of offline credentials", error));
+        return Future.succeededFuture();
+    }
+
+    /** With PKCE deferred this is the only check refusing code injection, so it fails closed without an ID token. */
+    private void verifyIssuedForCaller(ResourceCredentials credentials) {
+        String idToken = credentials.getIdToken();
+        if (idToken == null) {
+            throw new IllegalArgumentException(
+                    "The identity provider returned no ID token, so the credentials cannot be attributed to the caller");
+        }
+        String tokenUserId = tokenValidator.resolveIdTokenUserId(authHeader(), idToken);
+        if (tokenUserId == null || !tokenUserId.equals(context.getUserId())) {
+            throw new HttpException(HttpStatus.FORBIDDEN,
+                    "The authorization code belongs to a different user than the caller");
+        }
+        // Refresh runs with the user absent, so the provider must be recoverable from the record alone.
+        credentials.setIssuer(tokenValidator.extractIdTokenIssuer(idToken));
+    }
+
+    /** Audits the whole operation: a body rejected before storage is still a failed attempt. */
+    private <T> Handler<AsyncResult<T>> audited(String action) {
+        return result -> ExternalServiceAuditLog.offlineCredentials(
+                context, action, ExternalServiceErrorHandler.asRuntime(result.cause()));
+    }
+
+    /** Refuses loudly what the status endpoint reports as unavailable; chat should have checked there first. */
+    private ResourceAuthSettings requireOfflineClient() {
+        ResourceAuthSettings offlineClient;
+        try {
+            offlineClient = tokenValidator.resolveOfflineClient(authHeader());
+        } catch (JWTDecodeException e) {
+            // An opaque access token carries no issuer, so with several providers configured there is no way to
+            // tell which one to obtain offline credentials from.
+            throw new HttpException(HttpStatus.BAD_REQUEST,
+                    "Offline credentials are not available for this identity provider");
+        }
+        if (offlineClient == null) {
+            throw new HttpException(HttpStatus.BAD_REQUEST,
+                    "Offline credentials are not configured for this identity provider");
+        }
+        return offlineClient;
+    }
+
+    /** For status only: every way the feature can be unusable collapses into "not available". */
+    private ResourceAuthSettings offlineClientOrNull() {
+        try {
+            return tokenValidator.resolveOfflineClient(authHeader());
+        } catch (JWTDecodeException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private String authHeader() {
+        return context.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
+    }
+
+    private CredentialsDescriptor descriptor() {
+        return CredentialsDescriptorFactory.offlineCredentials(context);
+    }
+
+    /** These credentials belong to a person, so the caller must be one — not an app, not a userless key. */
+    private boolean rejectNonUserCaller() {
+        if (context.getApiKeyData().getPerRequestKey() != null) {
+            context.respond(HttpStatus.UNAUTHORIZED, "Offline credentials cannot be managed with a per-request key");
+            return true;
+        }
+        if (context.getUserId() == null) {
+            context.respond(HttpStatus.UNAUTHORIZED, "Offline credentials can only be managed by a signed-in user");
+            return true;
+        }
+        return false;
+    }
+
+    private void respondError(String message, Throwable error) {
+        ExternalServiceErrorHandler.respond(context, message, error);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/controller/OfflineCredentialsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/OfflineCredentialsController.java
@@ -18,6 +18,7 @@ import com.epam.aidial.core.server.data.OfflineCredentialsSignInRequest;
 import com.epam.aidial.core.server.data.OfflineCredentialsStatus;
 import com.epam.aidial.core.server.log.ExternalServiceAuditLog;
 import com.epam.aidial.core.server.security.AccessTokenValidator;
+import com.epam.aidial.core.server.service.PermissionDeniedException;
 import com.epam.aidial.core.server.util.CredentialsDescriptorFactory;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.validation.ValidationUtil;
@@ -166,8 +167,8 @@ public class OfflineCredentialsController {
         }
         String tokenUserId = tokenValidator.resolveIdTokenUserId(authHeader(), idToken);
         if (tokenUserId == null || !tokenUserId.equals(context.getUserId())) {
-            throw new HttpException(HttpStatus.FORBIDDEN,
-                    "The authorization code belongs to a different user than the caller");
+            // PermissionDeniedException, so the audit event records DENIED rather than a generic ERROR.
+            throw new PermissionDeniedException("The authorization code belongs to a different user than the caller");
         }
         // Refresh runs with the user absent, so the provider must be recoverable from the record alone.
         credentials.setIssuer(tokenValidator.extractIdTokenIssuer(idToken));

--- a/server/src/main/java/com/epam/aidial/core/server/data/OfflineCredentialsSignInRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/OfflineCredentialsSignInRequest.java
@@ -1,0 +1,18 @@
+package com.epam.aidial.core.server.data;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+public class OfflineCredentialsSignInRequest {
+
+    @NotBlank(message = "code should be specified")
+    @ToString.Exclude
+    private String code;
+
+    @NotBlank(message = "redirect_uri should be specified")
+    @JsonAlias({"redirectUri", "redirect_uri"})
+    private String redirectUri;
+}

--- a/server/src/main/java/com/epam/aidial/core/server/data/OfflineCredentialsStatus.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/OfflineCredentialsStatus.java
@@ -1,0 +1,36 @@
+package com.epam.aidial.core.server.data;
+
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Whether the caller has offline credentials and, when they do not, what chat needs to build the authorization URL.
+ * Carries only non-secret settings — the client secret stays in core, which performs the exchange.
+ *
+ * <p>{@code available} distinguishes "not connected yet" from "cannot connect": the caller's identity provider may
+ * carry no offline client at all, and chat should not offer a connect flow that can only end in an error.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record OfflineCredentialsStatus(boolean connected, boolean available, @JsonProperty("connect") Connect connect) {
+
+    public static OfflineCredentialsStatus of(boolean connected, ResourceAuthSettings offlineClient) {
+        if (connected || offlineClient == null) {
+            return new OfflineCredentialsStatus(connected, connected || offlineClient != null, null);
+        }
+        return new OfflineCredentialsStatus(false, true, new Connect(
+                offlineClient.getAuthorizationEndpoint(),
+                offlineClient.getClientId(),
+                offlineClient.getRedirectUri(),
+                offlineClient.getScopesSupported()));
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Connect(@JsonProperty("authorization_endpoint") String authorizationEndpoint,
+                          @JsonProperty("client_id") String clientId,
+                          @JsonProperty("redirect_uri") String redirectUri,
+                          @JsonProperty("scopes") List<String> scopes) {
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/data/OfflineCredentialsStatus.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/OfflineCredentialsStatus.java
@@ -18,7 +18,7 @@ public record OfflineCredentialsStatus(boolean connected, boolean available, @Js
 
     public static OfflineCredentialsStatus of(boolean connected, ResourceAuthSettings offlineClient) {
         if (connected || offlineClient == null) {
-            return new OfflineCredentialsStatus(connected, connected || offlineClient != null, null);
+            return new OfflineCredentialsStatus(connected, connected, null);
         }
         return new OfflineCredentialsStatus(false, true, new Connect(
                 offlineClient.getAuthorizationEndpoint(),

--- a/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
@@ -281,6 +281,15 @@ public enum RouteTemplate {
             "^/v1/user/info$",
             "/v1/user/info"
     ),
+    // The caller's own offline credentials: status plus the parameters chat needs to start the flow.
+    OFFLINE_CREDENTIALS(
+            "^/v1/user/offline-credentials$",
+            "/v1/user/offline-credentials"
+    ),
+    OFFLINE_CREDENTIALS_OPERATIONS(
+            "^/v1/user/offline-credentials/(signin|signout)$",
+            "/v1/user/offline-credentials/{operation}"
+    ),
     APP_SCHEMAS(
             "^/v1/application_type_schemas/(schemas|schema|meta_schema)$",
             "/v1/application_type_schemas/{operation}"

--- a/server/src/main/java/com/epam/aidial/core/server/log/ExternalServiceAuditLog.java
+++ b/server/src/main/java/com/epam/aidial/core/server/log/ExternalServiceAuditLog.java
@@ -33,19 +33,36 @@ public final class ExternalServiceAuditLog {
     /** One event per OBO retrieval outcome; {@code error} is {@code null} on success. */
     public static void oboRetrieval(ProxyContext context, String applicationId, String externalServiceId,
                                     String ownerUserId, RuntimeException error) {
-        String outcome = switch (error) {
+        // reason echoes only the exception message, never a response body or secret — keep it that way.
+        AUDIT.info("event=obo_credential_retrieval outcome={} actor={} owner_user_id={} application_id={} "
+                        + "external_service_id={} trace_id={}{}",
+                outcomeOf(error), actorEvidence(context), sanitizeToken(ownerUserId), sanitizeToken(applicationId),
+                sanitizeToken(externalServiceId), context.getTraceId(), reasonOf(error));
+    }
+
+    /**
+     * One event per change to a user's own offline credentials. The subject is the caller: these endpoints are
+     * self-service, so actor and owner are the same person.
+     */
+    public static void offlineCredentials(ProxyContext context, String action, RuntimeException error) {
+        AUDIT.info("event=offline_credentials action={} outcome={} actor={} user_id={} trace_id={}{}",
+                sanitizeToken(action), outcomeOf(error), actorEvidence(context),
+                sanitizeToken(context.getUserId()), context.getTraceId(),
+                reasonOf(error));
+    }
+
+    private static String outcomeOf(RuntimeException error) {
+        return switch (error) {
             case null -> "SUCCESS";
             case ConsentRequiredException ignored -> "CONSENT_REQUIRED";
             case PermissionDeniedException ignored -> "DENIED";
             case ResourceNotFoundException ignored -> "NOT_FOUND";
             default -> "ERROR";
         };
-        // reason echoes only the exception message, never a response body or secret — keep it that way.
-        AUDIT.info("event=obo_credential_retrieval outcome={} actor={} owner_user_id={} application_id={} "
-                        + "external_service_id={} trace_id={}{}",
-                outcome, actorEvidence(context), sanitizeToken(ownerUserId), sanitizeToken(applicationId),
-                sanitizeToken(externalServiceId), context.getTraceId(),
-                error == null ? "" : " reason=\"%s\"".formatted(sanitizeReason(error.getMessage())));
+    }
+
+    private static String reasonOf(RuntimeException error) {
+        return error == null ? "" : " reason=\"%s\"".formatted(sanitizeReason(error.getMessage()));
     }
 
     // Non-secret evidence of the calling actor: the DIAL key's project and/or the workload JWT's azp. Both are

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessTokenValidator.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessTokenValidator.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.security;
 import com.auth0.jwk.UrlJwkProvider;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import io.vertx.core.Future;
@@ -124,6 +125,77 @@ public class AccessTokenValidator {
                     /* we don't need to keep the failed response any longer */
                     userInfoCache.remove(accessToken);
                 });
+    }
+
+    /**
+     * The offline client of the provider that issued the caller's token, or {@code null} when that provider has
+     * none configured. The provider itself stays inside this package.
+     *
+     * @throws IllegalArgumentException when no token is presented or no provider matches.
+     * @throws JWTDecodeException when the access token is opaque, so the issuer cannot be read from it.
+     */
+    public ResourceAuthSettings resolveOfflineClient(String authHeader) {
+        return resolveProvider(authHeader).getOfflineClient();
+    }
+
+    /**
+     * As above, for a recorded issuer — the refresh path, where there is no caller token to match on.
+     *
+     * @throws IllegalArgumentException when no provider matches.
+     */
+    public ResourceAuthSettings resolveOfflineClientByIssuer(String issuer) {
+        return resolveProviderByIssuer(issuer).getOfflineClient();
+    }
+
+    /** The user id the caller's provider derives from an ID token, via the same {@code userIdPath} as a request. */
+    public String resolveIdTokenUserId(String authHeader, String idToken) {
+        return resolveProvider(authHeader).extractUserIdFromIdToken(idToken);
+    }
+
+    /** Issuer claim of an ID token, recorded at sign-in so a later refresh can find the provider again. */
+    public String extractIdTokenIssuer(String idToken) {
+        return IdentityProvider.decodeJwtToken(idToken).getIssuer();
+    }
+
+    /**
+     * The provider that issued the caller's token. A userinfo-only provider carries no {@code issuerPattern} and so
+     * can never match here, and cannot offer offline credentials.
+     *
+     * @throws IllegalArgumentException when no token is presented or no provider matches.
+     * @throws JWTDecodeException when the access token is opaque, so the issuer cannot be read from it.
+     */
+    IdentityProvider resolveProvider(String authHeader) {
+        if (providers.size() == 1) {
+            return providers.get(0);
+        }
+        String accessToken = extractTokenFromHeader(authHeader);
+        if (accessToken == null) {
+            throw new IllegalArgumentException("Access token must be presented in Auth header");
+        }
+        return resolveProviderByIssuer(IdentityProvider.decodeJwtToken(accessToken).getIssuer());
+    }
+
+    /**
+     * The provider for a recorded issuer, for refreshes where there is no caller token to match on.
+     *
+     * @throws IllegalArgumentException when no provider matches.
+     */
+    IdentityProvider resolveProviderByIssuer(String issuer) {
+        if (providers.size() == 1) {
+            IdentityProvider provider = providers.get(0);
+            // The only candidate, but an issuer it explicitly disclaims means the record was minted by an identity
+            // provider that is no longer configured — refreshing it against this one would use the wrong client.
+            if (issuer != null && provider.hasIssuerPattern() && !provider.matchesIssuer(issuer)) {
+                throw new IllegalArgumentException("Unknown Identity Provider for issuer: " + issuer);
+            }
+            return provider;
+        }
+        for (IdentityProvider idp : providers) {
+            if (idp.matchesIssuer(issuer)) {
+                return idp;
+            }
+        }
+        throw new IllegalArgumentException("Unknown Identity Provider for issuer: " + issuer);
     }
 
     private Future<UserInfoResult> createUserInfoResultFuture(String accessToken, IdentityProvider idp) {

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessTokenValidator.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessTokenValidator.java
@@ -165,12 +165,13 @@ public class AccessTokenValidator {
      * @throws JWTDecodeException when the access token is opaque, so the issuer cannot be read from it.
      */
     IdentityProvider resolveProvider(String authHeader) {
-        if (providers.size() == 1) {
-            return providers.get(0);
-        }
         String accessToken = extractTokenFromHeader(authHeader);
         if (accessToken == null) {
             throw new IllegalArgumentException("Access token must be presented in Auth header");
+        }
+        // The single-provider answer never needs the issuer, which keeps opaque tokens usable there.
+        if (providers.size() == 1) {
+            return providers.get(0);
         }
         return resolveProviderByIssuer(IdentityProvider.decodeJwtToken(accessToken).getIssuer());
     }

--- a/server/src/main/java/com/epam/aidial/core/server/security/IdentityProvider.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/IdentityProvider.java
@@ -459,12 +459,17 @@ public class IdentityProvider {
         return promise.future().onFailure(error -> log.warn("Can't extract claims from user info endpoint '{}':", userInfoUrl, error));
     }
 
-    private ExtractedClaims from(DecodedJWT jwt) {
-        String userKey = jwt.getClaim(loggingKey).asString();
+    private static Map<String, Object> claimsOf(DecodedJWT jwt) {
         Map<String, Object> map = new HashMap<>();
         for (Map.Entry<String, Claim> e : jwt.getClaims().entrySet()) {
             map.put(e.getKey(), e.getValue().as(Object.class));
         }
+        return map;
+    }
+
+    private ExtractedClaims from(DecodedJWT jwt) {
+        String userKey = jwt.getClaim(loggingKey).asString();
+        Map<String, Object> map = claimsOf(jwt);
         logClaims(map);
         return toExtractedClaims(map, extractUserRoles(map), userKey);
     }
@@ -506,12 +511,23 @@ public class IdentityProvider {
         }
     }
 
+    /** The user id this provider would derive from an ID token, via the same {@code userIdPath} as a request. */
+    String extractUserIdFromIdToken(String idToken) {
+        return extractStringClaim(claimsOf(decodeJwtToken(idToken)), userIdPath);
+    }
+
+    /** Whether this provider claims the given issuer. False when no {@code issuerPattern} is configured. */
+    boolean matchesIssuer(String issuer) {
+        return issuerPattern != null && issuer != null && issuerPattern.matcher(issuer).matches();
+    }
+
+    /** Whether the provider can disclaim an issuer at all — without a pattern, a non-match proves nothing. */
+    boolean hasIssuerPattern() {
+        return issuerPattern != null;
+    }
+
     boolean match(DecodedJWT jwt) {
-        if (issuerPattern == null) {
-            return false;
-        }
-        String issuer = jwt.getIssuer();
-        return issuerPattern.matcher(issuer).matches();
+        return matchesIssuer(jwt.getIssuer());
     }
 
     boolean hasUserinfoUrl() {

--- a/server/src/main/java/com/epam/aidial/core/server/security/IdentityProvider.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/IdentityProvider.java
@@ -516,7 +516,6 @@ public class IdentityProvider {
         return extractStringClaim(claimsOf(decodeJwtToken(idToken)), userIdPath);
     }
 
-    /** Whether this provider claims the given issuer. False when no {@code issuerPattern} is configured. */
     boolean matchesIssuer(String issuer) {
         return issuerPattern != null && issuer != null && issuerPattern.matcher(issuer).matches();
     }

--- a/server/src/main/java/com/epam/aidial/core/server/util/CredentialsDescriptorFactory.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/CredentialsDescriptorFactory.java
@@ -12,6 +12,9 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class CredentialsDescriptorFactory {
 
+    /** Reserved resource id for a user's offline credentials; deliberately not an app-scoped path. */
+    public static final String OFFLINE_CREDENTIALS_ID = "offline";
+
     public static CredentialsDescriptor fromAnyUrl(
             String resourceId,
             CredentialsLevel credentialsLevel,
@@ -71,6 +74,15 @@ public class CredentialsDescriptorFactory {
         String location = BucketBuilder.USER_BUCKET_PATTERN.formatted(ownerUserId);
         String name = proxyContext.getProxy().getEncryptionService().encrypt(location);
         return new BucketInfo(name, location);
+    }
+
+    /**
+     * The caller's offline credentials. The reserved id sits outside the shape
+     * {@code parseExternalServiceScope} requires, so no app-facing endpoint can address it.
+     */
+    public static CredentialsDescriptor offlineCredentials(ProxyContext proxyContext) {
+        BucketInfo bucket = getUserBucketInfo(proxyContext);
+        return new CredentialsDescriptor(OFFLINE_CREDENTIALS_ID, bucket.name(), bucket.location());
     }
 
     public static BucketInfo getPublicBucketInfo() {

--- a/server/src/test/java/com/epam/aidial/core/server/OfflineCredentialsApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/OfflineCredentialsApiTest.java
@@ -264,7 +264,7 @@ public class OfflineCredentialsApiTest extends ResourceBaseTest {
                     .toList();
             assertEquals(1, events.size(), events::toString);
             assertTrue(events.get(0).contains("action=SIGN_IN"), events::toString);
-            assertFalse(events.get(0).contains("outcome=SUCCESS"), events::toString);
+            assertTrue(events.get(0).contains("outcome=DENIED"), events::toString);
         } finally {
             auditLogger.setLevel(previous);
             auditLogger.detachAppender(appender);

--- a/server/src/test/java/com/epam/aidial/core/server/OfflineCredentialsApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/OfflineCredentialsApiTest.java
@@ -1,0 +1,281 @@
+package com.epam.aidial.core.server;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.ResourceAuthSettings;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import io.vertx.core.http.HttpMethod;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OfflineCredentialsApiTest extends ResourceBaseTest {
+
+    private static final String TOKEN_RESPONSE = """
+            {
+                "access_token": "offline-access-token",
+                "refresh_token": "offline-refresh-token",
+                "id_token": "id-token-for-user",
+                "expires_in": 3600
+            }
+            """;
+
+    @BeforeEach
+    void stubProvider() {
+        Mockito.when(validator.resolveOfflineClient(Mockito.any())).thenReturn(ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.OAUTH)
+                .clientId("dial-credentials-manager")
+                .clientSecret("secret")
+                .authorizationEndpoint("http://localhost:9877/authorize")
+                .tokenEndpoint("http://localhost:9877/token")
+                .redirectUri("http://localhost:3000/callback")
+                .scopesSupported(List.of("openid", "offline_access"))
+                .build());
+        Mockito.when(validator.extractIdTokenIssuer(Mockito.any())).thenReturn("http://idp/realms/dial");
+    }
+
+    @Test
+    void testStatusReportsNotConnectedWithConnectParameters() {
+        Response resp = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+        assertEquals(200, resp.status(), resp.body());
+        assertTrue(resp.body().contains("\"connected\":false"), resp.body());
+        assertTrue(resp.body().contains("\"available\":true"), resp.body());
+        assertTrue(resp.body().contains("dial-credentials-manager"), resp.body());
+        assertTrue(resp.body().contains("offline_access"), resp.body());
+        assertFalse(resp.body().contains("secret"), "client secret must never be published");
+    }
+
+    @Test
+    void testStatusOmitsUnsetConnectParameters() {
+        // redirectUri is optional: clients that manage their own callback are validated against
+        // allowedRedirectUris, and the connect block must omit the field rather than advertise null.
+        Mockito.when(validator.resolveOfflineClient(Mockito.any())).thenReturn(ResourceAuthSettings.builder()
+                .authenticationType(AuthenticationType.OAUTH)
+                .clientId("dial-credentials-manager")
+                .authorizationEndpoint("http://localhost:9877/authorize")
+                .tokenEndpoint("http://localhost:9877/token")
+                .scopesSupported(List.of("openid", "offline_access"))
+                .build());
+
+        Response resp = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+        assertEquals(200, resp.status(), resp.body());
+        assertTrue(resp.body().contains("\"connect\""), resp.body());
+        assertFalse(resp.body().contains("redirect_uri"), resp.body());
+    }
+
+    @Test
+    void testStatusReportsUnavailableWhenProviderHasNoOfflineClient() {
+        // Status must not offer a connect flow that can only fail; the loud 400 belongs to sign-in alone.
+        Mockito.when(validator.resolveOfflineClient(Mockito.any())).thenReturn(null);
+
+        Response resp = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+        assertEquals(200, resp.status(), resp.body());
+        assertTrue(resp.body().contains("\"connected\":false"), resp.body());
+        assertTrue(resp.body().contains("\"available\":false"), resp.body());
+        assertFalse(resp.body().contains("connect\":{"), resp.body());
+
+        Response signIn = send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                """, "authorization", "user");
+        assertEquals(400, signIn.status(), signIn.body());
+    }
+
+    @Test
+    void testSignInStoresCredentialsAndStatusFlipsToConnected() throws Exception {
+        Mockito.when(validator.resolveIdTokenUserId(Mockito.any(), Mockito.eq("id-token-for-user"))).thenReturn("user");
+        try (TestWebServer ignore = new TestWebServer(9877, request -> new MockResponse()
+                .setBody(TOKEN_RESPONSE).setHeader("Content-Type", "application/json"))) {
+
+            Response signIn = send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+            assertEquals(200, signIn.status(), signIn.body());
+
+            Response status = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+            assertTrue(status.body().contains("\"connected\":true"), status.body());
+            assertFalse(status.body().contains("client_id"), "no connect block once connected: " + status.body());
+        }
+    }
+
+    @Test
+    void testSignInRejectedWhenIdTokenBelongsToAnotherUser() throws Exception {
+        Mockito.when(validator.resolveIdTokenUserId(Mockito.any(), Mockito.eq("id-token-for-user"))).thenReturn("someone-else");
+        try (TestWebServer ignore = new TestWebServer(9877, request -> new MockResponse()
+                .setBody(TOKEN_RESPONSE).setHeader("Content-Type", "application/json"))) {
+
+            Response signIn = send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+            assertEquals(403, signIn.status(), signIn.body());
+
+            Response status = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+            assertTrue(status.body().contains("\"connected\":false"), "nothing may be stored: " + status.body());
+        }
+    }
+
+    @Test
+    void testSignInFailsClosedWhenNoIdTokenReturned() throws Exception {
+        String noIdToken = """
+                { "access_token": "a", "refresh_token": "r", "expires_in": 3600 }
+                """;
+        try (TestWebServer ignore = new TestWebServer(9877, request -> new MockResponse()
+                .setBody(noIdToken).setHeader("Content-Type", "application/json"))) {
+
+            Response signIn = send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+            assertEquals(400, signIn.status(), signIn.body());
+            assertTrue(signIn.body().contains("no ID token"), signIn.body());
+
+            Response status = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+            assertTrue(status.body().contains("\"connected\":false"), "nothing may be stored: " + status.body());
+        }
+    }
+
+    @Test
+    void testSignOutDeletesCredentials() throws Exception {
+        Mockito.when(validator.resolveIdTokenUserId(Mockito.any(), Mockito.eq("id-token-for-user"))).thenReturn("user");
+        try (TestWebServer ignore = new TestWebServer(9877, request -> new MockResponse()
+                .setBody(TOKEN_RESPONSE).setHeader("Content-Type", "application/json"))) {
+            send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+        }
+
+        Response signOut = send(HttpMethod.POST, "/v1/user/offline-credentials/signout", null, "", "authorization", "user");
+        assertEquals(200, signOut.status(), signOut.body());
+
+        Response status = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "", "authorization", "user");
+        assertTrue(status.body().contains("\"connected\":false"), status.body());
+    }
+
+    @Test
+    void testPerRequestKeyCannotManageOfflineCredentials() {
+        ApiKeyData appKey = newAppKey("app", "user");
+        apiKeyStore.assignPerRequestApiKey(appKey);
+
+        Response status = send(HttpMethod.GET, "/v1/user/offline-credentials", null, "",
+                "api-key", appKey.getPerRequestKey());
+        assertEquals(401, status.status(), status.body());
+
+        Response signIn = send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                """, "api-key", appKey.getPerRequestKey());
+        assertEquals(401, signIn.status(), signIn.body());
+    }
+
+    @Test
+    void testSignInAndSignOutAreAudited() throws Exception {
+        Mockito.when(validator.resolveIdTokenUserId(Mockito.any(), Mockito.eq("id-token-for-user"))).thenReturn("user");
+        Logger auditLogger = (Logger) LoggerFactory.getLogger("DIAL_OBO_AUDIT");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        auditLogger.addAppender(appender);
+        Level previous = auditLogger.getLevel();
+        auditLogger.setLevel(Level.INFO);
+        try (TestWebServer ignore = new TestWebServer(9877, request -> new MockResponse()
+                .setBody(TOKEN_RESPONSE).setHeader("Content-Type", "application/json"))) {
+            send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+            send(HttpMethod.POST, "/v1/user/offline-credentials/signout", null, "", "authorization", "user");
+
+            List<String> events = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .filter(m -> m.startsWith("event=offline_credentials"))
+                    .toList();
+            assertEquals(2, events.size(), events::toString);
+            assertTrue(events.get(0).contains("action=SIGN_IN"), events::toString);
+            assertTrue(events.get(0).contains("outcome=SUCCESS"), events::toString);
+            assertTrue(events.get(0).contains("user_id=user"), events::toString);
+            assertTrue(events.get(1).contains("action=SIGN_OUT"), events::toString);
+        } finally {
+            auditLogger.setLevel(previous);
+            auditLogger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void testSignInWithInvalidBodyIsRejectedAndAudited() {
+        // A body the validator refuses is a bad request, not a server fault — and it is still a sign-in attempt,
+        // so it belongs in the audit trail alongside the ones the identity provider rejects.
+        Logger auditLogger = (Logger) LoggerFactory.getLogger("DIAL_OBO_AUDIT");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        auditLogger.addAppender(appender);
+        Level previous = auditLogger.getLevel();
+        auditLogger.setLevel(Level.INFO);
+        try {
+            Response signIn = send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+            assertEquals(400, signIn.status(), signIn.body());
+
+            List<String> events = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .filter(m -> m.startsWith("event=offline_credentials"))
+                    .toList();
+            assertEquals(1, events.size(), events::toString);
+            assertTrue(events.get(0).contains("action=SIGN_IN"), events::toString);
+            assertFalse(events.get(0).contains("outcome=SUCCESS"), events::toString);
+        } finally {
+            auditLogger.setLevel(previous);
+            auditLogger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void testOfflineCredentialsRequireSignedInUser() {
+        // An api-key caller has no user behind it, so there is no bucket to look in: refuse plainly rather than
+        // failing while building one.
+        assertEquals(401, send(HttpMethod.GET, "/v1/user/offline-credentials", null, "").status());
+        assertEquals(401, send(HttpMethod.POST, "/v1/user/offline-credentials/signout", null, "").status());
+    }
+
+    @Test
+    void testRejectedSignInIsAudited() throws Exception {
+        Mockito.when(validator.resolveIdTokenUserId(Mockito.any(), Mockito.eq("id-token-for-user"))).thenReturn("someone-else");
+        Logger auditLogger = (Logger) LoggerFactory.getLogger("DIAL_OBO_AUDIT");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        auditLogger.addAppender(appender);
+        Level previous = auditLogger.getLevel();
+        auditLogger.setLevel(Level.INFO);
+        try (TestWebServer ignore = new TestWebServer(9877, request -> new MockResponse()
+                .setBody(TOKEN_RESPONSE).setHeader("Content-Type", "application/json"))) {
+            send(HttpMethod.POST, "/v1/user/offline-credentials/signin", null, """
+                    { "code": "auth-code", "redirect_uri": "http://localhost:3000/callback" }
+                    """, "authorization", "user");
+
+            List<String> events = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .filter(m -> m.startsWith("event=offline_credentials"))
+                    .toList();
+            assertEquals(1, events.size(), events::toString);
+            assertTrue(events.get(0).contains("action=SIGN_IN"), events::toString);
+            assertFalse(events.get(0).contains("outcome=SUCCESS"), events::toString);
+        } finally {
+            auditLogger.setLevel(previous);
+            auditLogger.detachAppender(appender);
+        }
+    }
+
+    private ApiKeyData newAppKey(String sourceDeployment, String role) {
+        ApiKeyData perRequestKey = new ApiKeyData();
+        perRequestKey.setExtractedClaims(createClaims(role));
+        perRequestKey.setSourceDeployment(sourceDeployment);
+        perRequestKey.setTraceId("trace-id");
+        return perRequestKey;
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/security/AccessTokenValidatorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/security/AccessTokenValidatorTest.java
@@ -256,6 +256,13 @@ public class AccessTokenValidatorTest {
         assertThrows(IllegalArgumentException.class, () -> validator.resolveProvider(null));
     }
 
+    @Test
+    public void testResolveProvider_withoutTokenFailsForSingleProviderToo() {
+        JsonObject single = new JsonObject().put("idp1", idpConfig.getJsonObject("idp1"));
+        AccessTokenValidator validator = new AccessTokenValidator(single, vertx, taskExecutor, client, "DEBUG");
+        assertThrows(IllegalArgumentException.class, () -> validator.resolveProvider(null));
+    }
+
     private static String getBearerHeaderValue(String token) {
         return String.format("bearer %s", token);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/security/AccessTokenValidatorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/security/AccessTokenValidatorTest.java
@@ -228,6 +228,34 @@ public class AccessTokenValidatorTest {
         assertEquals("token", AccessTokenValidator.extractTokenFromHeader("bearer token more"));
     }
 
+    @Test
+    public void testResolveProviderByIssuer_singleProviderRefusesAnIssuerItDisclaims() {
+        // The lone provider is the only candidate, but a record minted by an identity provider that has since been
+        // removed must not be refreshed against it — that would use the wrong client.
+        JsonObject single = new JsonObject().put("idp1", idpConfig.getJsonObject("idp1"));
+        AccessTokenValidator validator = new AccessTokenValidator(single, vertx, taskExecutor, client, "DEBUG");
+
+        assertNotNull(validator.resolveProviderByIssuer("issue1"));
+        assertNotNull(validator.resolveProviderByIssuer(null));
+        assertThrows(IllegalArgumentException.class, () -> validator.resolveProviderByIssuer("issue2"));
+    }
+
+    @Test
+    public void testResolveProviderByIssuer_singleProviderWithoutPatternClaimsEveryIssuer() {
+        // Without an issuerPattern a non-match proves nothing, so the provider still answers.
+        JsonObject single = new JsonObject().put("idp1",
+                JsonObject.of("jwksUrl", "http://host1/keys", "rolePath", "role1"));
+        AccessTokenValidator validator = new AccessTokenValidator(single, vertx, taskExecutor, client, "DEBUG");
+
+        assertNotNull(validator.resolveProviderByIssuer("anything"));
+    }
+
+    @Test
+    public void testResolveProvider_withoutTokenFailsAsBadRequest() {
+        AccessTokenValidator validator = new AccessTokenValidator(idpConfig, vertx, taskExecutor, client, "DEBUG");
+        assertThrows(IllegalArgumentException.class, () -> validator.resolveProvider(null));
+    }
+
     private static String getBearerHeaderValue(String token) {
         return String.format("bearer %s", token);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/util/CredentialsPathReservationTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/CredentialsPathReservationTest.java
@@ -1,6 +1,14 @@
 package com.epam.aidial.core.server.util;
 
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.storage.resource.ResourceTypes;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,7 +60,28 @@ public class CredentialsPathReservationTest {
         assertFalse(CredentialsDescriptorFactory.OFFLINE_CREDENTIALS_ID.contains("/"),
                 "the reserved id must stay separator-free");
         assertTrue("applications/config/my-app/external_services/dial".contains("/"));
-        assertTrue("toolsets/config/my-toolset".contains("/"));
+    }
+
+    @Test
+    void toolsetNamedOfflineResolvesElsewhere() {
+        // Derived from the real locator, not a literal: a config toolset named "offline" must land on the
+        // type-prefixed storage id, never on the reserved one.
+        ProxyContext proxyContext = Mockito.mock(ProxyContext.class);
+        Proxy proxy = Mockito.mock(Proxy.class);
+        Config config = Mockito.mock(Config.class);
+        EncryptionService encryptionService = Mockito.mock(EncryptionService.class);
+        Mockito.when(proxyContext.getProxy()).thenReturn(proxy);
+        Mockito.when(proxy.getEncryptionService()).thenReturn(encryptionService);
+        Mockito.when(proxyContext.getApiKeyData()).thenReturn(Mockito.mock(ApiKeyData.class));
+        Mockito.when(proxyContext.getConfig()).thenReturn(config);
+        Mockito.when(config.isDeploymentExists("offline")).thenReturn(true);
+        Mockito.when(proxyContext.getUserId()).thenReturn("userSub");
+        Mockito.when(encryptionService.encrypt(Mockito.any())).thenReturn("userBucket");
+
+        CredentialsLocator locator = CredentialsLocatorFactory.fromAnyUrl("offline", proxyContext, ResourceTypes.TOOL_SET);
+
+        assertEquals("toolsets/config/offline", locator.getResourceId());
+        assertNotEqualsReservedId(locator.getResourceId());
     }
 
     private static void assertNotEqualsReservedId(String storageId) {

--- a/server/src/test/java/com/epam/aidial/core/server/util/CredentialsPathReservationTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/CredentialsPathReservationTest.java
@@ -1,0 +1,62 @@
+package com.epam.aidial.core.server.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The reserved {@code offline} credentials id must stay unreachable from the app-scoped credential endpoints, no
+ * matter how an application, toolset or external service is named.
+ */
+public class CredentialsPathReservationTest {
+
+    @Test
+    void offlineIdIsRejectedAsExternalServiceScope() {
+        // Both credential endpoints reach their blobs through this parser, so anything it rejects is unaddressable.
+        assertThrows(IllegalArgumentException.class,
+                () -> CredentialsLocatorFactory.parseExternalServiceScope(CredentialsDescriptorFactory.OFFLINE_CREDENTIALS_ID));
+        assertThrows(IllegalArgumentException.class,
+                () -> CredentialsLocatorFactory.parseExternalServiceScope("applications/offline"));
+        assertThrows(IllegalArgumentException.class,
+                () -> CredentialsLocatorFactory.parseExternalServiceScope("offline/external_services/offline"));
+    }
+
+    @Test
+    void serviceNamedOfflineResolvesElsewhere() {
+        String[] parts = CredentialsLocatorFactory.parseExternalServiceScope(
+                "applications/my-app/external_services/offline");
+
+        assertEquals("my-app", parts[0]);
+        assertEquals("offline", parts[1]);
+        // The storage id is the normalized scope, never the bare service name.
+        assertNotEqualsReservedId("applications/config/my-app/external_services/offline");
+    }
+
+    @Test
+    void appNamedOfflineResolvesElsewhere() {
+        String[] parts = CredentialsLocatorFactory.parseExternalServiceScope(
+                "applications/offline/external_services/dial");
+
+        assertEquals("offline", parts[0]);
+        assertEquals("dial", parts[1]);
+        assertNotEqualsReservedId("applications/config/offline/external_services/dial");
+    }
+
+    @Test
+    void everyAppScopedIdIsPathShaped() {
+        // The reservation rests on this: app- and toolset-scoped ids always carry a type prefix and therefore a
+        // separator, while the offline id carries none.
+        assertFalse(CredentialsDescriptorFactory.OFFLINE_CREDENTIALS_ID.contains("/"),
+                "the reserved id must stay separator-free");
+        assertTrue("applications/config/my-app/external_services/dial".contains("/"));
+        assertTrue("toolsets/config/my-toolset".contains("/"));
+    }
+
+    private static void assertNotEqualsReservedId(String storageId) {
+        assertFalse(storageId.equals(CredentialsDescriptorFactory.OFFLINE_CREDENTIALS_ID),
+                "app-scoped credentials must never land on the reserved offline id");
+    }
+}


### PR DESCRIPTION
Part 2/4 of the offline-delegation split (replaces #1815). Based on #1818.

Adds `/v1/user/offline-credentials` (status), `/signin` and `/signout`: a user grants DIAL one platform-wide offline credential, stored in their own bucket under a reserved id no app-scoped endpoint can address. Sign-in exchanges the code via the provider's `offlineClient`, verifies through the ID token that the code belongs to the caller, and records the issuer for later refresh. Refresh responses without a refresh token keep the existing one (RFC 6749 §6). All operations audited; shared error mapping extracted into `ExternalServiceErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)