### PR TITLE
fix: validate empty apiKeyHeader in toolset auth settings #1538

### DIFF
--- a/credentials/src/main/java/com/epam/aidial/core/credentials/validation/BaseAuthSettingsValidator.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/validation/BaseAuthSettingsValidator.java
@@ -2,8 +2,10 @@ package com.epam.aidial.core.credentials.validation;
 
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsChangeMode;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 public abstract class BaseAuthSettingsValidator implements AuthSettingsValidator {
@@ -28,41 +30,36 @@ public abstract class BaseAuthSettingsValidator implements AuthSettingsValidator
         }
     }
 
+    /**
+     * A blank string or an empty list carries no value: clients send them for fields they left empty, and a
+     * required field filled that way is unusable downstream. Treating them as absent makes such a request fail
+     * here with the required-field error instead of storing a broken configuration.
+     */
     private Set<ResourceAuthSettingsField> extractFields(ResourceAuthSettings resourceAuthSettings) {
         Set<ResourceAuthSettingsField> fieldsWithValues = EnumSet.noneOf(ResourceAuthSettingsField.class);
 
-        if (resourceAuthSettings.getClientId() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.CLIENT_ID);
-        }
-        if (resourceAuthSettings.getClientSecret() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.CLIENT_SECRET);
-        }
-        if (resourceAuthSettings.getRedirectUri() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.REDIRECT_URI);
-        }
-        if (resourceAuthSettings.getAuthorizationEndpoint() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.AUTHORIZATION_ENDPOINT);
-        }
-        if (resourceAuthSettings.getTokenEndpoint() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.TOKEN_ENDPOINT);
-        }
-        if (resourceAuthSettings.getCodeChallenge() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.CODE_CHALLENGE);
-        }
-        if (resourceAuthSettings.getCodeVerifier() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.CODE_VERIFIER);
-        }
-        if (resourceAuthSettings.getCodeChallengeMethod() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.CODE_CHALLENGE_METHOD);
-        }
-        if (resourceAuthSettings.getScopesSupported() != null) {
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.CLIENT_ID, resourceAuthSettings.getClientId());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.CLIENT_SECRET, resourceAuthSettings.getClientSecret());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.REDIRECT_URI, resourceAuthSettings.getRedirectUri());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.AUTHORIZATION_ENDPOINT, resourceAuthSettings.getAuthorizationEndpoint());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.TOKEN_ENDPOINT, resourceAuthSettings.getTokenEndpoint());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.CODE_CHALLENGE, resourceAuthSettings.getCodeChallenge());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.CODE_VERIFIER, resourceAuthSettings.getCodeVerifier());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.CODE_CHALLENGE_METHOD, resourceAuthSettings.getCodeChallengeMethod());
+        addIfHasValue(fieldsWithValues, ResourceAuthSettingsField.API_KEY_HEADER, resourceAuthSettings.getApiKeyHeader());
+
+        List<String> scopesSupported = resourceAuthSettings.getScopesSupported();
+        if (scopesSupported != null && !scopesSupported.isEmpty()) {
             fieldsWithValues.add(ResourceAuthSettingsField.SCOPES_SUPPORTED);
-        }
-        if (resourceAuthSettings.getApiKeyHeader() != null) {
-            fieldsWithValues.add(ResourceAuthSettingsField.API_KEY_HEADER);
         }
 
         return fieldsWithValues;
+    }
+
+    private void addIfHasValue(Set<ResourceAuthSettingsField> fieldsWithValues, ResourceAuthSettingsField field, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            fieldsWithValues.add(field);
+        }
     }
 
     protected abstract ResourceAuthSettingsValidationFields getValidationFields(ResourceAuthSettingsChangeMode resourceAuthSettingsChangeMode);

--- a/credentials/src/test/java/com/epam/aidial/core/credentials/validation/ApiKeyAuthSettingsValidatorTest.java
+++ b/credentials/src/test/java/com/epam/aidial/core/credentials/validation/ApiKeyAuthSettingsValidatorTest.java
@@ -29,12 +29,38 @@ class ApiKeyAuthSettingsValidatorTest {
                 ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES));
     }
 
+    @Test
+    void testValidateCreate_BlankForbiddenFieldsAreTreatedAsNotProvided() {
+        assertDoesNotThrow(() -> validator.validate(
+                ResourceAuthSettings.builder()
+                        .authenticationType(AuthenticationType.API_KEY)
+                        .apiKeyHeader("Api-Key")
+                        .clientId("")
+                        .clientSecret("  ")
+                        .redirectUri("")
+                        .scopesSupported(List.of())
+                        .build(),
+                ResourceAuthSettingsChangeMode.NO_CLIENT_CHANGES));
+    }
+
     static Stream<Arguments> provideInvalidResourceAuthSettingsForUpdate() {
         return Stream.of(
                 // Invalid API_KEY cases
                 Arguments.of(ResourceAuthSettings.builder()
                                 .authenticationType(AuthenticationType.API_KEY)
                                 .apiKeyHeader(null)
+                                .build(),
+                        "Field 'API_KEY_HEADER' is required for API_KEY authentication."),
+
+                Arguments.of(ResourceAuthSettings.builder()
+                                .authenticationType(AuthenticationType.API_KEY)
+                                .apiKeyHeader("")
+                                .build(),
+                        "Field 'API_KEY_HEADER' is required for API_KEY authentication."),
+
+                Arguments.of(ResourceAuthSettings.builder()
+                                .authenticationType(AuthenticationType.API_KEY)
+                                .apiKeyHeader("   ")
                                 .build(),
                         "Field 'API_KEY_HEADER' is required for API_KEY authentication."),
 

--- a/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ToolSetApiTest.java
@@ -1527,6 +1527,24 @@ public class ToolSetApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testCreateToolSetWithBlankApiKeyHeader() {
+        for (String apiKeyHeader : List.of("", "   ")) {
+            Response response = send(HttpMethod.PUT, "/v1/toolsets/4X25dj1mja51jykqxsXnCH/toolset@", null, """
+                    {
+                        "endpoint": "http://localhost:9876",
+                        "transport": "HTTP",
+                        "allowedTools": [],
+                        "auth_settings": {
+                            "authentication_type": "API_KEY",
+                            "api_key_header": "%s"
+                        }
+                    }
+                    """.formatted(apiKeyHeader), "authorization", "admin");
+            verify(response, 400, "Field 'API_KEY_HEADER' is required for API_KEY authentication.");
+        }
+    }
+
+    @Test
     void testSignInWithIncorrectAuthType() {
         String globalSignInRequestJson = """
                 {


### PR DESCRIPTION
Creating a toolset with `"api_key_header": ""` under `API_KEY` authentication was accepted instead of rejected, storing a toolset that can never authenticate. Field presence in the auth-settings validator was decided with a null check, so an empty or blank string counted as a supplied value.

### Applicable issues

- fixes #1538

### Description of changes

- `BaseAuthSettingsValidator.extractFields` now treats a blank string (and an empty list for `scopes_supported`) as *not provided*, instead of only `null`. A blank `api_key_header` therefore fails the existing required-field check and the request is rejected with `400 Field 'API_KEY_HEADER' is required for API_KEY authentication.`
- Fixed in the shared helper rather than only for `apiKeyHeader`: the same null check let a blank `client_id`/`client_secret` satisfy the OAuth required-field checks.
- This also relaxes the *forbidden*-field direction — a blank value no longer trips it, so a client that leaves `api_key_header: ""` in the payload while switching to `NONE` is no longer rejected. Blank consistently means "not set" in both directions.
- Tests: unit coverage in `ApiKeyAuthSettingsValidatorTest` for empty and whitespace-only headers plus blank forbidden fields, and an end-to-end `ToolSetApiTest.testCreateToolSetWithBlankApiKeyHeader` reproducing the issue against the toolset PUT endpoint. All new tests were verified to fail without the fix.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.