### PR TITLE
feat: cache pricing decision tree for provider TTL/service-tier rate matrices

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Condition.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Condition.java
@@ -1,0 +1,24 @@
+package com.epam.aidial.core.config;
+
+import com.epam.aidial.core.config.validation.ValidCondition;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * A single test in a pricing decision tree: {@code field <operator> value}. {@code field} is
+ * either a bare standard-field name (see {@link StandardField}) or a {@code $}-prefixed JSON Path
+ * expression (RFC 9535) evaluated against the active call's usage data.
+ */
+@Data
+@ValidCondition
+public class Condition {
+
+    @NotNull
+    private String field;
+
+    @NotNull
+    private Operator operator;
+
+    @NotNull
+    private Object value;
+}

--- a/config/src/main/java/com/epam/aidial/core/config/Operator.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Operator.java
@@ -1,0 +1,29 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+/**
+ * Comparison operator for a pricing decision-tree {@link Condition}.
+ */
+@Getter
+public enum Operator {
+
+    EQ("=="),
+    NE("!="),
+    GT(">"),
+    LT("<"),
+    GE(">="),
+    LE("<=");
+
+    @JsonValue
+    private final String symbol;
+
+    Operator(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public boolean isOrdering() {
+        return this == GT || this == LT || this == GE || this == LE;
+    }
+}

--- a/config/src/main/java/com/epam/aidial/core/config/Pricing.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Pricing.java
@@ -14,9 +14,10 @@ public class Pricing {
     @JsonDeserialize(using = DoubleStringDeserializer.class)
     private String completion;
 
-    @JsonDeserialize(using = DoubleStringDeserializer.class)
-    private String cacheRead;
+    // Generated OpenAPI schema documents this as PricingRate's own object shape only; the
+    // generator has no field-level oneOf hook, so the flat-rate-string alternative doesn't
+    // render here even though the deserializer accepts it (PricingRateDeserializer).
+    private PricingRate cacheRead;
 
-    @JsonDeserialize(using = DoubleStringDeserializer.class)
-    private String cacheWrite;
+    private PricingRate cacheWrite;
 }

--- a/config/src/main/java/com/epam/aidial/core/config/PricingRate.java
+++ b/config/src/main/java/com/epam/aidial/core/config/PricingRate.java
@@ -1,0 +1,37 @@
+package com.epam.aidial.core.config;
+
+import com.epam.aidial.core.config.databind.PricingRateDeserializer;
+import com.epam.aidial.core.config.databind.PricingRateSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Data;
+
+/**
+ * A per-token pricing rate that is either a flat rate (the {@code rate} leaf shape, same
+ * convention as {@code Pricing.prompt}/{@code Pricing.completion}) or a decision tree that
+ * resolves to a rate based on a {@link Condition} evaluated against the active call's usage data.
+ * Not tied to cache pricing specifically - it is used today only for {@code Pricing.cacheRead}/
+ * {@code cacheWrite}, but nothing in its shape assumes that.
+ *
+ * <p>Deliberately carries no class-level {@code @ApiSchema}: the string-or-tree union is declared
+ * at each field that uses this type (see {@code Pricing.cacheRead}/{@code cacheWrite}), so this
+ * class's own bean shape (including the recursive {@code ifTrue}/{@code ifFalse} fields) still
+ * reflects normally wherever it's referenced as the object alternative of that union.
+ */
+@Data
+@JsonDeserialize(using = PricingRateDeserializer.class)
+@JsonSerialize(using = PricingRateSerializer.class)
+public class PricingRate {
+
+    // leaf shape
+    private String rate;
+
+    // node shape; ifTrue/ifFalse omitted -> falls back to promptRate
+    private Condition test;
+    private PricingRate ifTrue;
+    private PricingRate ifFalse;
+
+    public boolean isLeaf() {
+        return rate != null;
+    }
+}

--- a/config/src/main/java/com/epam/aidial/core/config/StandardField.java
+++ b/config/src/main/java/com/epam/aidial/core/config/StandardField.java
@@ -1,0 +1,40 @@
+package com.epam.aidial.core.config;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Fixed vocabulary of fields a pricing decision-tree {@link Condition} can address by bare name
+ * (as opposed to a {@code $}-prefixed JSON Path expression). Resolution of these fields against a
+ * specific upstream response shape is a runtime concern (see the server module); this enum only
+ * carries the vocabulary itself and each field's known type, which is enough to reject an ordering
+ * operator against a string-typed field at config load time.
+ */
+public enum StandardField {
+
+    CACHED_READ_TOKENS("cachedReadTokens", true),
+    CACHED_WRITE_TOKENS("cachedWriteTokens", true),
+    PROMPT_TOKENS("promptTokens", true),
+    SERVICE_TIER("serviceTier", false),
+    TTL("ttl", false);
+
+    private final String fieldName;
+    private final boolean numeric;
+
+    StandardField(String fieldName, boolean numeric) {
+        this.fieldName = fieldName;
+        this.numeric = numeric;
+    }
+
+    public static Optional<StandardField> fromFieldName(String fieldName) {
+        return Arrays.stream(values()).filter(field -> field.fieldName.equals(fieldName)).findFirst();
+    }
+
+    public boolean isNumeric() {
+        return numeric;
+    }
+
+    public boolean isString() {
+        return !numeric;
+    }
+}

--- a/config/src/main/java/com/epam/aidial/core/config/databind/PricingRateDeserializer.java
+++ b/config/src/main/java/com/epam/aidial/core/config/databind/PricingRateDeserializer.java
@@ -1,0 +1,64 @@
+package com.epam.aidial.core.config.databind;
+
+import com.epam.aidial.core.config.Condition;
+import com.epam.aidial.core.config.PricingRate;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+
+/**
+ * Accepts either a plain rate string (the flat, pre-existing shape) or a decision-tree node
+ * object ({@code {test, ifTrue, ifFalse}}), producing a unified {@link PricingRate}.
+ */
+public class PricingRateDeserializer extends JsonDeserializer<PricingRate> {
+
+    @Override
+    public PricingRate deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+        if (p.getCurrentToken() == JsonToken.VALUE_STRING) {
+            String rate = p.getValueAsString();
+            try {
+                Double.parseDouble(rate);
+            } catch (NumberFormatException e) {
+                throw InvalidFormatException.from(p, "Expected a JSON string with a valid double", rate, PricingRate.class);
+            }
+            PricingRate pricingRate = new PricingRate();
+            pricingRate.setRate(rate);
+            return pricingRate;
+        }
+
+        if (p.getCurrentToken() == JsonToken.START_OBJECT) {
+            Condition test = null;
+            PricingRate ifTrue = null;
+            PricingRate ifFalse = null;
+            while (p.nextToken() != JsonToken.END_OBJECT) {
+                String name = p.getCurrentName();
+                p.nextToken();
+                switch (name) {
+                    case "test" -> test = p.readValueAs(Condition.class);
+                    case "ifTrue" -> ifTrue = deserialize(p, ctx);
+                    case "ifFalse" -> ifFalse = deserialize(p, ctx);
+                    default -> p.skipChildren();
+                }
+            }
+            if (test == null) {
+                return ctx.reportInputMismatch(PricingRate.class, "A decision-tree node requires a \"test\" field");
+            }
+            PricingRate pricingRate = new PricingRate();
+            pricingRate.setTest(test);
+            pricingRate.setIfTrue(ifTrue);
+            pricingRate.setIfFalse(ifFalse);
+            return pricingRate;
+        }
+
+        if (p.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+
+        return ctx.reportInputMismatch(PricingRate.class,
+                "Expected a rate string or a decision-tree node object, got %s", p.getCurrentToken());
+    }
+}

--- a/config/src/main/java/com/epam/aidial/core/config/databind/PricingRateSerializer.java
+++ b/config/src/main/java/com/epam/aidial/core/config/databind/PricingRateSerializer.java
@@ -1,0 +1,37 @@
+package com.epam.aidial.core.config.databind;
+
+import com.epam.aidial.core.config.PricingRate;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Serializes a {@link PricingRate} as a plain rate string when it's the flat leaf shape, and as a
+ * {@code {test, ifTrue, ifFalse}} decision-tree node object otherwise.
+ */
+public class PricingRateSerializer extends JsonSerializer<PricingRate> {
+
+    @Override
+    public void serialize(PricingRate value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value.isLeaf()) {
+            gen.writeString(value.getRate());
+            return;
+        }
+
+        gen.writeStartObject();
+        gen.writeObjectField("test", value.getTest());
+        writeBranch(gen, serializers, "ifTrue", value.getIfTrue());
+        writeBranch(gen, serializers, "ifFalse", value.getIfFalse());
+        gen.writeEndObject();
+    }
+
+    private static void writeBranch(JsonGenerator gen, SerializerProvider serializers, String name, PricingRate branch)
+            throws IOException {
+        if (branch != null) {
+            gen.writeFieldName(name);
+            serializers.defaultSerializeValue(branch, gen);
+        }
+    }
+}

--- a/config/src/main/java/com/epam/aidial/core/config/validation/ValidCondition.java
+++ b/config/src/main/java/com/epam/aidial/core/config/validation/ValidCondition.java
@@ -1,0 +1,22 @@
+package com.epam.aidial.core.config.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ReportAsSingleViolation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+@Documented
+@Constraint(validatedBy = { ValidConditionValidator.class })
+@Target({ TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@ReportAsSingleViolation
+public @interface ValidCondition {
+    String message() default "Cache pricing condition is invalid";
+    Class<?>[] groups() default {};
+    Class<? extends jakarta.validation.Payload>[] payload() default {};
+}

--- a/config/src/main/java/com/epam/aidial/core/config/validation/ValidConditionValidator.java
+++ b/config/src/main/java/com/epam/aidial/core/config/validation/ValidConditionValidator.java
@@ -1,0 +1,40 @@
+package com.epam.aidial.core.config.validation;
+
+import com.epam.aidial.core.config.Condition;
+import com.epam.aidial.core.config.Operator;
+import com.epam.aidial.core.config.StandardField;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidConditionValidator implements ConstraintValidator<ValidCondition, Condition> {
+
+    @Override
+    public boolean isValid(Condition value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        Object conditionValue = value.getValue();
+        if (!(conditionValue instanceof String) && !(conditionValue instanceof Number)) {
+            return fail(context, "Condition value must be a string or a number");
+        }
+
+        String field = value.getField();
+        Operator operator = value.getOperator();
+        if (field != null && operator != null && operator.isOrdering() && !field.startsWith("$")) {
+            StandardField standardField = StandardField.fromFieldName(field).orElse(null);
+            if (standardField != null && standardField.isString()) {
+                return fail(context, "Ordering operator '" + operator.getSymbol()
+                        + "' is not valid against string-typed standard field '" + field + "'");
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean fail(ConstraintValidatorContext context, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        return false;
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/OperatorTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/OperatorTest.java
@@ -1,0 +1,34 @@
+package com.epam.aidial.core.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OperatorTest {
+
+    @ParameterizedTest
+    @EnumSource(value = Operator.class, names = {"GT", "LT", "GE", "LE"})
+    void orderingOperatorsAreOrdering(Operator operator) {
+        assertTrue(operator.isOrdering());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Operator.class, names = {"EQ", "NE"})
+    void equalityOperatorsAreNotOrdering(Operator operator) {
+        assertFalse(operator.isOrdering());
+    }
+
+    @Test
+    void symbolsMatchWireFormat() {
+        assertEquals("==", Operator.EQ.getSymbol());
+        assertEquals("!=", Operator.NE.getSymbol());
+        assertEquals(">", Operator.GT.getSymbol());
+        assertEquals("<", Operator.LT.getSymbol());
+        assertEquals(">=", Operator.GE.getSymbol());
+        assertEquals("<=", Operator.LE.getSymbol());
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/PricingRateTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/PricingRateTest.java
@@ -1,0 +1,93 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PricingRateTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void deserializesFlatRateString() throws Exception {
+        PricingRate rate = MAPPER.readValue("\"0.0000003\"", PricingRate.class);
+        assertTrue(rate.isLeaf());
+        assertEquals("0.0000003", rate.getRate());
+    }
+
+    @Test
+    void deserializesDecisionTreeNode() throws Exception {
+        String json = """
+                {
+                  "test": { "field": "promptTokens", "operator": ">", "value": 200000 },
+                  "ifTrue": "0.0000006",
+                  "ifFalse": "0.0000003"
+                }
+                """;
+        PricingRate rate = MAPPER.readValue(json, PricingRate.class);
+        assertFalse(rate.isLeaf());
+        assertEquals("promptTokens", rate.getTest().getField());
+        assertEquals(Operator.GT, rate.getTest().getOperator());
+        assertEquals(200000, rate.getTest().getValue());
+        assertTrue(rate.getIfTrue().isLeaf());
+        assertEquals("0.0000006", rate.getIfTrue().getRate());
+        assertTrue(rate.getIfFalse().isLeaf());
+        assertEquals("0.0000003", rate.getIfFalse().getRate());
+    }
+
+    @Test
+    void deserializesNestedDecisionTree() throws Exception {
+        String json = """
+                {
+                  "test": { "field": "promptTokens", "operator": ">", "value": 200000 },
+                  "ifTrue": {
+                    "test": { "field": "ttl", "operator": "==", "value": "1h" },
+                    "ifTrue": "0.000012"
+                  }
+                }
+                """;
+        PricingRate rate = MAPPER.readValue(json, PricingRate.class);
+        assertFalse(rate.isLeaf());
+        PricingRate ifTrue = rate.getIfTrue();
+        assertFalse(ifTrue.isLeaf());
+        assertEquals("ttl", ifTrue.getTest().getField());
+        assertEquals("0.000012", ifTrue.getIfTrue().getRate());
+        assertNull(ifTrue.getIfFalse());
+        assertNull(rate.getIfFalse());
+    }
+
+    @Test
+    void rejectsNonDoubleLeafString() {
+        assertThrows(InvalidFormatException.class, () -> MAPPER.readValue("\"not-a-number\"", PricingRate.class));
+    }
+
+    @Test
+    void rejectsNodeMissingTest() {
+        assertThrows(Exception.class, () -> MAPPER.readValue("{\"ifTrue\": \"0.1\"}", PricingRate.class));
+    }
+
+    @Test
+    void serializesLeafAsPlainString() throws Exception {
+        PricingRate rate = new PricingRate();
+        rate.setRate("0.0000003");
+        assertEquals("\"0.0000003\"", MAPPER.writeValueAsString(rate));
+    }
+
+    @Test
+    void roundTripsNestedTree() throws Exception {
+        String json = """
+                {"test":{"field":"promptTokens","operator":">","value":200000},"ifTrue":"0.000012","ifFalse":"0.0000075"}""";
+        PricingRate rate = MAPPER.readValue(json, PricingRate.class);
+        String written = MAPPER.writeValueAsString(rate);
+        PricingRate roundTripped = MAPPER.readValue(written, PricingRate.class);
+        assertEquals(rate.getTest().getField(), roundTripped.getTest().getField());
+        assertEquals(rate.getIfTrue().getRate(), roundTripped.getIfTrue().getRate());
+        assertEquals(rate.getIfFalse().getRate(), roundTripped.getIfFalse().getRate());
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/StandardFieldTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/StandardFieldTest.java
@@ -1,0 +1,42 @@
+package com.epam.aidial.core.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardFieldTest {
+
+    @Test
+    void fromFieldNameResolvesKnownNames() {
+        assertEquals(Optional.of(StandardField.CACHED_READ_TOKENS), StandardField.fromFieldName("cachedReadTokens"));
+        assertEquals(Optional.of(StandardField.CACHED_WRITE_TOKENS), StandardField.fromFieldName("cachedWriteTokens"));
+        assertEquals(Optional.of(StandardField.PROMPT_TOKENS), StandardField.fromFieldName("promptTokens"));
+        assertEquals(Optional.of(StandardField.SERVICE_TIER), StandardField.fromFieldName("serviceTier"));
+        assertEquals(Optional.of(StandardField.TTL), StandardField.fromFieldName("ttl"));
+    }
+
+    @Test
+    void fromFieldNameMissesUnknownOrJsonPathNames() {
+        assertEquals(Optional.empty(), StandardField.fromFieldName("$.usage.foo"));
+        assertEquals(Optional.empty(), StandardField.fromFieldName("notAStandardField"));
+    }
+
+    @Test
+    void numericFieldsAreNotString() {
+        assertTrue(StandardField.CACHED_READ_TOKENS.isNumeric());
+        assertTrue(StandardField.CACHED_WRITE_TOKENS.isNumeric());
+        assertTrue(StandardField.PROMPT_TOKENS.isNumeric());
+        assertFalse(StandardField.CACHED_READ_TOKENS.isString());
+    }
+
+    @Test
+    void stringFieldsAreNotNumeric() {
+        assertTrue(StandardField.SERVICE_TIER.isString());
+        assertTrue(StandardField.TTL.isString());
+        assertFalse(StandardField.SERVICE_TIER.isNumeric());
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/validation/ValidConditionValidatorTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/validation/ValidConditionValidatorTest.java
@@ -1,0 +1,81 @@
+package com.epam.aidial.core.config.validation;
+
+import com.epam.aidial.core.config.Condition;
+import com.epam.aidial.core.config.Operator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+class ValidConditionValidatorTest {
+
+    private ValidConditionValidator validator;
+
+    @Mock
+    private ConstraintValidatorContext context;
+    @Mock
+    private ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilder;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        doNothing().when(context).disableDefaultConstraintViolation();
+        when(context.buildConstraintViolationWithTemplate(any())).thenReturn(constraintViolationBuilder);
+        validator = new ValidConditionValidator();
+    }
+
+    private static Condition condition(String field, Operator operator, Object value) {
+        Condition condition = new Condition();
+        condition.setField(field);
+        condition.setOperator(operator);
+        condition.setValue(value);
+        return condition;
+    }
+
+    @Test
+    void isValidReturnsTrueWhenConditionIsNull() {
+        assertTrue(validator.isValid(null, context));
+    }
+
+    @Test
+    void rejectsOrderingOperatorAgainstServiceTier() {
+        assertFalse(validator.isValid(condition("serviceTier", Operator.GT, "flex"), context));
+    }
+
+    @Test
+    void rejectsOrderingOperatorAgainstTtl() {
+        assertFalse(validator.isValid(condition("ttl", Operator.LE, "5m"), context));
+    }
+
+    @Test
+    void allowsOrderingOperatorAgainstNumericStandardField() {
+        assertTrue(validator.isValid(condition("promptTokens", Operator.GT, 200000), context));
+        assertTrue(validator.isValid(condition("cachedReadTokens", Operator.GE, 0), context));
+        assertTrue(validator.isValid(condition("cachedWriteTokens", Operator.LT, 100), context));
+    }
+
+    @Test
+    void allowsEqualityOperatorAgainstStringStandardField() {
+        assertTrue(validator.isValid(condition("serviceTier", Operator.EQ, "flex"), context));
+        assertTrue(validator.isValid(condition("ttl", Operator.NE, "1h"), context));
+    }
+
+    @Test
+    void allowsOrderingOperatorAgainstJsonPathField() {
+        assertTrue(validator.isValid(condition("$.usage.server_tool_use.web_search_requests", Operator.GT, 0), context));
+    }
+
+    @Test
+    void rejectsNonStringNonNumberValue() {
+        assertFalse(validator.isValid(condition("promptTokens", Operator.EQ, List.of("bad")), context));
+    }
+}

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -221,6 +221,12 @@ Parameters defining the pricing for the model. Use to enables real-time cost est
     * `none`: disables all cost tracking for this model.
 * `prompt`: Cost per unit for prompt tokens.
 * `completion`: Cost per unit for completion tokens (chat responses).
+* `cacheRead` / `cacheWrite` (optional, `unit: "token"` only): Cost per cache-read/cache-write
+  token. Each is either a flat rate string (same convention as `prompt`/`completion`) or a
+  decision-tree object that picks a rate based on the call's own usage data — the field is
+  either a standard name (`cachedReadTokens`, `cachedWriteTokens`, `promptTokens`, `serviceTier`,
+  `ttl`) or a `$`-prefixed JSON Path expression. Left unset, cache tokens are billed at the
+  `prompt` rate, exactly as if caching weren't split out at all.
 
 **Example**
 
@@ -231,6 +237,19 @@ Parameters defining the pricing for the model. Use to enables real-time cost est
                 "unit": "token",
                 "prompt": "0.56",
                 "completion": "0.67"
+            },
+        },
+        "claude-sonnet-4-5": {
+            "pricing": {
+                "unit": "token",
+                "prompt": "0.000003",
+                "completion": "0.000015",
+                "cacheRead": "0.0000003",
+                "cacheWrite": {
+                    "test": { "field": "ttl", "operator": "==", "value": "1h" },
+                    "ifTrue": "0.000006",
+                    "ifFalse": "0.00000375"
+                }
             },
         }
 }

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -14651,6 +14651,14 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/MetadataBase"
+    Condition:
+      type: object
+      properties:
+        field:
+          type: string
+        operator:
+          $ref: "#/components/schemas/Operator"
+        value: {}
     Config:
       type: object
       properties:
@@ -15991,6 +15999,15 @@ components:
           type: array
           items:
             type: string
+    Operator:
+      type: string
+      enum:
+      - EQ
+      - NE
+      - GT
+      - LT
+      - GE
+      - LE
     ParallelToolCalls:
       type: boolean
       description: Whether to enable parallel `function` calling during the `tool` use.
@@ -16023,9 +16040,9 @@ components:
         unit:
           type: string
         cacheRead:
-          type: string
+          $ref: "#/components/schemas/PricingRate"
         cacheWrite:
-          type: string
+          $ref: "#/components/schemas/PricingRate"
     PricingData:
       type: object
       properties:
@@ -16036,9 +16053,20 @@ components:
         unit:
           type: string
         cache_read:
-          type: string
+          $ref: "#/components/schemas/PricingRate"
         cache_write:
+          $ref: "#/components/schemas/PricingRate"
+    PricingRate:
+      type: object
+      properties:
+        ifFalse:
+          $ref: "#/components/schemas/PricingRate"
+        ifTrue:
+          $ref: "#/components/schemas/PricingRate"
+        rate:
           type: string
+        test:
+          $ref: "#/components/schemas/Condition"
     Prompt:
       type: object
       properties:

--- a/server/src/main/java/com/epam/aidial/core/server/ProxyContext.java
+++ b/server/src/main/java/com/epam/aidial/core/server/ProxyContext.java
@@ -14,6 +14,7 @@ import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.util.UrlUtil;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -75,6 +76,9 @@ public class ProxyContext {
     private String userHash;
     private TokenUsage tokenUsage;
     private List<UsagePerModel> usagePerModel;
+    // Raw usage JSON accumulated live from SSE events, for pricing decision-tree evaluation. Null
+    // for non-streaming requests, where ModelCostCalculator parses responseBody directly instead.
+    private JsonNode pricingUsageNode;
     private Route route;
     private UpstreamRoute upstreamRoute;
     private HttpClientRequest proxyRequest;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -190,7 +190,8 @@ public class BaseDeploymentPostController {
             String bucket = BucketBuilder.buildInitiatorBucket(context);
             TokenUsage usage = context.getTokenUsage();
             return proxy.getRateLimiter().increase(
-                    context.getDeployment(), bucket, usage, context.getRequestBody(), context.getResponseBody())
+                    context.getDeployment(), bucket, usage, context.getRequestBody(), context.getResponseBody(),
+                    interfaceType(), context.getPricingUsageNode())
                     .transform(result -> {
                         if (result.failed()) {
                             log.warn("Failed to increase limit", result.cause());
@@ -252,6 +253,15 @@ public class BaseDeploymentPostController {
      */
     protected TokenUsage parseTokenUsage(Buffer responseBody) {
         return TokenUsageParser.parse(responseBody);
+    }
+
+    /**
+     * Which upstream interface shape this controller's response is in, for pricing decision-tree
+     * evaluation. Overridable so provider-specific controllers (Anthropic Messages, OpenAI Responses)
+     * can report their own shape; the default covers the OpenAI Chat Completions path.
+     */
+    protected InterfaceType interfaceType() {
+        return InterfaceType.OPENAI_CHAT_COMPLETIONS;
     }
 
     /**

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -258,7 +258,10 @@ public class BaseDeploymentPostController {
     /**
      * Which upstream interface shape this controller's response is in, for pricing decision-tree
      * evaluation. Overridable so provider-specific controllers (Anthropic Messages, OpenAI Responses)
-     * can report their own shape; the default covers the OpenAI Chat Completions path.
+     * can report their own shape; the default covers the OpenAI Chat Completions path. A controller
+     * that serves more than one shape from the same class (e.g. {@code DeploymentPostController}
+     * also handling {@code /embeddings}) must override this to report the actual per-request shape -
+     * otherwise a non-chat-completions response silently gets evaluated against the wrong alias table.
      */
     protected InterfaceType interfaceType() {
         return InterfaceType.OPENAI_CHAT_COMPLETIONS;

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -297,6 +297,11 @@ public class DeploymentPostController extends BaseDeploymentPostController {
                 : InterfaceType.OPENAI_CHAT_COMPLETIONS;
     }
 
+    @Override
+    protected InterfaceType interfaceType() {
+        return requestedInterface();
+    }
+
     @SneakyThrows
     private void sendRequest() {
         if (nextUpstream()) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -19,6 +19,7 @@ import com.epam.aidial.core.server.data.ErrorData;
 import com.epam.aidial.core.server.function.BaseRequestFunction;
 import com.epam.aidial.core.server.function.BaseResponseFunction;
 import com.epam.aidial.core.server.function.BuildUpstreamCacheFn;
+import com.epam.aidial.core.server.function.CollectChatCompletionUsageFn;
 import com.epam.aidial.core.server.function.CollectDeploymentsFn;
 import com.epam.aidial.core.server.function.CollectRequestApplicationFilesFn;
 import com.epam.aidial.core.server.function.CollectRequestStandardAttachmentsFn;
@@ -401,7 +402,8 @@ public class DeploymentPostController extends BaseDeploymentPostController {
 
         Supplier<BufferingReadStream.BaseEventListener> eventListenerSupplier = () ->
                 new ChatCompletionSseListener(isChatCompletionsPath()
-                        ? List.of(new StripUsagePerModelFn(proxy, context), new CollectResponseChatCompletionAttachmentsFn(proxy, context))
+                        ? List.of(new StripUsagePerModelFn(proxy, context), new CollectResponseChatCompletionAttachmentsFn(proxy, context),
+                                new CollectChatCompletionUsageFn(proxy, context))
                         : List.of(new CollectResponseChatCompletionAttachmentsFn(proxy, context)));
         BufferingReadStream responseStream = createResponseStream(proxyResponse, eventListenerSupplier);
 

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -75,6 +75,11 @@ public class ResponsesController extends BaseDeploymentPostController {
                 new CollectDeploymentsFn(proxy, context));
     }
 
+    @Override
+    protected InterfaceType interfaceType() {
+        return InterfaceType.OPENAI_RESPONSES;
+    }
+
     @ApiOperation(
             method = "POST",
             path = "/openai/v1/responses",

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesInterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesInterceptorController.java
@@ -63,4 +63,9 @@ public class ResponsesInterceptorController extends BaseInterceptorController {
     protected BufferingReadStream.BaseEventListener createListener(Proxy proxy, ProxyContext context) {
         return new ResponsesSseListener(List.of(new CollectResponsesApiOutputAttachmentsFn(proxy, context)));
     }
+
+    @Override
+    protected InterfaceType interfaceType() {
+        return InterfaceType.OPENAI_RESPONSES;
+    }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesController.java
@@ -178,4 +178,9 @@ public class MessagesController extends MessagesBaseController {
         }
         return MessagesTokenUsageParser.parse(responseBody);
     }
+
+    @Override
+    protected InterfaceType interfaceType() {
+        return InterfaceType.ANTHROPIC_MESSAGES;
+    }
 }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/route/RouteRequestBodyHandler.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/route/RouteRequestBodyHandler.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.controller.route;
 
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -177,8 +178,11 @@ class RouteRequestBodyHandler {
         if (responseStatusCode == 200) {
             context.getUpstreamRoute().succeed();
             String bucket = BucketBuilder.buildInitiatorBucket(context);
+            // interfaceType/liveUsageNode are inert here: context.getRoute() is never a Model, so
+            // ModelCostCalculator returns before either is consulted.
             proxy.getRateLimiter()
-                    .increase(context.getRoute(), bucket, context.getTokenUsage(), context.getRequestBody(), context.getResponseBody())
+                    .increase(context.getRoute(), bucket, context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(),
+                            InterfaceType.OPENAI_CHAT_COMPLETIONS, null)
                     .onFailure(error -> log.warn("Failed to increase limit", error));
         }
 

--- a/server/src/main/java/com/epam/aidial/core/server/data/PricingData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/PricingData.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server.data;
 
+import com.epam.aidial.core.config.PricingRate;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -12,6 +13,6 @@ public class PricingData {
     private String unit;
     private String prompt;
     private String completion;
-    private String cacheRead;
-    private String cacheWrite;
+    private PricingRate cacheRead;
+    private PricingRate cacheWrite;
 }

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFn.java
@@ -1,0 +1,51 @@
+package com.epam.aidial.core.server.function;
+
+import com.epam.aidial.core.server.Proxy;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.util.MergeChunks;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.Future;
+
+/**
+ * Accumulates the pricing-relevant fields of a streaming Chat Completions response - {@code usage}
+ * (merged cumulatively, same as {@link com.epam.aidial.core.server.token.TokenUsageParser} assumes),
+ * plus the {@code service_tier} and {@code custom_fields} siblings a plain token-usage byte-scan of
+ * the buffered body would not otherwise carry forward for pricing decision-tree evaluation.
+ */
+public class CollectChatCompletionUsageFn extends BaseResponseFunction {
+
+    private JsonNode usage;
+    private JsonNode serviceTier;
+    private JsonNode customFields;
+
+    public CollectChatCompletionUsageFn(Proxy proxy, ProxyContext context) {
+        super(proxy, context);
+    }
+
+    @Override
+    public Future<JsonNode> apply(JsonNode tree) {
+        usage = MergeChunks.merge(usage, tree.get("usage"));
+        if (tree.get("service_tier") != null) {
+            serviceTier = tree.get("service_tier");
+        }
+        if (tree.get("custom_fields") != null) {
+            customFields = tree.get("custom_fields");
+        }
+
+        ObjectNode merged = ProxyUtil.MAPPER.createObjectNode();
+        if (usage != null) {
+            merged.set("usage", usage);
+        }
+        if (serviceTier != null) {
+            merged.set("service_tier", serviceTier);
+        }
+        if (customFields != null) {
+            merged.set("custom_fields", customFields);
+        }
+        context.setPricingUsageNode(merged);
+
+        return Future.succeededFuture(tree);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectMessagesTokenUsageFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectMessagesTokenUsageFn.java
@@ -3,6 +3,8 @@ package com.epam.aidial.core.server.function;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.token.MessagesTokenUsageParser;
+import com.epam.aidial.core.server.util.MergeChunks;
+import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.Future;
 
@@ -22,6 +24,9 @@ public class CollectMessagesTokenUsageFn extends BaseResponseFunction {
     private long cacheReadTokens;
     private long cacheCreationTokens;
     private long thinkingTokens;
+    // Merged verbatim, unlike the scalars above, so pricing-relevant fields the scalars don't
+    // capture (service_tier, the cache_creation TTL-bucket breakdown) survive for cost evaluation.
+    private JsonNode mergedUsage;
 
     public CollectMessagesTokenUsageFn(Proxy proxy, ProxyContext context) {
         super(proxy, context);
@@ -43,6 +48,8 @@ public class CollectMessagesTokenUsageFn extends BaseResponseFunction {
             thinkingTokens = usage.path("output_tokens_details").path("thinking_tokens").asLong(thinkingTokens);
             context.setTokenUsage(MessagesTokenUsageParser.build(
                     inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, thinkingTokens));
+            mergedUsage = MergeChunks.merge(mergedUsage, usage);
+            context.setPricingUsageNode(ProxyUtil.MAPPER.createObjectNode().set("usage", mergedUsage));
         }
         return Future.succeededFuture(tree);
     }

--- a/server/src/main/java/com/epam/aidial/core/server/function/ExtractTerminalResponseFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/ExtractTerminalResponseFn.java
@@ -25,6 +25,7 @@ public class ExtractTerminalResponseFn extends BaseResponseFunction {
             JsonNode responseNode = tree.get("response");
             if (responseNode != null) {
                 assembledStreamingResponse = ProxyUtil.convertToString(responseNode);
+                context.setPricingUsageNode(responseNode);
             }
         }
         return Future.succeededFuture(tree);

--- a/server/src/main/java/com/epam/aidial/core/server/limiter/RateLimiter.java
+++ b/server/src/main/java/com/epam/aidial/core/server/limiter/RateLimiter.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.limiter;
 
 import com.epam.aidial.core.config.CostLimit;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Limit;
 import com.epam.aidial.core.config.Role;
 import com.epam.aidial.core.config.RoleBasedEntity;
@@ -21,6 +22,7 @@ import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.service.ResourceService;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import lombok.RequiredArgsConstructor;
@@ -47,14 +49,16 @@ public class RateLimiter {
     private final ResourceService resourceService;
 
     public Future<Void> increase(
-            RoleBasedEntity roleBasedEntity, String bucket, TokenUsage usage, Buffer requestBody, Buffer responseBody) {
+            RoleBasedEntity roleBasedEntity, String bucket, TokenUsage usage, Buffer requestBody, Buffer responseBody,
+            InterfaceType interfaceType, JsonNode liveUsageNode) {
         try {
             // skip checking limits if redis is not available
             if (resourceService == null) {
                 return Future.succeededFuture();
             }
 
-            BigDecimal cost = ModelCostCalculator.calculate(roleBasedEntity, usage, requestBody, responseBody);
+            BigDecimal cost = ModelCostCalculator.calculate(
+                    roleBasedEntity, usage, requestBody, responseBody, interfaceType, liveUsageNode);
             Future<Void> costFuture;
             if (cost != null && cost.compareTo(BigDecimal.ZERO) > 0) {
                 if (usage != null) {

--- a/server/src/main/java/com/epam/aidial/core/server/pricing/PricingRateEvaluator.java
+++ b/server/src/main/java/com/epam/aidial/core/server/pricing/PricingRateEvaluator.java
@@ -1,0 +1,64 @@
+package com.epam.aidial.core.server.pricing;
+
+import com.epam.aidial.core.config.Condition;
+import com.epam.aidial.core.config.Operator;
+import com.epam.aidial.core.config.PricingRate;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.experimental.UtilityClass;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * Walks a {@link PricingRate} decision tree against a {@link UsageEvalContext}, resolving to the
+ * matched leaf's rate string. A missing/unresolvable field (requirement 8) or a type-mismatched
+ * ordering comparison (requirement 9) both degrade to a non-match rather than an error; an omitted
+ * branch (requirement 2) surfaces as an empty result so the caller can fall back to {@code promptRate}.
+ */
+@UtilityClass
+public class PricingRateEvaluator {
+
+    public Optional<String> evaluate(PricingRate pricingRate, UsageEvalContext ctx) {
+        if (pricingRate.isLeaf()) {
+            return Optional.of(pricingRate.getRate());
+        }
+
+        boolean matched = test(pricingRate.getTest(), ctx);
+        PricingRate branch = matched ? pricingRate.getIfTrue() : pricingRate.getIfFalse();
+        return branch == null ? Optional.empty() : evaluate(branch, ctx);
+    }
+
+    private boolean test(Condition condition, UsageEvalContext ctx) {
+        Optional<JsonNode> resolved = ctx.resolve(condition.getField());
+        return resolved.isPresent() && compare(resolved.get(), condition.getOperator(), condition.getValue());
+    }
+
+    private boolean compare(JsonNode actual, Operator operator, Object expected) {
+        if (operator == Operator.EQ || operator == Operator.NE) {
+            boolean equal = actual.asText().equals(String.valueOf(expected));
+            return operator == Operator.EQ ? equal : !equal;
+        }
+
+        BigDecimal expectedNum = toNumeric(expected);
+        if (!actual.isNumber() || expectedNum == null) {
+            return false;
+        }
+
+        int cmp = new BigDecimal(actual.asText()).compareTo(expectedNum);
+        return switch (operator) {
+            case GT -> cmp > 0;
+            case LT -> cmp < 0;
+            case GE -> cmp >= 0;
+            case LE -> cmp <= 0;
+            default -> false;
+        };
+    }
+
+    private BigDecimal toNumeric(Object value) {
+        try {
+            return value instanceof Number number ? new BigDecimal(number.toString()) : new BigDecimal((String) value);
+        } catch (NumberFormatException | ClassCastException e) {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/pricing/StandardFieldResolver.java
+++ b/server/src/main/java/com/epam/aidial/core/server/pricing/StandardFieldResolver.java
@@ -1,0 +1,71 @@
+package com.epam.aidial.core.server.pricing;
+
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.StandardField;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import lombok.experimental.UtilityClass;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Resolves a {@link StandardField} against the usage shape of a specific upstream {@link InterfaceType},
+ * per the standard-field alias table in {@code cache_pricing_decision_tree.md}. Shared by both a pricing
+ * decision-tree condition's field lookup and the reserved cache-counter resolution, so there is exactly
+ * one implementation of "what does cachedReadTokens/cachedWriteTokens mean for this shape."
+ */
+@UtilityClass
+class StandardFieldResolver {
+
+    private static final Map<InterfaceType, Map<StandardField, Function<JsonNode, JsonNode>>> TABLE = Map.of(
+            InterfaceType.OPENAI_CHAT_COMPLETIONS, Map.of(
+                    StandardField.CACHED_READ_TOKENS, r -> r.path("usage").path("prompt_tokens_details").path("cached_tokens"),
+                    StandardField.CACHED_WRITE_TOKENS, r -> r.path("usage").path("prompt_tokens_details").path("cache_write_tokens"),
+                    StandardField.PROMPT_TOKENS, r -> r.path("usage").path("prompt_tokens"),
+                    StandardField.SERVICE_TIER, r -> r.path("service_tier")),
+            InterfaceType.OPENAI_RESPONSES, Map.of(
+                    StandardField.CACHED_READ_TOKENS, r -> r.path("usage").path("input_tokens_details").path("cached_tokens"),
+                    StandardField.CACHED_WRITE_TOKENS, r -> r.path("usage").path("input_tokens_details").path("cache_write_tokens"),
+                    StandardField.PROMPT_TOKENS, r -> r.path("usage").path("input_tokens"),
+                    StandardField.SERVICE_TIER, r -> r.path("service_tier")),
+            InterfaceType.ANTHROPIC_MESSAGES, Map.of(
+                    StandardField.CACHED_READ_TOKENS, r -> r.path("usage").path("cache_read_input_tokens"),
+                    StandardField.CACHED_WRITE_TOKENS, r -> r.path("usage").path("cache_creation_input_tokens"),
+                    StandardField.PROMPT_TOKENS, StandardFieldResolver::anthropicPromptTokens,
+                    StandardField.SERVICE_TIER, r -> r.path("usage").path("service_tier"),
+                    StandardField.TTL, StandardFieldResolver::anthropicTtl));
+
+    static JsonNode resolve(InterfaceType type, StandardField field, JsonNode root) {
+        if (type == null) {
+            return MissingNode.getInstance();
+        }
+        return TABLE.getOrDefault(type, Map.of())
+                .getOrDefault(field, r -> MissingNode.getInstance())
+                .apply(root);
+    }
+
+    private static JsonNode anthropicPromptTokens(JsonNode root) {
+        JsonNode usage = root.path("usage");
+        if (usage.isMissingNode()) {
+            return MissingNode.getInstance();
+        }
+        long total = usage.path("input_tokens").asLong(0)
+                + usage.path("cache_read_input_tokens").asLong(0)
+                + usage.path("cache_creation_input_tokens").asLong(0);
+        return LongNode.valueOf(total);
+    }
+
+    private static JsonNode anthropicTtl(JsonNode root) {
+        JsonNode creation = root.path("usage").path("cache_creation");
+        if (creation.path("ephemeral_1h_input_tokens").asLong(0) > 0) {
+            return TextNode.valueOf("1h");
+        }
+        if (creation.path("ephemeral_5m_input_tokens").asLong(0) > 0) {
+            return TextNode.valueOf("5m");
+        }
+        return MissingNode.getInstance();
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/pricing/UsageEvalContext.java
+++ b/server/src/main/java/com/epam/aidial/core/server/pricing/UsageEvalContext.java
@@ -1,0 +1,78 @@
+package com.epam.aidial.core.server.pricing;
+
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.StandardField;
+import com.epam.aidial.core.server.util.JsonUtil;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Optional;
+
+/**
+ * The usage data a pricing decision tree is evaluated against for one call, resolving requirement
+ * 4/5's translation-vs-passthrough priority (a {@code custom_fields.upstream_usage} envelope, when
+ * present, is authoritative) and requirement 6's two JSON Path roots ({@code $.usage}/{@code $.upstream_usage}).
+ */
+public final class UsageEvalContext {
+
+    private final InterfaceType activeInterface;
+    private final JsonNode aliasRoot;
+    private final JsonNode jsonPathRoot;
+
+    private UsageEvalContext(InterfaceType activeInterface, JsonNode aliasRoot, JsonNode jsonPathRoot) {
+        this.activeInterface = activeInterface;
+        this.aliasRoot = aliasRoot;
+        this.jsonPathRoot = jsonPathRoot;
+    }
+
+    public static UsageEvalContext build(InterfaceType nativeInterface, JsonNode nativeRoot) {
+        JsonNode upstreamUsage = nativeRoot.path("custom_fields").path("upstream_usage");
+        boolean translation = !upstreamUsage.isMissingNode();
+
+        InterfaceType active = translation
+                ? tryParseInterface(upstreamUsage.path("interface").asText(null))
+                : nativeInterface;
+        JsonNode aliasRoot = translation ? upstreamUsage : nativeRoot;
+
+        ObjectNode pathRoot = ProxyUtil.MAPPER.createObjectNode();
+        pathRoot.set("usage", nativeRoot.path("usage"));
+        pathRoot.set("upstream_usage", upstreamUsage.path("usage"));
+
+        return new UsageEvalContext(active, aliasRoot, pathRoot);
+    }
+
+    private static InterfaceType tryParseInterface(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return InterfaceType.fromValue(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public Optional<JsonNode> resolve(String field) {
+        return field.startsWith("$") ? resolveJsonPath(field) : resolveStandardField(field);
+    }
+
+    private Optional<JsonNode> resolveStandardField(String field) {
+        StandardField standardField = StandardField.fromFieldName(field).orElse(null);
+        if (standardField == null) {
+            return Optional.empty();
+        }
+        JsonNode node = StandardFieldResolver.resolve(activeInterface, standardField, aliasRoot);
+        return node.isMissingNode() || node.isNull() ? Optional.empty() : Optional.of(node);
+    }
+
+    private Optional<JsonNode> resolveJsonPath(String field) {
+        JsonNode node = JsonUtil.read(jsonPathRoot, field);
+        return node == null || node.isNull() ? Optional.empty() : Optional.of(node);
+    }
+
+    public Optional<Long> resolveCounter(StandardField field) {
+        JsonNode node = StandardFieldResolver.resolve(activeInterface, field, aliasRoot);
+        return node.isNumber() ? Optional.of(node.asLong()) : Optional.empty();
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/service/BackgroundJobService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/BackgroundJobService.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
@@ -234,8 +235,11 @@ public class BackgroundJobService {
                     Future<Void> limitFuture = Future.succeededFuture();
                     if (deployment instanceof Model && hasUsage) {
                         Buffer requestBody = Buffer.buffer(jobRecord.requestBody());
+                        // null liveUsageNode: this poller never streams, result.body() is a single
+                        // buffered document, so ModelCostCalculator parses it directly.
                         limitFuture = rateLimiter.increase(
-                                deployment, responseMapping.getInitiatorBucket(), usage, requestBody, result.body())
+                                deployment, responseMapping.getInitiatorBucket(), usage, requestBody, result.body(),
+                                InterfaceType.OPENAI_RESPONSES, null)
                                 .transform(limitResult -> {
                                     if (limitResult.failed()) {
                                         log.warn("Failed to increase limit", limitResult.cause());

--- a/server/src/main/java/com/epam/aidial/core/server/util/ModelCostCalculator.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/ModelCostCalculator.java
@@ -1,13 +1,19 @@
 package com.epam.aidial.core.server.util;
 
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
 import com.epam.aidial.core.config.Pricing;
+import com.epam.aidial.core.config.PricingRate;
 import com.epam.aidial.core.config.RoleBasedEntity;
+import com.epam.aidial.core.config.StandardField;
+import com.epam.aidial.core.server.pricing.PricingRateEvaluator;
+import com.epam.aidial.core.server.pricing.UsageEvalContext;
 import com.epam.aidial.core.server.token.PromptTokensDetails;
 import com.epam.aidial.core.server.token.TokenUsage;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
@@ -23,7 +29,8 @@ import java.util.Scanner;
 public class ModelCostCalculator {
 
     public static BigDecimal calculate(
-            RoleBasedEntity roleBasedEntity, TokenUsage tokenUsage, Buffer requestBody, Buffer responseBody) {
+            RoleBasedEntity roleBasedEntity, TokenUsage tokenUsage, Buffer requestBody, Buffer responseBody,
+            InterfaceType interfaceType, JsonNode liveUsageNode) {
         if (!(roleBasedEntity instanceof Model model)) {
             return null;
         }
@@ -34,29 +41,34 @@ public class ModelCostCalculator {
         }
 
         return switch (pricing.getUnit()) {
-            case "token" -> calculate(tokenUsage, pricing);
+            case "token" -> calculate(tokenUsage, pricing, interfaceType, responseBody, liveUsageNode);
             case "char_without_whitespace" ->
                     calculate(model.getType(), requestBody, responseBody, pricing.getPrompt(), pricing.getCompletion());
             default -> null;
         };
     }
 
-    private static BigDecimal calculate(TokenUsage tokenUsage, Pricing pricing) {
+    private static BigDecimal calculate(TokenUsage tokenUsage, Pricing pricing, InterfaceType interfaceType,
+            Buffer responseBody, JsonNode liveUsageNode) {
         if (tokenUsage == null) {
             return null;
         }
         String promptRate = pricing.getPrompt();
         String completionRate = pricing.getCompletion();
-        String cacheReadRate = pricing.getCacheRead() != null ? pricing.getCacheRead() : promptRate;
-        String cacheWriteRate = pricing.getCacheWrite() != null ? pricing.getCacheWrite() : promptRate;
 
-        long cachedTokens = 0;
-        long cacheWriteTokens = 0;
+        // streaming: already accumulated live by a per-event Fn; non-streaming: one cheap whole-body parse
+        JsonNode nativeRoot = liveUsageNode != null ? liveUsageNode
+                : responseBody == null ? MissingNode.getInstance() : JsonUtil.tryParse(responseBody.getBytes());
+        UsageEvalContext evalContext = UsageEvalContext.build(interfaceType, nativeRoot);
+
         PromptTokensDetails details = tokenUsage.getPromptTokensDetails();
-        if (details != null) {
-            cachedTokens = details.getCachedTokens();
-            cacheWriteTokens = details.getCacheWriteTokens();
-        }
+        long cachedTokens = evalContext.resolveCounter(StandardField.CACHED_READ_TOKENS)
+                .orElseGet(() -> details == null ? 0 : details.getCachedTokens());
+        long cacheWriteTokens = evalContext.resolveCounter(StandardField.CACHED_WRITE_TOKENS)
+                .orElseGet(() -> details == null ? 0 : details.getCacheWriteTokens());
+
+        String cacheReadRate = resolveRate(pricing.getCacheRead(), evalContext, promptRate);
+        String cacheWriteRate = resolveRate(pricing.getCacheWrite(), evalContext, promptRate);
 
         BigDecimal cost = null;
         if (promptRate != null) {
@@ -89,6 +101,13 @@ public class ModelCostCalculator {
             }
         }
         return cost;
+    }
+
+    private static String resolveRate(PricingRate pricingRate, UsageEvalContext evalContext, String promptRate) {
+        if (pricingRate == null) {
+            return promptRate;
+        }
+        return PricingRateEvaluator.evaluate(pricingRate, evalContext).orElse(promptRate);
     }
 
     private static BigDecimal addCost(BigDecimal cost, String rate, long tokens) {

--- a/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Interceptor;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Pricing;
+import com.epam.aidial.core.config.PricingRate;
 import com.epam.aidial.core.config.Role;
 import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.config.ToolSet;
@@ -121,7 +122,7 @@ public class ConfigPostProcessorTest {
         Model model = new Model();
         Pricing pricing = new Pricing();
         pricing.setUnit("char_without_whitespace");
-        pricing.setCacheRead("0.01");
+        pricing.setCacheRead(flatRate("0.01"));
         model.setPricing(pricing);
         config.getModels().put("model", model);
 
@@ -135,7 +136,7 @@ public class ConfigPostProcessorTest {
         Model model = new Model();
         Pricing pricing = new Pricing();
         pricing.setUnit("char_without_whitespace");
-        pricing.setCacheWrite("0.02");
+        pricing.setCacheWrite(flatRate("0.02"));
         model.setPricing(pricing);
         config.getModels().put("model", model);
 
@@ -158,8 +159,8 @@ public class ConfigPostProcessorTest {
         Model model = new Model();
         Pricing pricing = new Pricing();
         pricing.setUnit("token");
-        pricing.setCacheRead("0.01");
-        pricing.setCacheWrite("0.02");
+        pricing.setCacheRead(flatRate("0.01"));
+        pricing.setCacheWrite(flatRate("0.02"));
         model.setPricing(pricing);
         config.getModels().put("model", model);
 
@@ -194,6 +195,12 @@ public class ConfigPostProcessorTest {
         config.setInterceptors(new HashMap<>());
         config.setToolsets(new LinkedHashMap<>());
         return config;
+    }
+
+    private static PricingRate flatRate(String rate) {
+        PricingRate pricingRate = new PricingRate();
+        pricingRate.setRate(rate);
+        return pricingRate;
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -697,17 +697,51 @@ public class DeploymentPostControllerTest {
         when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
         when(request.method()).thenReturn(HttpMethod.POST);
         when(request.uri()).thenReturn("/test");
+        when(request.path()).thenReturn("/openai/deployments/name/chat/completions");
         when(request.headers()).thenReturn(new HeadersMultiMap());
         when(context.getProxyResponse()).thenReturn(mock(HttpClientResponse.class));
         BufferingReadStream bufferingReadStream = mock(BufferingReadStream.class);
 
         controller.handleResponse(bufferingReadStream);
 
-        verify(rateLimiter).increase(eq(model), any(), any(), any(), any(), any(), any());
+        ArgumentCaptor<InterfaceType> interfaceTypeCaptor = ArgumentCaptor.forClass(InterfaceType.class);
+        verify(rateLimiter).increase(eq(model), any(), any(), any(), any(), interfaceTypeCaptor.capture(), any());
+        assertEquals(InterfaceType.OPENAI_CHAT_COMPLETIONS, interfaceTypeCaptor.getValue());
         verify(context).setTokenUsage(any(TokenUsage.class));
         verify(logStore).save(any(AnalyticsLogContext.class));
         verify(tokenStatsTracker).endSpan(eq(context));
         verify(bufferingReadStream).end(response);
+    }
+
+    @Test
+    public void testHandleResponse_Model_Embeddings() {
+        Model model = new Model();
+        when(context.getDeployment()).thenReturn(model);
+        when(context.getUserId()).thenReturn("test-user");
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(context.getResponse()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(HttpStatus.OK.getCode());
+        when(proxy.getRateLimiter()).thenReturn(rateLimiter);
+        when(proxy.getLogStore()).thenReturn(logStore);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
+        when(context.getResponseBody()).thenReturn(Buffer.buffer());
+        when(proxy.getTokenStatsTracker()).thenReturn(tokenStatsTracker);
+        when(rateLimiter.increase(any(), any(), any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(context.getRequest()).thenReturn(request);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.uri()).thenReturn("/test");
+        when(request.path()).thenReturn("/openai/deployments/name/embeddings");
+        when(request.headers()).thenReturn(new HeadersMultiMap());
+        when(context.getProxyResponse()).thenReturn(mock(HttpClientResponse.class));
+        BufferingReadStream bufferingReadStream = mock(BufferingReadStream.class);
+
+        controller.handleResponse(bufferingReadStream);
+
+        ArgumentCaptor<InterfaceType> interfaceTypeCaptor = ArgumentCaptor.forClass(InterfaceType.class);
+        verify(rateLimiter).increase(eq(model), any(), any(), any(), any(), interfaceTypeCaptor.capture(), any());
+        assertEquals(InterfaceType.OPENAI_EMBEDDINGS, interfaceTypeCaptor.getValue());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -692,7 +692,7 @@ public class DeploymentPostControllerTest {
         when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
         when(context.getResponseBody()).thenReturn(Buffer.buffer());
         when(proxy.getTokenStatsTracker()).thenReturn(tokenStatsTracker);
-        when(rateLimiter.increase(any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(rateLimiter.increase(any(), any(), any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(context.getRequest()).thenReturn(request);
         when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
         when(request.method()).thenReturn(HttpMethod.POST);
@@ -703,7 +703,7 @@ public class DeploymentPostControllerTest {
 
         controller.handleResponse(bufferingReadStream);
 
-        verify(rateLimiter).increase(eq(model), any(), any(), any(), any());
+        verify(rateLimiter).increase(eq(model), any(), any(), any(), any(), any(), any());
         verify(context).setTokenUsage(any(TokenUsage.class));
         verify(logStore).save(any(AnalyticsLogContext.class));
         verify(tokenStatsTracker).endSpan(eq(context));
@@ -735,7 +735,7 @@ public class DeploymentPostControllerTest {
 
         controller.handleResponse(bufferingReadStream);
 
-        verify(rateLimiter, never()).increase(any(), any(), any(), any(), any());
+        verify(rateLimiter, never()).increase(any(), any(), any(), any(), any(), any(), any());
         verify(tokenStatsTracker).getUsageStats(eq(context));
         verify(context).setTokenUsage(any(TokenUsage.class));
         verify(context).setUsagePerModel(any());

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
@@ -338,7 +338,7 @@ public class ResponsesControllerTest {
                 .thenReturn(deployment);
         when(proxy.getRateLimiter().limit(context, deployment))
                 .thenReturn(Future.succeededFuture(RateLimitResult.SUCCESS));
-        when(proxy.getRateLimiter().increase(any(), any(), any(), any(), any()))
+        when(proxy.getRateLimiter().increase(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(Future.succeededFuture());
         when(proxy.getTaskExecutor()).thenReturn(taskExecutor(vertx));
         when(proxy.getClient()).thenReturn(httpClient);

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesInterceptorControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesInterceptorControllerTest.java
@@ -199,6 +199,13 @@ public class ResponsesInterceptorControllerTest {
     }
 
     @Test
+    void interfaceType_reportsOpenAiResponses() {
+        ResponsesInterceptorController controller = new ResponsesInterceptorController(proxy, context, 0);
+
+        assertEquals(InterfaceType.OPENAI_RESPONSES, controller.interfaceType());
+    }
+
+    @Test
     void handleRequestBody_doesNotOverrideModelName() throws IOException {
         Interceptor interceptor = new Interceptor();
         interceptor.setName("interceptor1");

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFnTest.java
@@ -1,0 +1,73 @@
+package com.epam.aidial.core.server.function;
+
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+
+@ExtendWith(MockitoExtension.class)
+class CollectChatCompletionUsageFnTest {
+
+    @Mock
+    private ProxyContext context;
+
+    @Test
+    public void testMergesUsageServiceTierAndCustomFieldsAcrossChunks() throws JsonProcessingException {
+        doCallRealMethod().when(context).setPricingUsageNode(any());
+        doCallRealMethod().when(context).getPricingUsageNode();
+
+        CollectChatCompletionUsageFn fn = new CollectChatCompletionUsageFn(null, context);
+
+        fn.apply(tree("""
+                {
+                  "choices": [{ "index": 0, "delta": { "content": "hi" } }],
+                  "service_tier": "flex"
+                }
+                """));
+        fn.apply(tree("""
+                {
+                  "choices": [{ "index": 0, "delta": {} }],
+                  "usage": {
+                    "prompt_tokens": 150000,
+                    "prompt_tokens_details": { "cached_tokens": 800, "cache_write_tokens": 50 },
+                    "completion_tokens": 200
+                  },
+                  "custom_fields": {
+                    "upstream_usage": { "interface": "anthropicMessages", "usage": { "input_tokens": 1 } }
+                  }
+                }
+                """));
+
+        JsonNode pricingUsageNode = context.getPricingUsageNode();
+        assertNotNull(pricingUsageNode);
+        assertEquals(150000, pricingUsageNode.path("usage").path("prompt_tokens").asLong());
+        assertEquals(800, pricingUsageNode.path("usage").path("prompt_tokens_details").path("cached_tokens").asLong());
+        assertEquals("flex", pricingUsageNode.path("service_tier").asText());
+        assertEquals("anthropicMessages", pricingUsageNode.path("custom_fields").path("upstream_usage").path("interface").asText());
+    }
+
+    @Test
+    public void testPassesEventThroughUnchanged() throws JsonProcessingException {
+        CollectChatCompletionUsageFn fn = new CollectChatCompletionUsageFn(null, context);
+        JsonNode input = tree("""
+                { "choices": [{ "index": 0, "delta": { "content": "hi" } }] }
+                """);
+
+        JsonNode output = fn.apply(input).result();
+
+        assertEquals(input, output);
+    }
+
+    private static JsonNode tree(String json) throws JsonProcessingException {
+        return ProxyUtil.MAPPER.readTree(json);
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectMessagesTokenUsageFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectMessagesTokenUsageFnTest.java
@@ -63,6 +63,46 @@ class CollectMessagesTokenUsageFnTest {
         assertEquals(6, usage.getCompletionTokensDetails().getReasoningTokens());
     }
 
+    @Test
+    public void testMergesPricingUsageNodeAcrossEvents() throws JsonProcessingException {
+        doCallRealMethod().when(context).setTokenUsage(any());
+        doCallRealMethod().when(context).setPricingUsageNode(any());
+        doCallRealMethod().when(context).getPricingUsageNode();
+
+        CollectMessagesTokenUsageFn fn = new CollectMessagesTokenUsageFn(null, context);
+
+        fn.apply(tree("""
+                {
+                  "type": "message_start",
+                  "message": {
+                    "usage": {
+                      "input_tokens": 249500,
+                      "cache_read_input_tokens": 400,
+                      "cache_creation_input_tokens": 100,
+                      "cache_creation": { "ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 100 },
+                      "service_tier": "standard"
+                    }
+                  }
+                }
+                """));
+        fn.apply(tree("""
+                {
+                  "type": "message_delta",
+                  "usage": { "output_tokens": 8 }
+                }
+                """));
+
+        JsonNode pricingUsageNode = context.getPricingUsageNode();
+        assertNotNull(pricingUsageNode);
+        JsonNode usage = pricingUsageNode.path("usage");
+        assertEquals(249500, usage.path("input_tokens").asLong());
+        assertEquals(400, usage.path("cache_read_input_tokens").asLong());
+        assertEquals(100, usage.path("cache_creation_input_tokens").asLong());
+        assertEquals(100, usage.path("cache_creation").path("ephemeral_1h_input_tokens").asLong());
+        assertEquals("standard", usage.path("service_tier").asText());
+        assertEquals(8, usage.path("output_tokens").asLong());
+    }
+
     private static JsonNode tree(String json) throws JsonProcessingException {
         return ProxyUtil.MAPPER.readTree(json);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/function/ExtractTerminalResponseFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/ExtractTerminalResponseFnTest.java
@@ -1,0 +1,71 @@
+package com.epam.aidial.core.server.function;
+
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ExtractTerminalResponseFnTest {
+
+    @Mock
+    private ProxyContext context;
+
+    @Test
+    public void testCapturesPricingUsageNodeOnResponseCompleted() throws JsonProcessingException {
+        doCallRealMethod().when(context).setPricingUsageNode(any());
+        doCallRealMethod().when(context).getPricingUsageNode();
+
+        ExtractTerminalResponseFn fn = new ExtractTerminalResponseFn(null, context);
+
+        fn.apply(tree("""
+                {
+                  "type": "response.in_progress"
+                }
+                """));
+
+        fn.apply(tree("""
+                {
+                  "type": "response.completed",
+                  "response": {
+                    "usage": { "input_tokens": 150000, "output_tokens": 200 },
+                    "service_tier": "flex"
+                  }
+                }
+                """));
+
+        JsonNode pricingUsageNode = context.getPricingUsageNode();
+        assertNotNull(pricingUsageNode);
+        assertEquals(150000, pricingUsageNode.path("usage").path("input_tokens").asLong());
+        assertEquals("flex", pricingUsageNode.path("service_tier").asText());
+    }
+
+    @Test
+    public void testIgnoresNonTerminalEvents() throws JsonProcessingException {
+        ExtractTerminalResponseFn fn = new ExtractTerminalResponseFn(null, context);
+
+        fn.apply(tree("""
+                {
+                  "type": "response.output_text.delta",
+                  "response": { "usage": { "input_tokens": 1 } }
+                }
+                """));
+
+        verify(context, never()).setPricingUsageNode(any());
+    }
+
+    private static JsonNode tree(String json) throws JsonProcessingException {
+        return ProxyUtil.MAPPER.readTree(json);
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/limiter/CostRateLimitTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/limiter/CostRateLimitTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.limiter;
 
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CostLimit;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Limit;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
@@ -198,11 +199,11 @@ public class CostRateLimitTest {
         // Mock ModelCostCalculator to return a cost
         try (MockedStatic<ModelCostCalculator> mockedCalculator = Mockito.mockStatic(ModelCostCalculator.class)) {
             // The first call returns $0.05 (below the limit)
-            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), any(), any(), any()))
+            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), any(), any(), any(), any(), any()))
                     .thenReturn(new BigDecimal("0.05"));
 
             // First increase and limit check should succeed
-            Future<Void> increaseLimitFuture = rateLimiter.increase(model, bucketLocation, proxyContext.getTokenUsage(), null, null);
+            Future<Void> increaseLimitFuture = rateLimiter.increase(model, bucketLocation, proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
             assertNotNull(increaseLimitFuture);
             assertNull(increaseLimitFuture.cause());
 
@@ -212,11 +213,11 @@ public class CostRateLimitTest {
             assertEquals(HttpStatus.OK, checkLimitFuture.result().status());
 
             // The second call returns $0.15 (above the limit)
-            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), any(), any(), any()))
+            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), any(), any(), any(), any(), any()))
                     .thenReturn(new BigDecimal("0.15"));
 
             // Second increase and limit check should fail due to cost limit
-            increaseLimitFuture = rateLimiter.increase(model, bucketLocation, proxyContext.getTokenUsage(), null, null);
+            increaseLimitFuture = rateLimiter.increase(model, bucketLocation, proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
             assertNotNull(increaseLimitFuture);
             assertNull(increaseLimitFuture.cause());
 
@@ -293,11 +294,11 @@ public class CostRateLimitTest {
 
         // Mock ModelCostCalculator to return a cost
         try (MockedStatic<ModelCostCalculator> mockedCalculator = Mockito.mockStatic(ModelCostCalculator.class)) {
-            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), any(), any(), any()))
+            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), any(), any(), any(), any(), any()))
                     .thenReturn(new BigDecimal("0.05"));
 
             // Increase limit to record usage
-            Future<Void> increaseLimitFuture = rateLimiter.increase(model, bucketLocation, proxyContext.getTokenUsage(), null, null);
+            Future<Void> increaseLimitFuture = rateLimiter.increase(model, bucketLocation, proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
             assertNotNull(increaseLimitFuture);
             assertNull(increaseLimitFuture.cause());
 
@@ -396,20 +397,20 @@ public class CostRateLimitTest {
         // Mock ModelCostCalculator to return costs
         try (MockedStatic<ModelCostCalculator> mockedCalculator = Mockito.mockStatic(ModelCostCalculator.class)) {
             // The first user gets $0.05 cost
-            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), same(tokenUsage1), any(), any()))
+            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), same(tokenUsage1), any(), any(), any(), any()))
                     .thenReturn(new BigDecimal("0.05"));
 
             // The second user gets $0.08 cost
-            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), same(tokenUsage2), any(), any()))
+            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), same(tokenUsage2), any(), any(), any(), any()))
                     .thenReturn(new BigDecimal("0.08"));
 
             // First user increases limit
-            Future<Void> increaseLimitFuture1 = rateLimiter.increase(model, bucketLocation1, tokenUsage1, null, null);
+            Future<Void> increaseLimitFuture1 = rateLimiter.increase(model, bucketLocation1, tokenUsage1, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
             assertNotNull(increaseLimitFuture1);
             assertNull(increaseLimitFuture1.cause());
 
             // Second user increases limit
-            Future<Void> increaseLimitFuture2 = rateLimiter.increase(model, bucketLocation2, tokenUsage2, null, null);
+            Future<Void> increaseLimitFuture2 = rateLimiter.increase(model, bucketLocation2, tokenUsage2, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
             assertNotNull(increaseLimitFuture2);
             assertNull(increaseLimitFuture2.cause());
 
@@ -442,11 +443,11 @@ public class CostRateLimitTest {
             assertEquals(new BigDecimal("0.08"), limitStats2.getMinuteCostStats().getUsed());
 
             // Now make first user exceed their limit
-            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), eq(tokenUsage1), any(), any()))
+            mockedCalculator.when(() -> ModelCostCalculator.calculate(any(), eq(tokenUsage1), any(), any(), any(), any()))
                     .thenReturn(new BigDecimal("0.06"));
 
             // First user increases limit again
-            increaseLimitFuture1 = rateLimiter.increase(model, bucketLocation1, tokenUsage1, null, null);
+            increaseLimitFuture1 = rateLimiter.increase(model, bucketLocation1, tokenUsage1, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
             assertNotNull(increaseLimitFuture1);
             assertNull(increaseLimitFuture1.cause());
 

--- a/server/src/test/java/com/epam/aidial/core/server/limiter/RateLimiterTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/limiter/RateLimiterTest.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.limiter;
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CostLimit;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Key;
 import com.epam.aidial.core.config.Limit;
 import com.epam.aidial.core.config.Model;
@@ -258,7 +259,8 @@ public class RateLimiterTest {
         tokenUsage.setTotalTokens(90);
         proxyContext.setTokenUsage(tokenUsage);
 
-        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -268,7 +270,8 @@ public class RateLimiterTest {
         assertNotNull(checkLimitFuture.result());
         assertEquals(HttpStatus.OK, checkLimitFuture.result().status());
 
-        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -318,7 +321,8 @@ public class RateLimiterTest {
         assertNotNull(resultFuture.result());
         assertEquals(HttpStatus.OK, resultFuture.result().status());
 
-        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -340,7 +344,8 @@ public class RateLimiterTest {
         assertEquals(10000000, limitStats.getMonthTokenStats().getTotal());
         assertEquals(90, limitStats.getMonthTokenStats().getUsed());
 
-        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -398,7 +403,8 @@ public class RateLimiterTest {
         tokenUsage.setTotalTokens(150);
         proxyContext.setTokenUsage(tokenUsage);
 
-        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -408,7 +414,8 @@ public class RateLimiterTest {
         assertNotNull(checkLimitFuture.result());
         assertEquals(HttpStatus.OK, checkLimitFuture.result().status());
 
-        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -442,7 +449,8 @@ public class RateLimiterTest {
         tokenUsage.setTotalTokens(90);
         proxyContext.setTokenUsage(tokenUsage);
 
-        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -452,7 +460,8 @@ public class RateLimiterTest {
         assertNotNull(checkLimitFuture.result());
         assertEquals(HttpStatus.OK, checkLimitFuture.result().status());
 
-        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -500,7 +509,8 @@ public class RateLimiterTest {
         tokenUsage.setTotalTokens(150);
         proxyContext.setTokenUsage(tokenUsage);
 
-        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        Future<Void> increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -510,7 +520,8 @@ public class RateLimiterTest {
         assertNotNull(checkLimitFuture.result());
         assertEquals(HttpStatus.OK, checkLimitFuture.result().status());
 
-        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), proxyContext.getTokenUsage(), null, null);
+        increaseLimitFuture = rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext),
+                proxyContext.getTokenUsage(), null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
         assertNotNull(increaseLimitFuture);
         assertNull(increaseLimitFuture.cause());
 
@@ -545,7 +556,7 @@ public class RateLimiterTest {
 
         TokenUsage tokenUsage = new TokenUsage();
         tokenUsage.setTotalTokens(90);
-        assertNull(rateLimiter.increase(usedModel, BucketBuilder.buildInitiatorBucket(proxyContext), tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(usedModel, BucketBuilder.buildInitiatorBucket(proxyContext), tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         UserLimitStats stats = rateLimiter.getUserStats(proxyContext, List.of(usedModel, unusedModel), false).result();
 
@@ -605,7 +616,7 @@ public class RateLimiterTest {
         tokenUsage.setPromptTokens(1000);
         tokenUsage.setCompletionTokens(2000);
         tokenUsage.setTotalTokens(3000);
-        assertNull(rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         UserLimitStats stats = rateLimiter.getUserStats(proxyContext, List.of(model), false).result();
 
@@ -639,8 +650,8 @@ public class RateLimiterTest {
         TokenUsage tokenUsage = new TokenUsage();
         tokenUsage.setTotalTokens(70);
         String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
-        assertNull(rateLimiter.increase(reported, bucket, tokenUsage, null, null).cause());
-        assertNull(rateLimiter.increase(revoked, bucket, tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(reported, bucket, tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
+        assertNull(rateLimiter.increase(revoked, bucket, tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         // only the accessible model is passed in, as the controller would after the access check
         UserLimitStats stats = rateLimiter.getUserStats(proxyContext, List.of(reported), false).result();
@@ -668,7 +679,7 @@ public class RateLimiterTest {
 
         TokenUsage tokenUsage = new TokenUsage();
         tokenUsage.setTotalTokens(11);
-        assertNull(rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(model, BucketBuilder.buildInitiatorBucket(proxyContext), tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         UserLimitStats stats = rateLimiter.getUserStats(proxyContext, List.of(model), false).result();
 
@@ -807,7 +818,7 @@ public class RateLimiterTest {
         String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
         // limit() writes the request counter, increase() the token one
         assertEquals(HttpStatus.OK, rateLimiter.limit(proxyContext, model).result().status());
-        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         // corrupt the token counter in place, leaving the request counter intact
         ResourceDescriptor tokens = ResourceDescriptorFactory
@@ -839,7 +850,7 @@ public class RateLimiterTest {
         tokenUsage.setTotalTokens(42);
         String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
         assertEquals(HttpStatus.OK, rateLimiter.limit(proxyContext, model).result().status());
-        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         // age the token record's listing entry past RateWindow.MONTH, leaving its counter untouched
         ResourceDescriptor tokens = ResourceDescriptorFactory
@@ -895,7 +906,7 @@ public class RateLimiterTest {
         tokenUsage.setTotalTokens(3000);
         String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
         assertEquals(HttpStatus.OK, rateLimiter.limit(proxyContext, model).result().status());
-        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(model, bucket, tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         // the record lands under the name exactly as configured
         assertNotNull(resourceService.getResource(ResourceDescriptorFactory
@@ -934,7 +945,7 @@ public class RateLimiterTest {
         TokenUsage tokenUsage = new TokenUsage();
         tokenUsage.setTotalTokens(7);
         String bucket = BucketBuilder.buildInitiatorBucket(proxyContext);
-        assertNull(rateLimiter.increase(application, bucket, tokenUsage, null, null).cause());
+        assertNull(rateLimiter.increase(application, bucket, tokenUsage, null, null, InterfaceType.OPENAI_CHAT_COMPLETIONS, null).cause());
 
         assertNotNull(resourceService.getResource(ResourceDescriptorFactory
                 .fromDecoded(ResourceTypes.LIMIT, bucket, bucket, "applications/buck/my app/tokens")));

--- a/server/src/test/java/com/epam/aidial/core/server/pricing/PricingRateEvaluatorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/pricing/PricingRateEvaluatorTest.java
@@ -1,0 +1,125 @@
+package com.epam.aidial.core.server.pricing;
+
+import com.epam.aidial.core.config.Condition;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Operator;
+import com.epam.aidial.core.config.PricingRate;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PricingRateEvaluatorTest {
+
+    private static PricingRate leaf(String rate) {
+        PricingRate pricingRate = new PricingRate();
+        pricingRate.setRate(rate);
+        return pricingRate;
+    }
+
+    private static PricingRate node(String field, Operator operator, Object value, PricingRate ifTrue, PricingRate ifFalse) {
+        Condition condition = new Condition();
+        condition.setField(field);
+        condition.setOperator(operator);
+        condition.setValue(value);
+        PricingRate pricingRate = new PricingRate();
+        pricingRate.setTest(condition);
+        pricingRate.setIfTrue(ifTrue);
+        pricingRate.setIfFalse(ifFalse);
+        return pricingRate;
+    }
+
+    private static UsageEvalContext contextFor(String json) throws JsonProcessingException {
+        JsonNode root = ProxyUtil.MAPPER.readTree(json);
+        return UsageEvalContext.build(InterfaceType.ANTHROPIC_MESSAGES, root);
+    }
+
+    @Test
+    void leafResolvesToItsOwnRate() throws JsonProcessingException {
+        UsageEvalContext ctx = contextFor("{}");
+        assertEquals(Optional.of("0.1"), PricingRateEvaluator.evaluate(leaf("0.1"), ctx));
+    }
+
+    @Test
+    void anthropicTtlContextTierMatrixResolvesToTheRightLeaf() throws JsonProcessingException {
+        // Mirrors the design doc's §3 worked example: promptTokens > 200000 and ttl == "1h" -> 0.000012
+        PricingRate tree = node("promptTokens", Operator.GT, 200000,
+                node("ttl", Operator.EQ, "1h", leaf("0.000012"), leaf("0.0000075")),
+                node("ttl", Operator.EQ, "1h", leaf("0.000006"), leaf("0.00000375")));
+
+        UsageEvalContext ctx = contextFor("""
+                {
+                  "usage": {
+                    "input_tokens": 249500,
+                    "cache_read_input_tokens": 400,
+                    "cache_creation_input_tokens": 100,
+                    "cache_creation": { "ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 100 }
+                  }
+                }
+                """);
+
+        assertEquals(Optional.of("0.000012"), PricingRateEvaluator.evaluate(tree, ctx));
+    }
+
+    @Test
+    void missingFieldIsNonMatchAndFallsThroughToIfFalse() throws JsonProcessingException {
+        PricingRate tree = node("serviceTier", Operator.EQ, "flex", leaf("0.1"), leaf("0.2"));
+        UsageEvalContext ctx = contextFor("{ \"usage\": {} }");
+
+        assertEquals(Optional.of("0.2"), PricingRateEvaluator.evaluate(tree, ctx));
+    }
+
+    @Test
+    void omittedBranchBottomsOutToEmptyForCallerToFallBackToPromptRate() throws JsonProcessingException {
+        PricingRate tree = node("serviceTier", Operator.EQ, "flex", leaf("0.1"), null);
+        UsageEvalContext ctx = contextFor("{ \"usage\": {} }");
+
+        assertTrue(PricingRateEvaluator.evaluate(tree, ctx).isEmpty());
+    }
+
+    @Test
+    void omittedBranchMidTreeAlsoFallsBackToEmpty() throws JsonProcessingException {
+        PricingRate inner = node("ttl", Operator.EQ, "1h", leaf("0.5"), null);
+        PricingRate tree = node("promptTokens", Operator.GT, 0, inner, leaf("0.9"));
+        UsageEvalContext ctx = contextFor("{ \"usage\": { \"input_tokens\": 1 } }");
+
+        assertTrue(PricingRateEvaluator.evaluate(tree, ctx).isEmpty());
+    }
+
+    @Test
+    void orderingOperatorAgainstJsonPathStringValueIsNonMatch() throws JsonProcessingException {
+        Condition condition = new Condition();
+        condition.setField("$.usage.service_tier");
+        condition.setOperator(Operator.GT);
+        condition.setValue(1);
+        PricingRate tree = new PricingRate();
+        tree.setTest(condition);
+        tree.setIfTrue(leaf("0.1"));
+        tree.setIfFalse(leaf("0.2"));
+
+        UsageEvalContext ctx = contextFor("{ \"usage\": { \"service_tier\": \"standard\" } }");
+
+        assertEquals(Optional.of("0.2"), PricingRateEvaluator.evaluate(tree, ctx));
+    }
+
+    @Test
+    void jsonPathConditionMatchesAgainstUsageRoot() throws JsonProcessingException {
+        Condition condition = new Condition();
+        condition.setField("$.usage.server_tool_use.web_search_requests");
+        condition.setOperator(Operator.GT);
+        condition.setValue(0);
+        PricingRate tree = new PricingRate();
+        tree.setTest(condition);
+        tree.setIfTrue(leaf("0.1"));
+        tree.setIfFalse(leaf("0.2"));
+
+        UsageEvalContext ctx = contextFor("{ \"usage\": { \"server_tool_use\": { \"web_search_requests\": 3 } } }");
+
+        assertEquals(Optional.of("0.1"), PricingRateEvaluator.evaluate(tree, ctx));
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/pricing/StandardFieldResolverTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/pricing/StandardFieldResolverTest.java
@@ -1,0 +1,95 @@
+package com.epam.aidial.core.server.pricing;
+
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.StandardField;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardFieldResolverTest {
+
+    @Test
+    void resolvesOpenAiChatCompletionsFields() throws JsonProcessingException {
+        JsonNode root = tree("""
+                {
+                  "usage": {
+                    "prompt_tokens": 150000,
+                    "prompt_tokens_details": { "cached_tokens": 800, "cache_write_tokens": 50 }
+                  },
+                  "service_tier": "flex"
+                }
+                """);
+        assertEquals(800, resolve(InterfaceType.OPENAI_CHAT_COMPLETIONS, StandardField.CACHED_READ_TOKENS, root).asLong());
+        assertEquals(50, resolve(InterfaceType.OPENAI_CHAT_COMPLETIONS, StandardField.CACHED_WRITE_TOKENS, root).asLong());
+        assertEquals(150000, resolve(InterfaceType.OPENAI_CHAT_COMPLETIONS, StandardField.PROMPT_TOKENS, root).asLong());
+        assertEquals("flex", resolve(InterfaceType.OPENAI_CHAT_COMPLETIONS, StandardField.SERVICE_TIER, root).asText());
+        assertTrue(resolve(InterfaceType.OPENAI_CHAT_COMPLETIONS, StandardField.TTL, root).isMissingNode());
+    }
+
+    @Test
+    void resolvesOpenAiResponsesFields() throws JsonProcessingException {
+        JsonNode root = tree("""
+                {
+                  "usage": {
+                    "input_tokens": 150000,
+                    "input_tokens_details": { "cached_tokens": 800, "cache_write_tokens": 50 }
+                  },
+                  "service_tier": "priority"
+                }
+                """);
+        assertEquals(800, resolve(InterfaceType.OPENAI_RESPONSES, StandardField.CACHED_READ_TOKENS, root).asLong());
+        assertEquals(50, resolve(InterfaceType.OPENAI_RESPONSES, StandardField.CACHED_WRITE_TOKENS, root).asLong());
+        assertEquals(150000, resolve(InterfaceType.OPENAI_RESPONSES, StandardField.PROMPT_TOKENS, root).asLong());
+        assertEquals("priority", resolve(InterfaceType.OPENAI_RESPONSES, StandardField.SERVICE_TIER, root).asText());
+    }
+
+    @Test
+    void resolvesAnthropicMessagesFieldsIncludingDerivations() throws JsonProcessingException {
+        JsonNode root = tree("""
+                {
+                  "usage": {
+                    "input_tokens": 249500,
+                    "cache_read_input_tokens": 400,
+                    "cache_creation_input_tokens": 100,
+                    "cache_creation": { "ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 100 },
+                    "service_tier": "standard"
+                  }
+                }
+                """);
+        assertEquals(400, resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.CACHED_READ_TOKENS, root).asLong());
+        assertEquals(100, resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.CACHED_WRITE_TOKENS, root).asLong());
+        // derivation: input_tokens + cache_read + cache_creation = 249500 + 400 + 100 = 250000
+        assertEquals(250000, resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.PROMPT_TOKENS, root).asLong());
+        assertEquals("standard", resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.SERVICE_TIER, root).asText());
+        assertEquals("1h", resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.TTL, root).asText());
+    }
+
+    @Test
+    void anthropicTtlPrefers1hOver5mAndMissesWhenNeitherPresent() throws JsonProcessingException {
+        JsonNode fiveMinute = tree("""
+                { "usage": { "cache_creation": { "ephemeral_5m_input_tokens": 10, "ephemeral_1h_input_tokens": 0 } } }
+                """);
+        assertEquals("5m", resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.TTL, fiveMinute).asText());
+
+        JsonNode neither = tree("{ \"usage\": {} }");
+        assertTrue(resolve(InterfaceType.ANTHROPIC_MESSAGES, StandardField.TTL, neither).isMissingNode());
+    }
+
+    @Test
+    void nullInterfaceAlwaysMisses() throws JsonProcessingException {
+        JsonNode root = tree("{ \"usage\": { \"prompt_tokens\": 1 } }");
+        assertTrue(resolve(null, StandardField.PROMPT_TOKENS, root).isMissingNode());
+    }
+
+    private static JsonNode resolve(InterfaceType type, StandardField field, JsonNode root) {
+        return StandardFieldResolver.resolve(type, field, root);
+    }
+
+    private static JsonNode tree(String json) throws JsonProcessingException {
+        return ProxyUtil.MAPPER.readTree(json);
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/pricing/UsageEvalContextTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/pricing/UsageEvalContextTest.java
@@ -1,0 +1,108 @@
+package com.epam.aidial.core.server.pricing;
+
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.StandardField;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UsageEvalContextTest {
+
+    @Test
+    void passthroughResolvesStandardFieldsAgainstNativeResponse() throws JsonProcessingException {
+        JsonNode root = tree("""
+                {
+                  "usage": {
+                    "input_tokens": 249500,
+                    "cache_read_input_tokens": 400,
+                    "cache_creation_input_tokens": 100,
+                    "cache_creation": { "ephemeral_1h_input_tokens": 100 }
+                  }
+                }
+                """);
+        UsageEvalContext ctx = UsageEvalContext.build(InterfaceType.ANTHROPIC_MESSAGES, root);
+
+        assertEquals(250000, ctx.resolve("promptTokens").orElseThrow().asLong());
+        assertEquals("1h", ctx.resolve("ttl").orElseThrow().asText());
+        assertEquals(400, ctx.resolveCounter(StandardField.CACHED_READ_TOKENS).orElseThrow());
+    }
+
+    @Test
+    void translationModeUpstreamUsageTakesPriorityOverNativeUsage() throws JsonProcessingException {
+        // Chat-Completions-shaped native usage disagrees with the untranslated Anthropic envelope;
+        // the envelope must win per requirement 4's priority rule.
+        JsonNode root = tree("""
+                {
+                  "usage": { "prompt_tokens": 999 },
+                  "custom_fields": {
+                    "upstream_usage": {
+                      "interface": "anthropicMessages",
+                      "usage": { "input_tokens": 249500, "cache_read_input_tokens": 400, "cache_creation_input_tokens": 100 }
+                    }
+                  }
+                }
+                """);
+        UsageEvalContext ctx = UsageEvalContext.build(InterfaceType.OPENAI_CHAT_COMPLETIONS, root);
+
+        assertEquals(250000, ctx.resolve("promptTokens").orElseThrow().asLong());
+    }
+
+    @Test
+    void unrecognizedUpstreamInterfaceAlwaysMissesStandardFields() throws JsonProcessingException {
+        JsonNode root = tree("""
+                {
+                  "usage": {},
+                  "custom_fields": { "upstream_usage": { "interface": "someFutureShape", "usage": { "x": 1 } } }
+                }
+                """);
+        UsageEvalContext ctx = UsageEvalContext.build(InterfaceType.OPENAI_CHAT_COMPLETIONS, root);
+
+        assertTrue(ctx.resolve("promptTokens").isEmpty());
+    }
+
+    @Test
+    void jsonPathResolvesAgainstUsageRootInPassthroughMode() throws JsonProcessingException {
+        JsonNode root = tree("""
+                { "usage": { "server_tool_use": { "web_search_requests": 3 } } }
+                """);
+        UsageEvalContext ctx = UsageEvalContext.build(InterfaceType.ANTHROPIC_MESSAGES, root);
+
+        assertEquals(3, ctx.resolve("$.usage.server_tool_use.web_search_requests").orElseThrow().asInt());
+        assertTrue(ctx.resolve("$.upstream_usage.server_tool_use.web_search_requests").isEmpty());
+    }
+
+    @Test
+    void jsonPathResolvesAgainstUpstreamUsageRootInTranslationMode() throws JsonProcessingException {
+        JsonNode root = tree("""
+                {
+                  "usage": {},
+                  "custom_fields": {
+                    "upstream_usage": {
+                      "interface": "anthropicMessages",
+                      "usage": { "server_tool_use": { "web_search_requests": 3 } }
+                    }
+                  }
+                }
+                """);
+        UsageEvalContext ctx = UsageEvalContext.build(InterfaceType.OPENAI_CHAT_COMPLETIONS, root);
+
+        assertEquals(3, ctx.resolve("$.upstream_usage.server_tool_use.web_search_requests").orElseThrow().asInt());
+    }
+
+    @Test
+    void missingUsageSourceMissesEveryStandardField() throws JsonProcessingException {
+        JsonNode root = tree("{}");
+        UsageEvalContext ctx = UsageEvalContext.build(InterfaceType.OPENAI_CHAT_COMPLETIONS, root);
+
+        assertTrue(ctx.resolve("promptTokens").isEmpty());
+        assertTrue(ctx.resolveCounter(StandardField.CACHED_READ_TOKENS).isEmpty());
+    }
+
+    private static JsonNode tree(String json) throws JsonProcessingException {
+        return ProxyUtil.MAPPER.readTree(json);
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/util/ModelCostCalculatorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/ModelCostCalculatorTest.java
@@ -1,8 +1,12 @@
 package com.epam.aidial.core.server.util;
 
+import com.epam.aidial.core.config.Condition;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
+import com.epam.aidial.core.config.Operator;
 import com.epam.aidial.core.config.Pricing;
+import com.epam.aidial.core.config.PricingRate;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.token.PromptTokensDetails;
 import com.epam.aidial.core.server.token.TokenUsage;
@@ -25,15 +29,21 @@ public class ModelCostCalculatorTest {
     @Mock
     private ProxyContext context;
 
+    private static PricingRate flatRate(String rate) {
+        PricingRate pricingRate = new PricingRate();
+        pricingRate.setRate(rate);
+        return pricingRate;
+    }
+
     @Test
     public void testCalculate_DeploymentIsNotModel() {
-        assertNull(ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertNull(ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
     public void testCalculate_PricingIsNull() {
         when(context.getDeployment()).thenReturn(new Model());
-        assertNull(ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertNull(ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -43,7 +53,7 @@ public class ModelCostCalculatorTest {
         pricing.setUnit("unknown");
         model.setPricing(pricing);
         when(context.getDeployment()).thenReturn(model);
-        assertNull(ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertNull(ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -61,7 +71,7 @@ public class ModelCostCalculatorTest {
         tokenUsage.setPromptTokens(10);
         when(context.getTokenUsage()).thenReturn(tokenUsage);
 
-        assertEquals(new BigDecimal("6.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("6.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -83,7 +93,7 @@ public class ModelCostCalculatorTest {
         tokenUsage.setPromptTokensDetails(details);
         when(context.getTokenUsage()).thenReturn(tokenUsage);
 
-        assertEquals(new BigDecimal("6.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("6.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -92,8 +102,8 @@ public class ModelCostCalculatorTest {
         Pricing pricing = new Pricing();
         pricing.setPrompt("0.1");
         pricing.setCompletion("0.5");
-        pricing.setCacheRead("0.01");
-        pricing.setCacheWrite("0.02");
+        pricing.setCacheRead(flatRate("0.01"));
+        pricing.setCacheWrite(flatRate("0.02"));
         pricing.setUnit("token");
         model.setPricing(pricing);
         when(context.getDeployment()).thenReturn(model);
@@ -107,7 +117,7 @@ public class ModelCostCalculatorTest {
         tokenUsage.setPromptTokensDetails(details);
         when(context.getTokenUsage()).thenReturn(tokenUsage);
 
-        assertEquals(new BigDecimal("5.48"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("5.48"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -116,7 +126,7 @@ public class ModelCostCalculatorTest {
         Pricing pricing = new Pricing();
         pricing.setPrompt("0.1");
         pricing.setCompletion("0.5");
-        pricing.setCacheRead("0");
+        pricing.setCacheRead(flatRate("0"));
         pricing.setUnit("token");
         model.setPricing(pricing);
         when(context.getDeployment()).thenReturn(model);
@@ -129,7 +139,7 @@ public class ModelCostCalculatorTest {
         tokenUsage.setPromptTokensDetails(details);
         when(context.getTokenUsage()).thenReturn(tokenUsage);
 
-        assertEquals(new BigDecimal("5.6"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("5.6"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -185,7 +195,7 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("13.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("13.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -242,7 +252,7 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("13.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("13.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -280,7 +290,7 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("1.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("1.0"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -330,7 +340,7 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("6.5"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("6.5"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -380,7 +390,7 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("5.5"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("5.5"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -406,7 +416,7 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("0.7"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("0.7"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
     }
 
     @Test
@@ -432,6 +442,223 @@ public class ModelCostCalculatorTest {
                 """;
         when(context.getRequestBody()).thenReturn(Buffer.buffer(request));
 
-        assertEquals(new BigDecimal("0.4"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody()));
+        assertEquals(new BigDecimal("0.4"), ModelCostCalculator.calculate(context.getDeployment(), context.getTokenUsage(), context.getRequestBody(), context.getResponseBody(), InterfaceType.OPENAI_CHAT_COMPLETIONS, null));
+    }
+
+    private static PricingRate node(String field, Operator operator, Object value, PricingRate ifTrue, PricingRate ifFalse) {
+        Condition condition = new Condition();
+        condition.setField(field);
+        condition.setOperator(operator);
+        condition.setValue(value);
+        PricingRate pricingRate = new PricingRate();
+        pricingRate.setTest(condition);
+        pricingRate.setIfTrue(ifTrue);
+        pricingRate.setIfFalse(ifFalse);
+        return pricingRate;
+    }
+
+    /** Design doc §3: Anthropic claude-sonnet-4-5-style TTL x context-tier matrix, passthrough mode. */
+    @Test
+    public void testCalculate_DecisionTree_AnthropicTtlContextTierMatrix() {
+        Model model = new Model();
+        Pricing pricing = new Pricing();
+        pricing.setUnit("token");
+        pricing.setPrompt("0.000003");
+        pricing.setCompletion("0.000015");
+        pricing.setCacheRead(node("promptTokens", Operator.GT, 200000, flatRate("0.0000006"), flatRate("0.0000003")));
+        pricing.setCacheWrite(node("promptTokens", Operator.GT, 200000,
+                node("ttl", Operator.EQ, "1h", flatRate("0.000012"), flatRate("0.0000075")),
+                node("ttl", Operator.EQ, "1h", flatRate("0.000006"), flatRate("0.00000375"))));
+        model.setPricing(pricing);
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(250000);
+        tokenUsage.setCompletionTokens(0);
+
+        String response = """
+                {
+                  "usage": {
+                    "input_tokens": 249500,
+                    "cache_read_input_tokens": 400,
+                    "cache_creation_input_tokens": 100,
+                    "cache_creation": { "ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 100 },
+                    "service_tier": "standard"
+                  }
+                }
+                """;
+
+        BigDecimal cost = ModelCostCalculator.calculate(model, tokenUsage, null, Buffer.buffer(response),
+                InterfaceType.ANTHROPIC_MESSAGES, null);
+
+        // base: (250000 - 400 - 100) * 0.000003
+        // cacheRead: 400 * 0.0000006 (promptTokens>200000 -> the >200K leaf)
+        // cacheWrite: 100 * 0.000012 (promptTokens>200000 && ttl==1h -> the above_1hr_above_200k leaf)
+        BigDecimal expected = new BigDecimal("249500").multiply(new BigDecimal("0.000003"))
+                .add(new BigDecimal("400").multiply(new BigDecimal("0.0000006")))
+                .add(new BigDecimal("100").multiply(new BigDecimal("0.000012")));
+        assertEquals(expected, cost);
+    }
+
+    /** Design doc §6: OpenAI gpt-5.6-style service-tier x context-tier matrix, passthrough mode. */
+    @Test
+    public void testCalculate_DecisionTree_OpenAiServiceTierContextTierMatrix() {
+        Model model = new Model();
+        Pricing pricing = new Pricing();
+        pricing.setUnit("token");
+        pricing.setPrompt("0.0000025");
+        pricing.setCompletion("0.00001");
+        pricing.setCacheWrite(node("promptTokens", Operator.GT, 272000,
+                node("serviceTier", Operator.EQ, "flex", flatRate("0.00000625"), flatRate("0.0000125")),
+                node("serviceTier", Operator.EQ, "flex", flatRate("0.000003125"),
+                        node("serviceTier", Operator.EQ, "priority", flatRate("0.0000125"), flatRate("0.00000625")))));
+        pricing.setCacheRead(node("promptTokens", Operator.GT, 272000,
+                node("serviceTier", Operator.EQ, "flex", flatRate("0.0000005"), flatRate("0.000001")),
+                node("serviceTier", Operator.EQ, "flex", flatRate("0.00000025"),
+                        node("serviceTier", Operator.EQ, "priority", flatRate("0.000001"), flatRate("0.0000005")))));
+        model.setPricing(pricing);
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(150000);
+        tokenUsage.setCompletionTokens(200);
+
+        String response = """
+                {
+                  "usage": {
+                    "prompt_tokens": 150000,
+                    "prompt_tokens_details": { "cached_tokens": 800, "cache_write_tokens": 50 },
+                    "completion_tokens": 200
+                  },
+                  "service_tier": "flex"
+                }
+                """;
+
+        BigDecimal cost = ModelCostCalculator.calculate(model, tokenUsage, null, Buffer.buffer(response),
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
+
+        // base: (150000 - 800 - 50) * promptRate; completion: 200 * completionRate
+        // cacheRead: 800 * 0.00000025 (<=272k, flex leaf); cacheWrite: 50 * 0.000003125 (<=272k, flex leaf)
+        BigDecimal expected = new BigDecimal("149150").multiply(new BigDecimal("0.0000025"))
+                .add(new BigDecimal("200").multiply(new BigDecimal("0.00001")))
+                .add(new BigDecimal("800").multiply(new BigDecimal("0.00000025")))
+                .add(new BigDecimal("50").multiply(new BigDecimal("0.000003125")));
+        assertEquals(expected, cost);
+    }
+
+    /** Design doc §7a: missing discriminator (service_tier absent), tree still configured. */
+    @Test
+    public void testCalculate_DecisionTree_MissingDiscriminatorFallsBackToIfFalseLeaf() {
+        Model model = new Model();
+        Pricing pricing = new Pricing();
+        pricing.setUnit("token");
+        pricing.setPrompt("0.0000025");
+        pricing.setCompletion("0.00001");
+        pricing.setCacheWrite(node("promptTokens", Operator.GT, 272000,
+                node("serviceTier", Operator.EQ, "flex", flatRate("0.00000625"), flatRate("0.0000125")),
+                node("serviceTier", Operator.EQ, "flex", flatRate("0.000003125"),
+                        node("serviceTier", Operator.EQ, "priority", flatRate("0.0000125"), flatRate("0.00000625")))));
+        model.setPricing(pricing);
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(150000);
+        tokenUsage.setCompletionTokens(200);
+        PromptTokensDetails details = new PromptTokensDetails();
+        details.setCacheWriteTokens(50);
+        tokenUsage.setPromptTokensDetails(details);
+
+        String response = """
+                {
+                  "usage": {
+                    "prompt_tokens": 150000,
+                    "prompt_tokens_details": { "cached_tokens": 800, "cache_write_tokens": 50 },
+                    "completion_tokens": 200
+                  }
+                }
+                """;
+
+        BigDecimal cost = ModelCostCalculator.calculate(model, tokenUsage, null, Buffer.buffer(response),
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
+
+        // serviceTier is absent -> every serviceTier test is a non-match -> bottoms out at the
+        // <=272k, not-flex, not-priority leaf: 0.00000625
+        BigDecimal expected = new BigDecimal("150000").subtract(new BigDecimal("800")).subtract(new BigDecimal("50"))
+                .multiply(new BigDecimal("0.0000025"))
+                .add(new BigDecimal("200").multiply(new BigDecimal("0.00001")))
+                .add(new BigDecimal("800").multiply(new BigDecimal("0.0000025"))) // cacheRead unset -> promptRate
+                .add(new BigDecimal("50").multiply(new BigDecimal("0.00000625")));
+        assertEquals(expected, cost);
+    }
+
+    /** Design doc §7b: no usable usage source at all (no custom_fields.upstream_usage, no native usage). */
+    @Test
+    public void testCalculate_DecisionTree_NoUsableUsageSourceFallsBackToPromptTokensDetails() {
+        Model model = new Model();
+        Pricing pricing = new Pricing();
+        pricing.setUnit("token");
+        pricing.setPrompt("0.1");
+        pricing.setCompletion("0.5");
+        pricing.setCacheRead(node("serviceTier", Operator.EQ, "flex", flatRate("0.01"), flatRate("0.02")));
+        model.setPricing(pricing);
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(10);
+        tokenUsage.setCompletionTokens(10);
+        PromptTokensDetails details = new PromptTokensDetails();
+        details.setCachedTokens(4);
+        tokenUsage.setPromptTokensDetails(details);
+
+        BigDecimal cost = ModelCostCalculator.calculate(model, tokenUsage, null, null,
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
+
+        // no responseBody at all -> counter falls back to PromptTokensDetails.cachedTokens=4,
+        // rate resolution never matches serviceTier -> falls back to ifFalse=0.02
+        BigDecimal expected = new BigDecimal("6").multiply(new BigDecimal("0.1"))
+                .add(new BigDecimal("10").multiply(new BigDecimal("0.5")))
+                .add(new BigDecimal("4").multiply(new BigDecimal("0.02")));
+        assertEquals(expected, cost);
+    }
+
+    /** Design doc §4: translation-mode parity - same price as the passthrough §3 case for a byte-identical envelope. */
+    @Test
+    public void testCalculate_DecisionTree_TranslationModeParityWithPassthrough() {
+        Model model = new Model();
+        Pricing pricing = new Pricing();
+        pricing.setUnit("token");
+        pricing.setPrompt("0.000003");
+        pricing.setCompletion("0.000015");
+        pricing.setCacheRead(node("promptTokens", Operator.GT, 200000, flatRate("0.0000006"), flatRate("0.0000003")));
+        pricing.setCacheWrite(node("promptTokens", Operator.GT, 200000,
+                node("ttl", Operator.EQ, "1h", flatRate("0.000012"), flatRate("0.0000075")),
+                node("ttl", Operator.EQ, "1h", flatRate("0.000006"), flatRate("0.00000375"))));
+        model.setPricing(pricing);
+
+        TokenUsage tokenUsage = new TokenUsage();
+        tokenUsage.setPromptTokens(250000);
+        tokenUsage.setCompletionTokens(0);
+
+        String translatedResponse = """
+                {
+                  "usage": { "prompt_tokens": 250000, "prompt_tokens_details": { "cached_tokens": 400, "cache_write_tokens": 100 } },
+                  "custom_fields": {
+                    "upstream_usage": {
+                      "interface": "anthropicMessages",
+                      "usage": {
+                        "input_tokens": 249500,
+                        "cache_read_input_tokens": 400,
+                        "cache_creation_input_tokens": 100,
+                        "cache_creation": { "ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 100 },
+                        "service_tier": "standard"
+                      }
+                    }
+                  }
+                }
+                """;
+
+        BigDecimal translationCost = ModelCostCalculator.calculate(model, tokenUsage, null, Buffer.buffer(translatedResponse),
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, null);
+
+        BigDecimal expected = new BigDecimal("249500").multiply(new BigDecimal("0.000003"))
+                .add(new BigDecimal("400").multiply(new BigDecimal("0.0000006")))
+                .add(new BigDecimal("100").multiply(new BigDecimal("0.000012")));
+        assertEquals(expected, translationCost);
     }
 }


### PR DESCRIPTION
## Summary
- Extends `Pricing.cacheRead`/`cacheWrite` to optionally be a decision tree (`{test, ifTrue, ifFalse}`) evaluated against standard usage fields (`cachedReadTokens`, `cachedWriteTokens`, `promptTokens`, `serviceTier`, `ttl`) or an open-vocabulary JSON Path expression, instead of only a flat rate string — lets operators express real provider cache-pricing matrices (e.g. Anthropic's TTL x context-tier grid, OpenAI's service-tier x context-tier grid) that a single number can't represent.
- New server-side evaluation engine (`server/.../pricing/`: `StandardFieldResolver`, `UsageEvalContext`, `PricingRateEvaluator`) resolves the tree against either the native passthrough response or, additively, a `custom_fields.upstream_usage` envelope from a future translating adapter — same alias table either way, so both routes to the same upstream call price identically.
- For streaming responses, the needed usage fields are now captured live per SSE event (extended `CollectMessagesTokenUsageFn`/`ExtractTerminalResponseFn`, new `CollectChatCompletionUsageFn`) into a new `ProxyContext.pricingUsageNode` field, rather than re-scanning the buffered response afterward.
- A model without `cacheRead`/`cacheWrite` configured, or with only the flat-string form, computes cost exactly as it did before this change — no silent cost shift on rollout.
- New `ValidCondition` config-load-time check rejects an ordering operator (`>`, `<`, `>=`, `<=`) against the string-typed standard fields (`serviceTier`, `ttl`).

## Applicable issues

- fixes #1857 

## Test plan
- [x] `./gradlew :config:test :server:test` — full pass
- [x] `./gradlew checkstyleMain checkstyleTest` — clean
- [x] New unit tests: `PricingRateTest`, `OperatorTest`, `StandardFieldTest`, `ValidConditionValidatorTest` (config); `StandardFieldResolverTest`, `UsageEvalContextTest`, `PricingRateEvaluatorTest`, `CollectChatCompletionUsageFnTest`, `ExtractTerminalResponseFnTest` (server)
- [x] Worked-example integration tests in `ModelCostCalculatorTest` covering the design doc's Anthropic TTL matrix, OpenAI service-tier matrix, missing-discriminator fallback, no-usable-usage-source fallback, and translation-mode parity scenarios
- [x] Existing `ModelCostCalculatorTest`/`RateLimiterTest`/`CostRateLimitTest` suites updated for the new signature and still green, confirming no cost regression for unconfigured/flat-rate models

🤖 Generated with [Claude Code](https://claude.com/claude-code)