### PR TITLE
fix: Tools Overview shows only default tools, not openapi ones #1837

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/McpResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/McpResourceController.java
@@ -184,7 +184,7 @@ public class McpResourceController implements Controller {
                         endpoint,
                         Duration.ofMillis(proxy.getClientOptions().getIdleTimeout()),
                         mcpHttpClientBuilder.httpClientBuilder(),
-                        builder -> authHeaders.forEach(builder::header),
+                        (builder, body) -> authHeaders.forEach(builder::header),
                         client -> {
                             McpSchema.ReadResourceResult result = client.readResource(
                                     new McpSchema.ReadResourceRequest(resourceUri));

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetToolsController.java
@@ -14,6 +14,7 @@ import com.epam.aidial.core.openapi.annotations.ParameterIn;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.function.enhancement.InjectApplicationPropsToMcpRequest;
 import com.epam.aidial.core.server.mcp.McpClientUtils;
 import com.epam.aidial.core.server.mcp.McpHttpClientBuilder;
 import com.epam.aidial.core.server.security.AccessService;
@@ -34,6 +35,7 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.transport.McpHttpClientTransportAuthorizationException;
@@ -183,7 +185,7 @@ public class ToolSetToolsController implements Controller {
                     upstream.getEndpoint(),
                     Duration.ofMillis(proxy.getClientOptions().getIdleTimeout()),
                     mcpHttpClientBuilder.httpClientBuilder(),
-                    builder -> customizeRequest(builder, deployment),
+                    (builder, body) -> customizeRequest(builder, body, deployment),
                     client -> {
                         if (filterAllowed) {
                             // listTools() auto-paginates all pages via the SDK's expand() chain
@@ -209,11 +211,26 @@ public class ToolSetToolsController implements Controller {
         }
     }
 
-    private void customizeRequest(HttpRequest.Builder builder, Deployment deployment) {
+    private void customizeRequest(HttpRequest.Builder builder, String body, Deployment deployment) {
         if (deployment instanceof ToolSet toolSet) {
             authInjector.inject(builder::header, toolSet, context, credentialsLocator);
         } else if (deployment instanceof Application application) {
             authInjector.inject(builder::header, application, context);
+            injectAiDialConfig(builder, body, application);
+        }
+    }
+
+    private void injectAiDialConfig(HttpRequest.Builder builder, String body, Application application) {
+        if (body == null) {
+            return;
+        }
+        try {
+            ObjectNode tree = (ObjectNode) ProxyUtil.MAPPER.readTree(body);
+            if (InjectApplicationPropsToMcpRequest.injectAiDialConfig(tree, application)) {
+                builder.POST(HttpRequest.BodyPublishers.ofString(ProxyUtil.MAPPER.writeValueAsString(tree)));
+            }
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to inject application properties into MCP request body", e);
         }
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/InjectApplicationPropsToMcpRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/InjectApplicationPropsToMcpRequest.java
@@ -22,27 +22,38 @@ public class InjectApplicationPropsToMcpRequest extends BaseRequestFunction<Obje
     @Override
     public Boolean apply(ObjectNode tree) {
         Deployment deployment = context.getDeployment();
-        if (deployment instanceof Application application
-                && application.getMcp().getConfigDelivery() == Application.McpConfigDelivery.META) {
-            Map<String, Object> props = application.getApplicationProperties();
-            if (props == null || props.isEmpty()) {
-                return false;
-            }
-            ObjectNode node = getApplicationPropsNode(tree);
-            put(node, application.getApplicationProperties());
-            return true;
+        if (deployment instanceof Application application) {
+            return injectAiDialConfig(tree, application);
         }
         return false;
     }
 
-    private void put(ObjectNode node, Map<String, Object> appProps) {
+    /**
+     * Injects the application's custom properties (e.g. {@code openapi}) into the JSON-RPC request
+     * body at {@code params._meta.ai_dial_config}, when the application uses {@code META} config
+     * delivery (the default). Returns {@code true} if the body was modified.
+     */
+    public static boolean injectAiDialConfig(ObjectNode tree, Application application) {
+        if (application.getMcp().getConfigDelivery() != Application.McpConfigDelivery.META) {
+            return false;
+        }
+        Map<String, Object> props = application.getApplicationProperties();
+        if (props == null || props.isEmpty()) {
+            return false;
+        }
+        ObjectNode node = getApplicationPropsNode(tree);
+        put(node, props);
+        return true;
+    }
+
+    private static void put(ObjectNode node, Map<String, Object> appProps) {
         for (Map.Entry<String, Object> e : appProps.entrySet()) {
             JsonNode val = ProxyUtil.MAPPER.valueToTree(e.getValue());
             node.set(e.getKey(), val);
         }
     }
 
-    private ObjectNode getApplicationPropsNode(ObjectNode tree) {
+    private static ObjectNode getApplicationPropsNode(ObjectNode tree) {
         ObjectNode root = tree;
         for (String field : APP_PROPS_PATH) {
             JsonNode node = root.get(field);

--- a/server/src/main/java/com/epam/aidial/core/server/mcp/McpClientUtils.java
+++ b/server/src/main/java/com/epam/aidial/core/server/mcp/McpClientUtils.java
@@ -21,7 +21,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * Shared helpers for talking to MCP servers, used by both the Vert.x-based MCP proxy path
@@ -95,11 +94,11 @@ public class McpClientUtils {
      */
     public static <T> T withSyncClient(String endpoint, Duration timeout,
             HttpClient.Builder clientBuilder,
-            Consumer<HttpRequest.Builder> requestCustomizer, McpAction<T> action) throws Exception {
+            RequestCustomizer requestCustomizer, McpAction<T> action) throws Exception {
         HttpClientStreamableHttpTransport transport = transportBuilder(endpoint)
                 .clientBuilder(clientBuilder)
                 .jsonMapper(MCP_JSON_MAPPER)
-                .httpRequestCustomizer((builder, method, ep, body, ctx) -> requestCustomizer.accept(builder))
+                .httpRequestCustomizer((builder, method, ep, body, ctx) -> requestCustomizer.customize(builder, body))
                 .build();
         try (McpSyncClient client = McpClient.sync(transport)
                 .clientInfo(new McpSchema.Implementation("DIAL", "1.0"))
@@ -114,6 +113,11 @@ public class McpClientUtils {
     @FunctionalInterface
     public interface McpAction<T> {
         T apply(McpSyncClient client) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface RequestCustomizer {
+        void customize(HttpRequest.Builder builder, String body);
     }
 
     private static McpJsonMapper createLenientMcpJsonMapper() {

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.http.HttpMethod;
 import lombok.SneakyThrows;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,8 +50,17 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     private static TestWebServer.Handler mcpToolsHandler(String toolsResponse, String contentType) {
+        return mcpToolsHandler(toolsResponse, contentType, (body, request) -> { });
+    }
+
+    // requestListener is invoked with the request body read exactly once - RecordedRequest's Buffer
+    // is consumed on read, so callers that need the body (e.g. to assert on it) must observe it here
+    // rather than reading request.getBody() again themselves.
+    private static TestWebServer.Handler mcpToolsHandler(String toolsResponse, String contentType,
+            BiConsumer<String, RecordedRequest> requestListener) {
         return request -> {
             String body = request.getBody().readString(StandardCharsets.UTF_8);
+            requestListener.accept(body, request);
             if ("GET".equals(request.getMethod())) {
                 // SSE stream connection - return 405 to signal no streaming support
                 return new MockResponse().setResponseCode(405);
@@ -2664,6 +2675,95 @@ public class ToolSetApiTest extends ResourceBaseTest {
         Response resp = send(HttpMethod.GET, "/v1/toolset/unknown-toolset/tools",
                 null, null, "authorization", "admin");
         assertEquals(404, resp.status());
+    }
+
+    @DialConfigLocation("dial-config/mcp-app-config-delivery.json")
+    @Test
+    void testGetAllTools_ApplicationMetaConfigDelivery_InjectsApplicationProperties() throws JsonProcessingException {
+        // "mcp-app" uses the default META config delivery: the application's custom properties
+        // (e.g. `openapi`) must be inlined into the tools/list JSON-RPC body at params._meta.ai_dial_config,
+        // otherwise App Runner falls back to its static default tools (#1837).
+        String mcpToolsListResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 2,
+                   "result": {
+                     "tools": [
+                       {"name": "openapi_verify", "description": "Verify spec"},
+                       {"name": "custom_openapi_tool", "description": "Derived from openapi spec"}
+                     ]
+                   }
+                 }
+                """;
+        AtomicReference<String> toolsListBody = new AtomicReference<>();
+        TestWebServer.Handler handler = mcpToolsHandler(mcpToolsListResponse, "application/json", (body, request) -> {
+            if (body.contains("\"method\":\"tools/list\"") || body.contains("\"method\": \"tools/list\"")) {
+                toolsListBody.set(body);
+            }
+        });
+        try (TestWebServer ignore = new TestWebServer(9876, handler)) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/mcp-app/tools",
+                    null, null, "authorization", "admin");
+
+            assertEquals(200, resp.status());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            assertEquals(2, tools.size());
+
+            assertNotNull(toolsListBody.get(), "tools/list request was not received by the MCP server");
+            JsonNode requestTree = ProxyUtil.MAPPER.readTree(toolsListBody.get());
+            JsonNode aiDialConfig = requestTree.at("/params/_meta/ai_dial_config");
+            assertFalse(aiDialConfig.isMissingNode(), "ai_dial_config was not injected into the tools/list body");
+            assertEquals("openapi-spec-marker", aiDialConfig.get("openapi").asText());
+        }
+    }
+
+    @DialConfigLocation("dial-config/mcp-app-config-delivery.json")
+    @Test
+    void testGetAllTools_ApplicationHeaderConfigDelivery_SetsHeaderNotBody() throws JsonProcessingException {
+        // "mcp-app-header" opts into HEADER config delivery: properties travel via the
+        // X-DIAL-APPLICATION-PROPERTIES header (already worked before #1837), not the request body.
+        String mcpToolsListResponse = """
+                {
+                   "jsonrpc": "2.0",
+                   "id": 2,
+                   "result": {
+                     "tools": [
+                       {"name": "custom_openapi_tool", "description": "Derived from openapi spec"}
+                     ]
+                   }
+                 }
+                """;
+        AtomicReference<String> toolsListBody = new AtomicReference<>();
+        AtomicReference<String> toolsListPropertiesHeader = new AtomicReference<>();
+        TestWebServer.Handler handler = mcpToolsHandler(mcpToolsListResponse, "application/json", (body, request) -> {
+            if (body.contains("\"method\":\"tools/list\"") || body.contains("\"method\": \"tools/list\"")) {
+                toolsListBody.set(body);
+                toolsListPropertiesHeader.set(request.getHeader("X-DIAL-APPLICATION-PROPERTIES"));
+            }
+        });
+        try (TestWebServer ignore = new TestWebServer(9876, handler)) {
+            Response resp = send(HttpMethod.GET, "/v1/toolset/mcp-app-header/tools",
+                    null, null, "authorization", "admin");
+
+            assertEquals(200, resp.status());
+            var json = ProxyUtil.MAPPER.readTree(resp.body());
+            ArrayNode tools = Optional.ofNullable(json.get("tools"))
+                    .map(node -> (ArrayNode) node)
+                    .orElse(ProxyUtil.MAPPER.createArrayNode());
+            assertEquals(1, tools.size());
+
+            assertNotNull(toolsListBody.get(), "tools/list request was not received by the MCP server");
+            JsonNode requestTree = ProxyUtil.MAPPER.readTree(toolsListBody.get());
+            assertTrue(requestTree.at("/params/_meta/ai_dial_config").isMissingNode(),
+                    "ai_dial_config must not be injected into the body in HEADER delivery mode");
+
+            assertNotNull(toolsListPropertiesHeader.get(), "X-DIAL-APPLICATION-PROPERTIES header was not sent");
+            JsonNode headerProperties = ProxyUtil.MAPPER.readTree(toolsListPropertiesHeader.get());
+            assertEquals("openapi-spec-marker", headerProperties.get("openapi").asText());
+        }
     }
 
     @Test

--- a/server/src/test/resources/dial-config/mcp-app-config-delivery.json
+++ b/server/src/test/resources/dial-config/mcp-app-config-delivery.json
@@ -1,0 +1,33 @@
+{
+  "applications": {
+    "mcp-app": {
+      "endpoint": "http://localhost:9876",
+      "displayName": "MCP App",
+      "description": "Application exposing MCP tools, used to test aiDial config delivery",
+      "mcp": {
+        "endpoint": "http://localhost:9876"
+      },
+      "applicationProperties": {
+        "openapi": "openapi-spec-marker"
+      }
+    },
+    "mcp-app-header": {
+      "endpoint": "http://localhost:9876",
+      "displayName": "MCP App (header delivery)",
+      "description": "Application exposing MCP tools via header config delivery",
+      "mcp": {
+        "endpoint": "http://localhost:9876",
+        "configDelivery": "HEADER"
+      },
+      "applicationProperties": {
+        "openapi": "openapi-spec-marker"
+      }
+    }
+  },
+  "keys": {
+    "proxyKey1": {
+      "project": "EPM-RTC-GPT",
+      "role": "default"
+    }
+  }
+}


### PR DESCRIPTION
Fetching tools via `GET /v1/toolset/{id}/tools` used the MCP SDK's own client, which never forwarded the application's `aiDial.config` custom properties (e.g. the `openapi` parameter) into the `tools/list` request body, unlike the chat MCP proxy path. As a result, App Runner apps fell back to their static default tools instead of the ones derived from `openapi`.

### Applicable issues

- fixes #1837

### Description of changes

- Threaded the JSON-RPC request body through `McpClientUtils.withSyncClient`'s customizer callback (previously discarded), via a new `RequestCustomizer` functional interface.
- Extracted the existing (proven-correct) body-injection logic from `InjectApplicationPropsToMcpRequest` into a reusable static `injectAiDialConfig(...)` method.
- Updated `ToolSetToolsController` to inject `params._meta.ai_dial_config` for META-mode `Application` deployments before dispatching `tools/list`/`initialize`, matching the behavior already used by the chat MCP session.
- Updated `McpResourceController`'s customizer lambda to the new 2-arg signature (no behavior change there).
- Added regression tests in `ToolSetApiTest` covering both META (body injection) and HEADER (header injection, pre-existing behavior) config delivery modes, backed by a new isolated `dial-config/mcp-app-config-delivery.json` fixture.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.