### PR TITLE
feat: skip API key sign-in when the submitted key is unchanged #1843

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/SecuredResourceService.java
@@ -1,10 +1,12 @@
 package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.AuthenticationType;
+import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.SecuredResource;
 import com.epam.aidial.core.config.ToolSet;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsDescriptor;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
+import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
@@ -29,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.time.Duration;
+import java.util.Objects;
 
 @Slf4j
 @AllArgsConstructor
@@ -41,13 +44,57 @@ public class SecuredResourceService {
     private final McpHttpClientBuilder mcpHttpClientBuilder;
 
     public void signIn(ProxyContext context, SecuredResource securedResource, ResourceSignInRequest request) {
-        if (AuthenticationType.API_KEY.equals(request.getAuthenticationType())) {
-            validateApiKey(securedResource, request.getApiKey());
+        boolean apiKeyAuth = AuthenticationType.API_KEY.equals(request.getAuthenticationType());
+        if (apiKeyAuth) {
+            validateApiKeyFormat(request.getApiKey());
         }
         CredentialsLocator credentialsLocator = createCredentialsLocator(context, securedResource, request.getUrl());
         CredentialsDescriptor credentialsDescriptor = credentialsLocator.getCredentialsDescriptors().get(request.getCredentialsLevel());
+        if (apiKeyAuth) {
+            if (isStoredApiKeyUnchanged(credentialsDescriptor, securedResource, request, context.getInitiatorId())) {
+                log.debug("Skipping API key sign-in for resourceId={}: the submitted key matches the stored one",
+                        credentialsDescriptor.getResourceId());
+                return;
+            }
+            probeApiKey(securedResource, request.getApiKey());
+        }
         resourceCredentialsService.addResourceCredentials(credentialsDescriptor, securedResource.getAuthSettings(),
                 request, context.getInitiatorId());
+    }
+
+    /**
+     * True when re-storing the submitted key would be a no-op: the record already held at this level is an
+     * API_KEY record with the same key, the same header, and (for USER level) the same owner and offline-usage
+     * consent. Anything else — including an unreadable record — must go through the normal store path (#1843).
+     */
+    private boolean isStoredApiKeyUnchanged(CredentialsDescriptor credentialsDescriptor,
+                                            SecuredResource securedResource,
+                                            ResourceSignInRequest request,
+                                            String userId) {
+        if (credentialsDescriptor == null) {
+            return false;
+        }
+        ResourceCredentials stored;
+        try {
+            stored = resourceCredentialsService.getResourceCredentials(credentialsDescriptor);
+        } catch (RuntimeException e) {
+            // Best-effort: a record that cannot be read (undecryptable, malformed, storage hiccup) must still be
+            // overwritable by sign-in, as it was before this pre-check existed.
+            log.warn("Cannot read stored credentials for resourceId={}: {}", credentialsDescriptor.getResourceId(), e.getMessage());
+            return false;
+        }
+        if (stored == null
+                || !AuthenticationType.API_KEY.equals(stored.getAuthenticationType())
+                || !request.getCredentialsLevel().equals(stored.getCredentialsLevel())
+                || !Objects.equals(securedResource.getAuthSettings().getApiKeyHeader(), stored.getApiKeyHeader())
+                || !Objects.equals(request.getApiKey(), stored.getApiKey())) {
+            return false;
+        }
+        if (CredentialsLevel.USER.equals(request.getCredentialsLevel())) {
+            return Objects.equals(userId, stored.getUserId())
+                    && stored.isOfflineUsageConsent() == request.isOfflineUsageConsent();
+        }
+        return true;
     }
 
     public boolean signOut(ProxyContext context, SecuredResource securedResource, ResourceSignOutRequest request) {
@@ -67,21 +114,22 @@ public class SecuredResourceService {
         throw new IllegalArgumentException("Unsupported secured resource type: " + resource.getClass().getSimpleName());
     }
 
-    /**
-     * Validates an API key before it is stored at sign-in: rejects blank/malformed keys, then probes
-     * the resource endpoint, assuming it speaks MCP (initialize + tools/list). Rejects only when the
-     * server explicitly refuses the request (HTTP 401/403 or a JSON-RPC error); connectivity issues
-     * and non-MCP endpoints are tolerated because the key may be provisioned before the server is
-     * reachable (#1698).
-     */
-    private void validateApiKey(SecuredResource securedResource, String apiKey) {
+    private static void validateApiKeyFormat(String apiKey) {
         if (StringUtils.isBlank(apiKey)) {
             throw new HttpException(HttpStatus.BAD_REQUEST, "api_key must not be blank");
         }
         if (containsIllegalHeaderChars(apiKey)) {
             throw new HttpException(HttpStatus.BAD_REQUEST, "api_key contains illegal control characters");
         }
+    }
 
+    /**
+     * Validates an API key before it is stored at sign-in by probing the resource endpoint, assuming it
+     * speaks MCP (initialize + tools/list). Rejects only when the server explicitly refuses the request
+     * (HTTP 401/403 or a JSON-RPC error); connectivity issues and non-MCP endpoints are tolerated because
+     * the key may be provisioned before the server is reachable (#1698).
+     */
+    private void probeApiKey(SecuredResource securedResource, String apiKey) {
         String endpoint = securedResource.getEndpoint();
         String apiKeyHeader = securedResource.getAuthSettings().getApiKeyHeader();
         if (StringUtils.isBlank(endpoint) || StringUtils.isBlank(apiKeyHeader)) {

--- a/server/src/test/java/com/epam/aidial/core/server/service/SecuredResourceServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/SecuredResourceServiceTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.core.config.CredentialsLevel;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.SecuredResource;
 import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.credentials.data.credentials.ResourceCredentials;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignInRequest;
 import com.epam.aidial.core.credentials.data.credentials.ResourceSignOutRequest;
 import com.epam.aidial.core.credentials.service.ResourceCredentialsService;
@@ -16,6 +17,7 @@ import com.epam.aidial.core.server.mcp.McpHttpClientBuilder;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,12 +25,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -129,6 +134,114 @@ class SecuredResourceServiceTest {
 
         assertThrows(IllegalArgumentException.class, () -> service.signIn(context, unknownResource, request));
         verifyNoInteractions(resourceCredentialsService);
+    }
+
+    // #1843: re-submitting the stored key must neither probe the endpoint nor rewrite the credentials
+    @Test
+    void testSignIn_UnchangedApiKeySkipsProbeAndStore() throws IOException {
+        mockLocatorPlumbing();
+        try (MockWebServer mcpServer = new MockWebServer()) {
+            mcpServer.start();
+            ToolSet toolSet = createToolSet(mcpServer.url("/mcp").toString());
+            ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "same-key");
+            when(resourceCredentialsService.getResourceCredentials(any()))
+                    .thenReturn(storedApiKey("same-key", "Authorization", CredentialsLevel.GLOBAL));
+
+            service.signIn(context, toolSet, request);
+
+            assertEquals(0, mcpServer.getRequestCount());
+            verify(resourceCredentialsService, never()).addResourceCredentials(any(), any(), any(), any());
+        }
+    }
+
+    @Test
+    void testSignIn_ChangedApiKeyStored() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "new-key");
+        when(resourceCredentialsService.getResourceCredentials(any()))
+                .thenReturn(storedApiKey("old-key", "Authorization", CredentialsLevel.GLOBAL));
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    // The header the key is sent under is part of the stored record, so a config change must be persisted
+    @Test
+    void testSignIn_SameApiKeyWithChangedHeaderStored() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "same-key");
+        when(resourceCredentialsService.getResourceCredentials(any()))
+                .thenReturn(storedApiKey("same-key", "X-Api-Key", CredentialsLevel.GLOBAL));
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    @Test
+    void testSignIn_UserLevelUnchangedApiKeySkipped() {
+        mockLocatorPlumbing();
+        ResourceSignInRequest request = userSignInRequest("same-key", true);
+        ResourceCredentials stored = storedApiKey("same-key", "Authorization", CredentialsLevel.USER);
+        stored.setUserId("userSub");
+        stored.setOfflineUsageConsent(true);
+        when(resourceCredentialsService.getResourceCredentials(any())).thenReturn(stored);
+
+        service.signIn(context, createToolSet(null), request);
+
+        verify(resourceCredentialsService, never()).addResourceCredentials(any(), any(), any(), any());
+    }
+
+    // Offline-usage consent is recorded on the credentials, so flipping it must go through the store path
+    @Test
+    void testSignIn_UserLevelConsentChangeStored() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = userSignInRequest("same-key", true);
+        ResourceCredentials stored = storedApiKey("same-key", "Authorization", CredentialsLevel.USER);
+        stored.setUserId("userSub");
+        when(resourceCredentialsService.getResourceCredentials(any())).thenReturn(stored);
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    // An unreadable record must not fail sign-in: it is overwritten, as before the pre-check existed
+    @Test
+    void testSignIn_UnreadableStoredCredentialsStored() {
+        mockLocatorPlumbing();
+        ToolSet toolSet = createToolSet(null);
+        ResourceSignInRequest request = signInRequest(AuthenticationType.API_KEY, "some-key");
+        when(resourceCredentialsService.getResourceCredentials(any()))
+                .thenThrow(new IllegalArgumentException("Provided payload do not match required schema"));
+
+        service.signIn(context, toolSet, request);
+
+        verify(resourceCredentialsService).addResourceCredentials(any(), eq(toolSet.getAuthSettings()), eq(request), eq("userSub"));
+    }
+
+    private static ResourceCredentials storedApiKey(String apiKey, String apiKeyHeader, CredentialsLevel credentialsLevel) {
+        return ResourceCredentials.builder()
+                .resourceId(RESOURCE_URL)
+                .credentialsLevel(credentialsLevel)
+                .authenticationType(AuthenticationType.API_KEY)
+                .apiKeyHeader(apiKeyHeader)
+                .apiKey(apiKey)
+                .build();
+    }
+
+    private static ResourceSignInRequest userSignInRequest(String apiKey, boolean offlineUsageConsent) {
+        return ResourceSignInRequest.builder()
+                .url(RESOURCE_URL)
+                .credentialsLevel(CredentialsLevel.USER)
+                .authenticationType(AuthenticationType.API_KEY)
+                .apiKey(apiKey)
+                .offlineUsageConsent(offlineUsageConsent)
+                .build();
     }
 
     private void mockLocatorPlumbing() {


### PR DESCRIPTION
`POST /v1/ops/toolset/signin` with `authentication_type: API_KEY` now short-circuits when the submitted key is identical to the one already stored at that credentials level: no MCP `initialize` + `tools/list` probe against the toolset endpoint, and no re-encryption/rewrite of the credentials record. Any other case — no record, a different key or header, a different auth type, or a record that cannot be read — goes through the existing validate-and-store path unchanged.

### Applicable issues

- fixes #1843

### Description of changes

- `SecuredResourceService.signIn` resolves the credentials descriptor first, then checks `isStoredApiKeyUnchanged` before probing or storing; on a match it returns success immediately.
- A record counts as unchanged only when it is an `API_KEY` record at the requested level with the same `apiKey` **and** the same `apiKeyHeader` from the current auth settings. For `USER` level it must additionally match the caller's user id and the request's `offlineUsageConsent`, so a consent flip or a header config change is still persisted.
- The pre-check is best-effort: if the stored record cannot be read (undecryptable, malformed, transient storage error) it falls back to the normal store path, preserving the previous behavior where sign-in simply overwrites such a record. Without this, a malformed blob would have turned every subsequent sign-in into a 400.
- `validateApiKey` split into `validateApiKeyFormat` (blank / illegal control characters) and `probeApiKey` (the MCP probe). Format validation still runs first, before any storage read, so malformed keys are rejected exactly as before.
- Authorization is unaffected — `verifyAccess` runs in the controller before `signIn`, so the skip is reachable only by callers who could already overwrite the credential.
- Tests cover: unchanged key skips both the probe (asserted via request count against a mock server) and the store; changed key, changed header, and flipped `USER`-level consent all still store; an unreadable stored record still stores.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.