### PR TITLE
fix: resolve limit and consent paths for deployment names that are not valid URIs

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/ProxyContext.java
+++ b/server/src/main/java/com/epam/aidial/core/server/ProxyContext.java
@@ -253,7 +253,9 @@ public class ProxyContext {
 
     public boolean hasNextInterceptor() {
         // initial call to the deployment or the interceptor calls another deployment
-        String decodedName = UrlUtil.decodePath(deployment.getName());
+        // a name is url form for an application and plain config text for a model, so it is decoded the same
+        // lenient way as the source deployment above - a model named "claude-opus-4-8[1m]" is not a valid URI
+        String decodedName = UrlUtil.tryDecodePath(deployment.getName());
         if (apiKeyData.getInterceptors() == null || !decodedName.equals(getInitialDeployment())) {
             return !interceptors.isEmpty();
         } else { // make sure if a next interceptor is available from the list

--- a/server/src/main/java/com/epam/aidial/core/server/limiter/RateLimiter.java
+++ b/server/src/main/java/com/epam/aidial/core/server/limiter/RateLimiter.java
@@ -373,8 +373,15 @@ public class RateLimiter {
         return getResourceDescription(bucketLocation, path);
     }
 
+    /**
+     * Builds a descriptor for a limit record from an internal relative path, which may carry an entity name.
+     * {@link RoleBasedEntity#getName()} is plain configuration text for a file defined model or route, but an
+     * already url encoded resource url for a custom application - so such a path can never be validated as a
+     * URI (a model named {@code claude-opus-4-8[1m]} is legal config), while it must still be decoded, or a
+     * record written for an application under its encoded name would not be found again.
+     */
     private ResourceDescriptor getResourceDescription(String bucketLocation, String path) {
-        return ResourceDescriptorFactory.fromEncoded(ResourceTypes.LIMIT, bucketLocation, bucketLocation, path);
+        return ResourceDescriptorFactory.fromEntityPath(ResourceTypes.LIMIT, bucketLocation, bucketLocation, path);
     }
 
     private RateLimitResult checkLimit(ProxyContext context, Limit limit, RoleBasedEntity roleBasedEntity) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ConsentService.java
@@ -125,8 +125,12 @@ public class ConsentService {
                 && Boolean.TRUE.equals(deployment.getFeatures().getConsentRequired());
     }
 
+    /**
+     * The id is already decoded - a deployment name from the config, or a path parameter the route decoded -
+     * so it is not a url and cannot be validated as one.
+     */
     private static ResourceDescriptor getResourceDescription(ProxyContext context, String deploymentId) {
         String bucketLocation = BucketBuilder.buildInitiatorBucket(context);
-        return ResourceDescriptorFactory.fromEncoded(ResourceTypes.USER_CONSENT, bucketLocation, bucketLocation, deploymentId);
+        return ResourceDescriptorFactory.fromEntityPath(ResourceTypes.USER_CONSENT, bucketLocation, bucketLocation, deploymentId);
     }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/util/ResourceDescriptorFactory.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ResourceDescriptorFactory.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
 
 public class ResourceDescriptorFactory {
@@ -26,17 +27,48 @@ public class ResourceDescriptorFactory {
      * @param path           url encoded relative path; if url path is null or empty we treat it as user home
      */
     public static ResourceDescriptor fromEncoded(ResourceType type, String bucketName, String bucketLocation, String path) {
+        return build(type, bucketName, bucketLocation, path, UrlUtil::decodePath);
+    }
+
+    /**
+     * Same as {@link #fromEncoded}, but for an internal path assembled from an identifier that is not a url:
+     * a deployment name defined in the config, or the resource url a custom application reports as its name.
+     * Such a path is percent decoded exactly the way {@link #fromEncoded} decodes one, so it resolves to the
+     * same storage key, but it is not required to be a valid URI - {@code claude-opus-4-8[1m]} is a legal
+     * deployment name, and brackets are illegal in a URI path. A segment that is not valid percent encoding
+     * is kept verbatim rather than rejected.
+     *
+     * <p>Only the URI check is relaxed. Every element must still be a valid file name, because the resulting
+     * key has to be storable by each blob provider, and because such a path can come from a request - a
+     * consent deployment id does.
+     *
+     * @param type           resource type
+     * @param bucketName     bucket name (encrypted)
+     * @param bucketLocation bucket location on blob storage; bucket location must end with /
+     * @param path           relative path built from an entity name; if null or empty we treat it as user home
+     */
+    public static ResourceDescriptor fromEntityPath(ResourceType type, String bucketName, String bucketLocation, String path) {
+        return build(type, bucketName, bucketLocation, path, UrlUtil::tryDecodePath);
+    }
+
+    /**
+     * The two differ in one thing only: whether a segment that is not a valid URI is rejected or decoded as
+     * best it can be. Every other check, and the decode itself, is shared - which is what makes both resolve
+     * any path they both accept to the same storage key.
+     */
+    private static ResourceDescriptor build(ResourceType type, String bucketName, String bucketLocation, String path,
+                                           UnaryOperator<String> decoder) {
         // in case empty path - treat it as a home folder
-        String urlEncodedRelativePath = StringUtils.isBlank(path) ? ResourceDescriptor.PATH_SEPARATOR : path;
+        String relativePath = StringUtils.isBlank(path) ? ResourceDescriptor.PATH_SEPARATOR : path;
         verify(bucketLocation.endsWith(ResourceDescriptor.PATH_SEPARATOR), "Bucket location must end with /");
 
-        String[] encodedElements = urlEncodedRelativePath.split(ResourceDescriptor.PATH_SEPARATOR);
-        List<String> elements = Arrays.stream(encodedElements).map(UrlUtil::decodePath).toList();
+        String[] rawElements = relativePath.split(ResourceDescriptor.PATH_SEPARATOR);
+        List<String> elements = Arrays.stream(rawElements).map(decoder).toList();
         elements.forEach(element ->
-                verify(isValidFilename(element), "Invalid path provided " + urlEncodedRelativePath)
+                verify(isValidFilename(element), "Invalid path provided " + relativePath)
         );
 
-        ResourceDescriptor resource = from(type, bucketName, bucketLocation, elements, ResourceUtil.isFolder(urlEncodedRelativePath));
+        ResourceDescriptor resource = from(type, bucketName, bucketLocation, elements, ResourceUtil.isFolder(relativePath));
         verify(resource.getAbsoluteFilePath().getBytes(StandardCharsets.UTF_8).length <= MAX_PATH_SIZE,
                 "Resource path exceeds max allowed size: " + MAX_PATH_SIZE);
 

--- a/server/src/test/java/com/epam/aidial/core/server/LimitApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/LimitApiTest.java
@@ -187,7 +187,37 @@ public class LimitApiTest extends ResourceBaseTest {
         }
     }
 
+    /**
+     * A model name only has to be legal configuration, and brackets are - but they are illegal in a URI path, so
+     * a single such model used to fail the whole report with 500 for every user who could access it.
+     */
+    @Test
+    @DialConfigLocation("dial-config/bracket-named-model.json")
+    public void testGetUserLimits_DeploymentNameThatIsNotUriSafe() {
+        String deployment = "anthropic.claude-opus-4-8[1m]";
+        String encodedId = "anthropic.claude-opus-4-8%5B1m%5D";
+
+        assertEquals(List.of(), deploymentIds(getUserUsage()));
+        assertNotNull(deployment(getUserLimits(), deployment));
+
+        completion(deployment, encodedId);
+
+        JsonNode used = deployment(getUserUsage(), deployment);
+        assertEquals(100, used.get("minuteTokenStats").get("total").asLong());
+        assertEquals(30, used.get("minuteTokenStats").get("used").asLong());
+        assertEquals(1000, used.get("dayTokenStats").get("total").asLong());
+        assertEquals(1, used.get("hourRequestStats").get("used").asLong());
+
+        // the per-deployment endpoint agrees; its id is percent encoded in the request path
+        JsonNode single = readJson(send(HttpMethod.GET, "/v1/deployments/" + encodedId + "/limits", null, null));
+        assertEquals(30, single.get("minuteTokenStats").get("used").asLong());
+    }
+
     private void completion(String deployment) {
+        completion(deployment, deployment);
+    }
+
+    private void completion(String deployment, String encodedId) {
         String answer = "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"model\":\"" + deployment + "\","
                 + "\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}],"
                 + "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}";
@@ -195,7 +225,7 @@ public class LimitApiTest extends ResourceBaseTest {
         try (TestWebServer server = new TestWebServer(4848)) {
             server.map(HttpMethod.POST, "/chat/completions", 200, answer);
 
-            Response response = send(HttpMethod.POST, "/openai/deployments/" + deployment + "/chat/completions", null,
+            Response response = send(HttpMethod.POST, "/openai/deployments/" + encodedId + "/chat/completions", null,
                     "{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
                     "content-type", "application/json");
             verify(response, 200);

--- a/server/src/test/java/com/epam/aidial/core/server/limiter/RateLimiterTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/limiter/RateLimiterTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server.limiter;
 
+import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CostLimit;
 import com.epam.aidial.core.config.Key;
@@ -864,6 +865,84 @@ public class RateLimiterTest {
         assertNotNull(stats);
         assertEquals(0, stats.getMinuteTokenStats().getUsed());
         assertEquals(1, stats.getHourRequestStats().getUsed());
+    }
+
+    /**
+     * A deployment name is plain configuration text and has to satisfy nothing but the config, so brackets are
+     * legal - and a URI, which forbids them in a path, is the wrong thing to validate the record path as.
+     * Covers admission, accounting and both reporting endpoints, all of which failed for such a name.
+     */
+    @Test
+    public void testLimitsForDeploymentNameThatIsNotUriSafe() {
+        Config config = new Config();
+        Role role = new Role();
+        role.setLimits(Map.of());
+        role.setCostLimit(costLimit("100"));
+        config.setRoles(Map.of("role", role));
+
+        ProxyContext proxyContext = userContext(config, List.of("role"));
+        Model model = model("anthropic.claude-opus-4-8[1m]");
+        Pricing pricing = new Pricing();
+        pricing.setUnit("token");
+        pricing.setPrompt("0.001");
+        pricing.setCompletion("0.002");
+        model.setPricing(pricing);
+        stubInlineExecutor();
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(1000);
+        tokenUsage.setCompletionTokens(2000);
+        tokenUsage.setTotalTokens(3000);
+        String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
+        assertEquals(HttpStatus.OK, rateLimiter.limit(proxyContext, model).result().status());
+        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null).cause());
+
+        // the record lands under the name exactly as configured
+        assertNotNull(resourceService.getResource(ResourceDescriptorFactory
+                .fromDecoded(ResourceTypes.LIMIT, bucket, bucket, "anthropic.claude-opus-4-8[1m]/tokens")));
+
+        // dropEmpty=true is what GET /v1/user/usage asks for, the endpoint the incident was reported on
+        Future<UserLimitStats> future = rateLimiter.getUserStats(proxyContext, List.of(model), true);
+        assertNull(future.cause(), String.valueOf(future.cause()));
+        LimitStats stats = future.result().getDeployments().get("anthropic.claude-opus-4-8[1m]");
+        assertNotNull(stats);
+        assertEquals(3000, stats.getMinuteTokenStats().getUsed());
+        assertEquals(1, stats.getHourRequestStats().getUsed());
+        assertEquals(0, new BigDecimal("5.000").compareTo(stats.getDayCostStats().getUsed()));
+
+        // and the per-deployment endpoint agrees with it
+        assertEquals(3000, rateLimiter.getLimitStats(model, proxyContext).result().getMinuteTokenStats().getUsed());
+    }
+
+    /**
+     * A custom application reports an already url encoded resource url as its name, and reaches the limiter
+     * through increase() even though limit() skips it. Its record must stay where it has always been, which is
+     * why the path is still percent decoded.
+     */
+    @Test
+    public void testIncreaseKeepsTheRecordPathOfAnEncodedApplicationName() {
+        Config config = new Config();
+        Role role = new Role();
+        role.setLimits(Map.of());
+        config.setRoles(Map.of("role", role));
+
+        ProxyContext proxyContext = userContext(config, List.of("role"));
+        Application application = new Application();
+        application.setName("applications/buck/my%20app");
+        stubInlineExecutor();
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setTotalTokens(7);
+        String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
+        assertNull(rateLimiter.increase(application, bucket, tokenUsage, null, null).cause());
+
+        assertNotNull(resourceService.getResource(ResourceDescriptorFactory
+                .fromDecoded(ResourceTypes.LIMIT, bucket, bucket, "applications/buck/my app/tokens")));
+
+        // and the read side resolves to the same record, so the encoded name stays symmetric end to end
+        UserLimitStats stats = rateLimiter.getUserStats(proxyContext, List.of(application), true).result();
+        assertNotNull(stats);
+        assertEquals(7, stats.getDeployments().get("applications/buck/my%20app").getMinuteTokenStats().getUsed());
     }
 
     private ProxyContext userContext(Config config, List<String> roles) {

--- a/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ConsentServiceTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -520,6 +521,40 @@ public class ConsentServiceTest {
         root.setName("A");
 
         assertDoesNotThrow(() -> service.verifyUserConsent(context, application));
+    }
+
+    /**
+     * A deployment id is not a url. Here it is a config defined model name holding brackets, which are illegal
+     * in a URI path, so validating it as one used to fail before any storage access.
+     */
+    @Test
+    public void testAcceptConsent_DeploymentIdThatIsNotUriSafe() {
+        when(context.getUserId()).thenReturn("sub");
+
+        service.acceptConsent(context, "anthropic.claude-opus-4-8[1m]", new Consent());
+
+        assertEquals("anthropic.claude-opus-4-8[1m]", capturePutDescriptor().getName());
+    }
+
+    /**
+     * A custom application's id is an already encoded resource url, so the record path stays decoded the way it
+     * has always been - the read side derives it from that very same name.
+     */
+    @Test
+    public void testAcceptConsent_EncodedApplicationId() {
+        when(context.getUserId()).thenReturn("sub");
+
+        service.acceptConsent(context, "applications/buck/my%20app", new Consent());
+
+        ResourceDescriptor descriptor = capturePutDescriptor();
+        assertEquals("my app", descriptor.getName());
+        assertEquals(List.of("applications", "buck"), descriptor.getParentFolders());
+    }
+
+    private ResourceDescriptor capturePutDescriptor() {
+        ArgumentCaptor<ResourceDescriptor> captor = ArgumentCaptor.forClass(ResourceDescriptor.class);
+        verify(resourceService).putResource(captor.capture(), eq("{\"deployments\":{}}"), eq(EtagHeader.ANY));
+        return captor.getValue();
     }
 
     @SneakyThrows

--- a/server/src/test/java/com/epam/aidial/core/server/util/ResourceDescriptorFactoryTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ResourceDescriptorFactoryTest.java
@@ -305,4 +305,79 @@ public class ResourceDescriptorFactoryTest {
         assertTrue(resourceDescriptor.isFolder());
 
     }
+
+    /**
+     * A deployment name is plain configuration text, not a url. {@code [} and {@code ]} are illegal in a URI
+     * path, so validating one as a URI is what made {@code GET /v1/user/usage} fail for a model named
+     * {@code anthropic.claude-opus-4-8[1m]}.
+     */
+    @Test
+    public void testFromEntityPath_NameThatIsNotUriSafe() {
+        ResourceDescriptor resource = ResourceDescriptorFactory.fromEntityPath(
+                ResourceTypes.LIMIT, "buckets/location/", "buckets/location/", "anthropic.claude-opus-4-8[1m]/tokens");
+        assertEquals("tokens", resource.getName());
+        assertEquals("anthropic.claude-opus-4-8[1m]", resource.getParentPath());
+        assertEquals("buckets/location/limits/anthropic.claude-opus-4-8[1m]/tokens", resource.getAbsoluteFilePath());
+        assertFalse(resource.isFolder());
+
+        // what the incident hit: the same path through the strict factory fails its URI check. Note the name
+        // passes isValidFilename - brackets are not in INVALID_FILE_NAME_CHARS - so the URI check is the whole
+        // of the defect, and relaxing anything else would be gratuitous
+        assertThrows(RuntimeException.class, () -> ResourceDescriptorFactory.fromEncoded(
+                ResourceTypes.LIMIT, "buckets/location/", "buckets/location/", "anthropic.claude-opus-4-8[1m]/tokens"));
+    }
+
+    /**
+     * Why the decode step is kept: a custom application reports an already encoded resource url as its name,
+     * so dropping the decode would move every stored record of such a deployment to a new key. A spot check of
+     * representative shapes, not a proof - the guarantee comes from both factories sharing the decode call, and
+     * differing only in whether it may throw.
+     *
+     * <p>The non-ASCII case pins that the two agree; it says nothing about which bytes are correct, since both
+     * sides route through {@code Charset.defaultCharset()}.
+     */
+    @Test
+    public void testFromEntityPath_KeepsTheKeyFromEncodedBuilds() {
+        for (String path : List.of("model/tokens", "applications/buck/my%20app/tokens", "модель/tokens", "costs")) {
+            assertEquals(
+                    ResourceDescriptorFactory.fromEncoded(ResourceTypes.LIMIT, "b", "location/", path).getAbsoluteFilePath(),
+                    ResourceDescriptorFactory.fromEntityPath(ResourceTypes.LIMIT, "b", "location/", path).getAbsoluteFilePath(),
+                    path);
+        }
+    }
+
+    /**
+     * Only the URI check is relaxed. The file name charset is not: a brace lets the caller pick the Redis
+     * Cluster hash slot, and a double quote is rejected on purpose (see commit bc971243) because it cannot be
+     * stored by every provider.
+     */
+    @Test
+    public void testFromEntityPath_KeepsTheFileNameCharset() {
+        for (String path : List.of("gpt{4}/tokens", "gpt}4/tokens", "gpt\"4/tokens", "%7Bgpt%7D/tokens")) {
+            assertThrows(IllegalArgumentException.class, () -> ResourceDescriptorFactory.fromEntityPath(
+                    ResourceTypes.LIMIT, "b", "location/", path), path);
+        }
+    }
+
+    /**
+     * A name that is not valid percent encoding is kept verbatim instead of failing to decode.
+     */
+    @Test
+    public void testFromEntityPath_KeepsBrokenPercentEncodingVerbatim() {
+        assertEquals("location/limits/100% off/tokens", ResourceDescriptorFactory.fromEntityPath(
+                ResourceTypes.LIMIT, "b", "location/", "100% off/tokens").getAbsoluteFilePath());
+    }
+
+    @Test
+    public void testFromEntityPath_StillRejectsUnstorableElements() {
+        // an encoded separator decodes after the split, so it would silently add a path level
+        assertThrows(IllegalArgumentException.class, () -> ResourceDescriptorFactory.fromEntityPath(
+                ResourceTypes.LIMIT, "b", "location/", "a%2Fb/tokens"));
+        assertThrows(IllegalArgumentException.class, () -> ResourceDescriptorFactory.fromEntityPath(
+                ResourceTypes.LIMIT, "b", "location/", "a%00b/tokens"));
+        assertThrows(IllegalArgumentException.class, () -> ResourceDescriptorFactory.fromEntityPath(
+                ResourceTypes.LIMIT, "b", "location/", "//tokens"));
+        assertThrows(IllegalArgumentException.class, () -> ResourceDescriptorFactory.fromEntityPath(
+                ResourceTypes.LIMIT, "b", "location/", "x".repeat(1000) + "/tokens"));
+    }
 }

--- a/server/src/test/resources/dial-config/bracket-named-model.json
+++ b/server/src/test/resources/dial-config/bracket-named-model.json
@@ -1,0 +1,24 @@
+{
+  "models": {
+    "anthropic.claude-opus-4-8[1m]": {
+      "type": "chat",
+      "endpoint": "http://localhost:4848/chat/completions"
+    }
+  },
+  "roles": {
+    "default": {
+      "limits": {
+        "anthropic.claude-opus-4-8[1m]": {
+          "minute": "100",
+          "day": "1000"
+        }
+      }
+    }
+  },
+  "keys": {
+    "proxyKey1": {
+      "project": "EPM-RTC-GPT",
+      "role": "default"
+    }
+  }
+}


### PR DESCRIPTION
### Description of changes

A model named `anthropic.claude-opus-4-8[1m]` makes `GET /v1/user/usage` and `GET /v1/user/limits` answer **500 for every caller who can access it**, and breaks admission, accounting and consent for that deployment:

```
java.lang.RuntimeException: java.net.URISyntaxException: Illegal character in path at index 25: anthropic.claude-opus-4-8[1m]
  at UrlUtil.decodePath(UrlUtil.java:72)
  at ResourceDescriptorFactory.fromEncoded(ResourceDescriptorFactory.java:34)
  at RateLimiter.getResourceDescription(RateLimiter.java:377)
  at RateLimiter.getLimitAbsolutePath(RateLimiter.java:246)
  at RateLimiter.collectUserStats(RateLimiter.java:170)
```

#### Root cause

The limit record path is assembled from an entity name and handed to `fromEncoded`, which validates every segment by constructing a `java.net.URI`. `[` and `]` are illegal in a URI path (legal only in an authority, for IPv6 literals), and nothing stops such a name: `ConfigPostProcessor` only rejects names holding a separator, and its `^[A-Za-z0-9-_]+$` pattern applies to toolset keys and external-service ids, not models. **A URI syntax check was being applied to a string that is not a URI.**

Worth noting what is *not* wrong with the name: it passes `isValidFilename` — `[` and `]` are not in `INVALID_FILE_NAME_CHARS`. The URI check is the entire defect, so nothing else is relaxed here.

The same helper backs admission (`checkTokenLimit`, `checkRequestLimit`), accounting (`increase`, `updateCostLimits`) and reporting (`getLimitStats`, `getUserStats`), so chat completions, `/anthropic/v1/messages`, `/openai/v1/responses`, the MCP and route surfaces and `/v1/deployments/{id}/limits` all failed too. `/v1/user/limits` and `/v1/user/usage` are the worst case, because `listAccessibleModels` walks *every* accessible model. `ConsentService.getResourceDescription` had the identical defect and failed even earlier, at the consent gate.

#### Why the name is not simply encoded first

`RoleBasedEntity.getName()` has mixed provenance:

| Source | `getName()` |
|---|---|
| File-config models / routes | plain configuration text, e.g. `anthropic.claude-opus-4-8[1m]` |
| Blob-sourced custom applications | an already url-encoded resource url containing `/`, e.g. `applications/<bucket>/my%20app` |

`increase()` has no type guard and is called with `context.getDeployment()`, so applications already hold nested records under `limits/applications/<bucket>/<app>/tokens`. Escaping the name would collapse that into one segment, get it rejected as a filename, and **silently stop all application usage and cost accounting** (that failure is only logged). Dropping the decode step instead (`fromDecoded`) would move the stored records of every escaped name to a new key and desynchronise consent, whose read and write sides currently agree only because both decode.

#### The change

- **`ResourceDescriptorFactory.fromEntityPath`** (new): decodes segments leniently and does not require the path to be a valid URI. Every other check is kept — including the file name charset, because the resulting key still has to be storable by each blob provider, and because such a path can come from a request (a consent deployment id does). Since only that one check is relaxed, any name that resolves today resolves to a **byte-identical** key, so no existing counter is orphaned. `fromEncoded` is unchanged and keeps rejecting non-URI input for client-supplied resource urls.
- **`RateLimiter`** and **`ConsentService`** build their descriptors with it.
- **`ProxyContext.hasNextInterceptor`** decodes the deployment name the same lenient way `decodedSourceDeployment` already does. Without this, completions still returned 500 — the end-to-end test caught it.

#### Tests

- `ResourceDescriptorFactoryTest` — the bracketed name resolves while `fromEncoded` still rejects it; the file name charset is still enforced (`{`, `}`, `"`, encoded or raw); broken percent-encoding kept verbatim; separator, control char, empty segment and >900-byte paths still rejected. Plus a key-stability spot-check over representative shapes (plain, `my%20app`, non-ASCII, single-segment) asserting both factories agree — the general guarantee comes from the two sharing one decode call and differing only in whether it may throw, not from this test.
- `RateLimiterTest` — full cycle for `anthropic.claude-opus-4-8[1m]` (admission, accounting, `/v1/user/usage` and per-deployment reporting), and an application-shaped name proving its record path is unchanged and read/write stay symmetric.
- `LimitApiTest` — end-to-end on a dedicated config: 200 from `/v1/user/limits`, `/v1/user/usage` and `/v1/deployments/{id}/limits`, with counters advancing after a completion.
- `ConsentServiceTest` — bracketed id, and an encoded application id pinning the decoded record path.

#### Verified against a running core

Before: all four request shapes above returned 500 with the exact stack trace from the incident. After: the completion returns 200 and counters advance to 30 tokens / 1 request, with the record stored verbatim at `limits/anthropic.claude-opus-4-8[1m]/tokens` in both blob storage and Redis.

#### Follow-ups deliberately left out

- `UrlUtil.decodePath` wraps `URISyntaxException` in a bare `RuntimeException` while the adjacent fragment/query check throws `IllegalArgumentException`. That inconsistency makes some malformed-path surfaces answer 500 where they mean 400 (e.g. `PublicationController.decodeRule`). Fixing it globally also changes two `catch (IllegalArgumentException) { /* ignore */ }` sites in `ApplicationSchemaService`/`CatalogSchemaService` from "hard error" to "silently skip the resource", so it needs its own change and test sweep.
- `/v1/user/limits` and `/v1/user/usage` answer for the entire config, so a name that *decodes* to something no record path can hold — `gpt%2Fbeta`, `gpt%00x`, or one long enough to exceed the 900-byte limit — would still fail them for every caller. Not user-reachable (names a user controls are `getUrl()` output, singly escaped, and Guava escapes `%`), so this is an admin-config typo rather than the reported bug; per-deployment error isolation belongs in its own change.
- `ConsentService.acceptConsent` does not call `findDeployment`, unlike `buildConsent`, so any authenticated caller can write an arbitrary-key consent record in their own bucket. Pre-existing; adding the check changes API behavior and deserves its own PR.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
