### PR TITLE
feat: support defaultHeaders on deployment and interfaces levels

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Application.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Application.java
@@ -194,6 +194,7 @@ public class Application extends Deployment {
         this.setMaxInputAttachments(source.getMaxInputAttachments());
         this.setDefaults(source.getDefaults());
         this.setResponsesDefaults(source.getResponsesDefaults());
+        this.setDefaultHeaders(source.getDefaultHeaders());
         this.setInterceptors(source.getInterceptors());
         this.setDescriptionKeywords(source.getDescriptionKeywords());
         this.setFunction(source.getFunction());

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -139,6 +139,7 @@ public abstract class Deployment extends RoleBasedEntity {
         if (interfaceHeaders.isEmpty()) {
             return defaultHeaders;
         }
+        // TreeMap for its case-insensitive comparator, not for ordering: an interface entry has to override a deployment-level header spelled in another case
         Map<String, String> merged = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         merged.putAll(defaultHeaders);
         merged.putAll(interfaceHeaders);

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -61,6 +62,14 @@ public abstract class Deployment extends RoleBasedEntity {
      * Default parameters are applied if a request doesn't contain them in OpenAI Responses API call.
      */
     private Map<String, Object> responsesDefaults = Map.of();
+    /**
+     * Headers added to a request that carries none under that name, for every interface the deployment
+     * serves. Overlaid per interface by {@code interfaces.<type>.defaultHeaders}, see
+     * {@link #resolveDefaultHeaders}.
+     */
+    @JsonAlias({"defaultHeaders", "default_headers"})
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> defaultHeaders = Map.of();
     /**
      * List of interceptors to be called for the deployment
      */
@@ -117,5 +126,22 @@ public abstract class Deployment extends RoleBasedEntity {
     @JsonIgnore
     public String getTargetName() {
         return overrideName != null ? overrideName : getName();
+    }
+
+    /**
+     * The default headers in force for the interface type: the deployment-level {@link #defaultHeaders}
+     * with {@code interfaces.<type>.defaultHeaders} laid over them. Names are compared case-insensitively,
+     * so an interface entry overrides a deployment-level header however either spells it.
+     */
+    public Map<String, String> resolveDefaultHeaders(InterfaceType type) {
+        DeploymentInterface declared = interfaces == null ? null : interfaces.get(type.getValue());
+        Map<String, String> interfaceHeaders = declared == null ? Map.of() : declared.getDefaultHeaders();
+        if (interfaceHeaders.isEmpty()) {
+            return defaultHeaders;
+        }
+        Map<String, String> merged = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        merged.putAll(defaultHeaders);
+        merged.putAll(interfaceHeaders);
+        return merged;
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.Map;
+
 /**
  * Per-interface routing configuration for a {@link Deployment}. Intentionally minimal;
  * future per-interface options (auth mode, defaults, ...) go here.
@@ -19,6 +21,14 @@ public class DeploymentInterface {
      */
     @JsonProperty("base_url")
     private String baseUrl;
+
+    /**
+     * Headers added to a request for this interface that carries none under that name, laid over the
+     * deployment-level {@code defaultHeaders}. Resolved by {@link Deployment#resolveDefaultHeaders}.
+     */
+    @JsonAlias({"defaultHeaders", "default_headers"})
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> defaultHeaders = Map.of();
 
     @JsonCreator
     public DeploymentInterface(

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static com.epam.aidial.core.config.InterfaceType.ANTHROPIC_MESSAGES;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
 import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -164,7 +165,8 @@ public class DeploymentTest {
     void applicationCopyConstructorPreservesDefaultHeaders() {
         Application source = new Application();
         source.setName("app1");
-        source.setEndpoint("http://host/chat/completions");
+        source.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface("http://adapter")));
         source.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority"));
 
         Application copy = new Application(source);

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static com.epam.aidial.core.config.InterfaceType.ANTHROPIC_MESSAGES;
 import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,6 +80,96 @@ public class DeploymentTest {
 
         assertEquals(source.getInterfaces(), copy.getInterfaces());
         assertEquals("http://adapter", copy.getInterfaces().get(OPENAI_RESPONSES.getValue()).getBaseUrl());
+    }
+
+    @Test
+    void defaultHeadersFallBackToDeploymentLevelForEveryInterface() {
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority"));
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new DeploymentInterface("http://anthropic")));
+
+        // declared without headers of its own, and not declared at all, resolve alike
+        assertEquals(Map.of("x-dial-cache-policy", "cache-priority"), model.resolveDefaultHeaders(ANTHROPIC_MESSAGES));
+        assertEquals(Map.of("x-dial-cache-policy", "cache-priority"), model.resolveDefaultHeaders(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void interfaceDefaultHeadersOverrideAndExtendDeploymentLevel() {
+        DeploymentInterface anthropic = new DeploymentInterface("http://anthropic");
+        anthropic.setDefaultHeaders(Map.of("x-dial-custom-header", "foo-bar-2", "x-dial-custom-header-2", "some-value"));
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar"));
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        assertEquals(
+                Map.of("x-dial-cache-policy", "cache-priority",
+                        "x-dial-custom-header", "foo-bar-2",
+                        "x-dial-custom-header-2", "some-value"),
+                model.resolveDefaultHeaders(ANTHROPIC_MESSAGES));
+        // the overlay is scoped to its own interface
+        assertEquals(
+                Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar"),
+                model.resolveDefaultHeaders(OPENAI_RESPONSES));
+    }
+
+    @Test
+    void interfaceDefaultHeadersOverrideDeploymentLevelSpelledInAnotherCase() {
+        DeploymentInterface anthropic = new DeploymentInterface("http://anthropic");
+        anthropic.setDefaultHeaders(Map.of("x-dial-custom-header", "foo-bar-2"));
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("X-Dial-Custom-Header", "foo-bar"));
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        Map<String, String> resolved = model.resolveDefaultHeaders(ANTHROPIC_MESSAGES);
+
+        assertEquals(1, resolved.size());
+        assertEquals("foo-bar-2", resolved.get("X-DIAL-CUSTOM-HEADER"));
+    }
+
+    @Test
+    void roundTripDefaultHeaders() throws Exception {
+        String json = """
+                {
+                    "endpoint": "http://host/chat/completions",
+                    "defaultHeaders": {"x-dial-cache-policy": "cache-priority"},
+                    "interfaces": {
+                        "anthropicMessages": {
+                            "base_url": "http://anthropic",
+                            "default_headers": {"x-dial-custom-header": "foo-bar-2"}
+                        }
+                    }
+                }
+                """;
+
+        Model restored = MAPPER.readValue(MAPPER.writeValueAsString(MAPPER.readValue(json, Model.class)), Model.class);
+
+        assertEquals(Map.of("x-dial-cache-policy", "cache-priority"), restored.getDefaultHeaders());
+        assertEquals(
+                Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar-2"),
+                restored.resolveDefaultHeaders(ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void defaultHeadersAreOmittedWhenEmpty() throws Exception {
+        Model model = new Model();
+        model.setEndpoint("http://host/chat/completions");
+        model.setInterfaces(Map.of(OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
+
+        String json = MAPPER.writeValueAsString(model);
+
+        assertFalse(json.contains("defaultHeaders"), json);
+    }
+
+    @Test
+    void applicationCopyConstructorPreservesDefaultHeaders() {
+        Application source = new Application();
+        source.setName("app1");
+        source.setEndpoint("http://host/chat/completions");
+        source.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority"));
+
+        Application copy = new Application(source);
+
+        assertEquals(Map.of("x-dial-cache-policy", "cache-priority"), copy.getDefaultHeaders());
     }
 
     @Test

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -173,7 +173,7 @@ Each value is an object with the following fields:
 
 An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
 
-A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request and forwards it to the application under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
+A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request and forwards it to the application under the same rules as a client header. That cuts both ways: a name DIAL Core strips on the way to the application — a hop-by-hop header, `Api-Key`/`x-api-key`, `traceparent`/`tracestate`, or `Authorization` unless `forwardAuthToken` is set — is stripped when it comes from `defaultHeaders` too, even though DIAL Core itself still sees it on the incoming request.
 
 The application-level `defaultHeaders` apply to every interface the application serves. `interfaces.openaiChatCompletions.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other application-level header still applies.
 

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -48,6 +48,7 @@ An object containing parameters for each [application](#applications).
 * `viewerUrl`: A string with URL of the application's [custom viewer UI](https://github.com/epam/ai-dial-chat/tree/development/docs). A custom UI, if enabled, will override the standard DIAL Chat UI.
 * `editorUrl`: A string with URL of the application's custom builder UI. Application builder allows DIAL Chat end-users to create instances of apps using a [UI wizards](https://docs.dialx.ai/tutorials/user-guide#application-builder).
 * `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.         
+* `defaultHeaders`: HTTP headers applied to a request that doesn't already carry them — the header counterpart of `defaults`. Works exactly as for models, including the per-interface overlay: refer to [models.<model_name>.defaultHeaders](./models.md#modelsmodel_namedefaultheaders).
 * `interceptors`: A list of local interceptors to be triggered for the given application. Refer to [Interceptors](./interceptors.md) to learn more.
 * `mcp`: MCP configuration. Refer to [MCP](#applicationsapplication_namemcp) to learn more.
 * `features`: A list of features supported by the application. Refer to [Features](#applicationsapplication_namefeatures) for more details.
@@ -154,6 +155,7 @@ Applications support only one interface type:
 Each value is an object with the following fields:
 
 * `base_url`: The application adapter root that the matching ingress path is appended to.
+* `defaultHeaders`: Headers applied to requests for this interface only, laid over the application-level `defaultHeaders`.
 
 **Example**
 

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -48,7 +48,7 @@ An object containing parameters for each [application](#applications).
 * `viewerUrl`: A string with URL of the application's [custom viewer UI](https://github.com/epam/ai-dial-chat/tree/development/docs). A custom UI, if enabled, will override the standard DIAL Chat UI.
 * `editorUrl`: A string with URL of the application's custom builder UI. Application builder allows DIAL Chat end-users to create instances of apps using a [UI wizards](https://docs.dialx.ai/tutorials/user-guide#application-builder).
 * `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.         
-* `defaultHeaders`: HTTP headers applied to a request that doesn't already carry them — the header counterpart of `defaults`. Works exactly as for models, including the per-interface overlay: refer to [models.<model_name>.defaultHeaders](./models.md#modelsmodel_namedefaultheaders).
+* `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them. Refer to [applications.<application_name>.defaultHeaders](#applicationsapplication_namedefaultheaders).
 * `interceptors`: A list of local interceptors to be triggered for the given application. Refer to [Interceptors](./interceptors.md) to learn more.
 * `mcp`: MCP configuration. Refer to [MCP](#applicationsapplication_namemcp) to learn more.
 * `features`: A list of features supported by the application. Refer to [Features](#applicationsapplication_namefeatures) for more details.
@@ -155,7 +155,7 @@ Applications support only one interface type:
 Each value is an object with the following fields:
 
 * `base_url`: The application adapter root that the matching ingress path is appended to.
-* `defaultHeaders`: Headers applied to requests for this interface only, laid over the application-level `defaultHeaders`.
+* `defaultHeaders`: Headers applied to requests for this interface only, laid over the application-level `defaultHeaders`. Refer to [applications.<application_name>.defaultHeaders](#applicationsapplication_namedefaultheaders).
 
 **Example**
 
@@ -164,6 +164,30 @@ Each value is an object with the following fields:
     "app-via-interfaces": {
         "interfaces": {
             "openaiChatCompletions": { "base_url": "http://localhost:7005" }
+        }
+    }
+}
+```
+
+#### applications.<application_name>.defaultHeaders
+
+An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
+
+A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request and forwards it to the application under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
+
+The application-level `defaultHeaders` apply to every interface the application serves. `interfaces.openaiChatCompletions.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other application-level header still applies.
+
+They are applied once per request, when it enters the application: with `interceptors` configured that is the hop to the first interceptor, from where they travel down the chain. An interceptor's own `defaultHeaders` are applied on the hop that calls it and take precedence over the application's.
+
+**Example**
+
+```json
+"applications": {
+    "app-with-default-headers": {
+        "endpoint": "http://localhost:7001/openai/deployments/10k/chat/completions",
+        "defaultHeaders": {
+            "x-dial-cache-policy": "cache-priority",
+            "x-dial-custom-header": "foo-bar"
         }
     }
 }

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -46,6 +46,7 @@ An object containing parameters for each [interceptor](#interceptors).
 * `features`: Features supported by the interceptors.
 *  `configurationEndpoint`: The URL that exposes the configuration of the interceptor.
 *  `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.
+*  `defaultHeaders`: HTTP headers applied to a request that doesn't already carry them, on the hop that calls this interceptor. They take precedence over the `defaultHeaders` of the model or application the interceptor fronts, which are applied at the first interceptor of the chain and travel down it from there. Works as for models otherwise, including the per-interface overlay: refer to [models.<model_name>.defaultHeaders](./models.md#modelsmodel_namedefaultheaders).
 
 ### interceptors.<interceptor_name>.interfaces
 
@@ -59,9 +60,10 @@ Interceptors support only one interface type:
 
 > The Responses API (`openaiResponses`) and any other interface types are **not** supported for interceptors. If declared, they are dropped on config read with a warning.
 
-Each value is an object with a single field:
+Each value is an object with the following fields:
 
 * `base_url`: The interceptor service root that the matching ingress path is appended to.
+* `defaultHeaders`: Headers applied to requests for this interface only, laid over the interceptor-level `defaultHeaders`.
 
 **Example**
 

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -46,7 +46,7 @@ An object containing parameters for each [interceptor](#interceptors).
 * `features`: Features supported by the interceptors.
 *  `configurationEndpoint`: The URL that exposes the configuration of the interceptor.
 *  `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.
-*  `defaultHeaders`: HTTP headers applied to a request that doesn't already carry them, on the hop that calls this interceptor. They take precedence over the `defaultHeaders` of the model or application the interceptor fronts, which are applied at the first interceptor of the chain and travel down it from there. Works as for models otherwise, including the per-interface overlay: refer to [models.<model_name>.defaultHeaders](./models.md#modelsmodel_namedefaultheaders).
+*  `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them, on the hop that calls this interceptor. Refer to [interceptors.<interceptor_name>.defaultHeaders](#interceptorsinterceptor_namedefaultheaders).
 
 ### interceptors.<interceptor_name>.interfaces
 
@@ -63,7 +63,7 @@ Interceptors support only one interface type:
 Each value is an object with the following fields:
 
 * `base_url`: The interceptor service root that the matching ingress path is appended to.
-* `defaultHeaders`: Headers applied to requests for this interface only, laid over the interceptor-level `defaultHeaders`.
+* `defaultHeaders`: Headers applied to requests for this interface only, laid over the interceptor-level `defaultHeaders`. Refer to [interceptors.<interceptor_name>.defaultHeaders](#interceptorsinterceptor_namedefaultheaders).
 
 **Example**
 
@@ -72,6 +72,29 @@ Each value is an object with the following fields:
     "interceptor-via-interfaces": {
         "interfaces": {
             "openaiChatCompletions": { "base_url": "http://localhost:4088" }
+        }
+    }
+}
+```
+
+### interceptors.<interceptor_name>.defaultHeaders
+
+An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name, on the hop that calls this interceptor. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
+
+A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request and forwards it to the interceptor under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
+
+The interceptor-level `defaultHeaders` apply to every interface the interceptor serves. `interfaces.openaiChatCompletions.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other interceptor-level header still applies.
+
+The `defaultHeaders` of the model or application the interceptor fronts are applied at the first interceptor of the chain and travel down it from there. Where both declare the same name, the interceptor's value wins.
+
+**Example**
+
+```json
+"interceptors": {
+    "interceptor-with-default-headers": {
+        "endpoint": "http://localhost:4088/api/v1/interceptor/handle",
+        "defaultHeaders": {
+            "x-dial-custom-header": "foo-bar"
         }
     }
 }

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -81,7 +81,7 @@ Each value is an object with the following fields:
 
 An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name, on the hop that calls this interceptor. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
 
-A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request and forwards it to the interceptor under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
+A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request and forwards it to the interceptor under the same rules as a client header. That cuts both ways: a name DIAL Core strips on the way to the interceptor — a hop-by-hop header, `Api-Key`/`x-api-key`, or `traceparent`/`tracestate` — is stripped when it comes from `defaultHeaders` too, even though DIAL Core itself still sees it on the incoming request.
 
 The interceptor-level `defaultHeaders` apply to every interface the interceptor serves. `interfaces.openaiChatCompletions.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other interceptor-level header still applies.
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -50,7 +50,7 @@ An object containing parameters for each [model](#models).
 
   DIAL Core rewrites upstream response IDs to stable `resp_dial_*` identifiers and uses sticky routing to ensure follow-up requests are forwarded to the same upstream instance that handled the original request. `previous_response_id`, conversations, prompts, and files are not supported.
 * `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API.
-* `defaultHeaders`: HTTP headers applied to a request that doesn't already carry them, for every interface the model serves — the header counterpart of `defaults`. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
+* `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them, for every interface the model serves. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
 * `interfaces`: An alternative to the flat `endpoint`/`responsesEndpoint` fields for declaring routing targets, keyed by interface type. Both shapes are first-class — pick whichever you prefer per model. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interceptors`: A list of interceptors to be triggered for the given model. Refer to [Interceptors](https://github.com/epam/ai-dial/blob/main/docs/platform/3.core/6.interceptors.md) to learn more.
 * `fieldsHashingOrder`: **Deprecated, no longer has any effect.** It used to let `POST /openai/deployments/{deployment_name}/chat/completions` customize the order in which request components are hashed for upstream-cache pinning. DIAL Core now always uses a built-in, non-configurable order per interface, fixed by that API's wire format — the same mechanism `POST /anthropic/v1/messages` and `POST /openai/v1/responses` use:
@@ -193,13 +193,13 @@ Each value is an object with the following fields:
 
 #### models.<model_name>.defaultHeaders
 
-An object of HTTP header names and values applied to a request that does not already carry a header of that name, the way `defaults` applies to body parameters. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-UPSTREAM-*`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
+An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-UPSTREAM-*`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
 
 A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request — so `X-DIAL-CACHE-POLICY` set this way drives upstream cache pinning, not just what the adapter receives — and forwards it under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
 
 The model-level `defaultHeaders` apply to every interface the model serves. `interfaces.<type>.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other model-level header still applies.
 
-Defaults are applied once per request, when it enters the model: with `interceptors` configured that is the hop to the first interceptor, from where they travel down the chain. An interceptor's own `defaultHeaders` are applied on the hop that calls it and take precedence over the model's.
+They are applied once per request, when it enters the model: with `interceptors` configured that is the hop to the first interceptor, from where they travel down the chain. An interceptor's own `defaultHeaders` are applied on the hop that calls it and take precedence over the model's.
 
 **Example**
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -50,6 +50,7 @@ An object containing parameters for each [model](#models).
 
   DIAL Core rewrites upstream response IDs to stable `resp_dial_*` identifiers and uses sticky routing to ensure follow-up requests are forwarded to the same upstream instance that handled the original request. `previous_response_id`, conversations, prompts, and files are not supported.
 * `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API.
+* `defaultHeaders`: HTTP headers applied to a request that doesn't already carry them, for every interface the model serves — the header counterpart of `defaults`. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
 * `interfaces`: An alternative to the flat `endpoint`/`responsesEndpoint` fields for declaring routing targets, keyed by interface type. Both shapes are first-class — pick whichever you prefer per model. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interceptors`: A list of interceptors to be triggered for the given model. Refer to [Interceptors](https://github.com/epam/ai-dial/blob/main/docs/platform/3.core/6.interceptors.md) to learn more.
 * `fieldsHashingOrder`: **Deprecated, no longer has any effect.** It used to let `POST /openai/deployments/{deployment_name}/chat/completions` customize the order in which request components are hashed for upstream-cache pinning. DIAL Core now always uses a built-in, non-configurable order per interface, fixed by that API's wire format — the same mechanism `POST /anthropic/v1/messages` and `POST /openai/v1/responses` use:
@@ -168,6 +169,7 @@ Only the interface types a model declares are reported in the `interfaces` array
 Each value is an object with the following fields:
 
 * `base_url`: The model adapter root that the matching ingress path is appended to.
+* `defaultHeaders`: Headers applied to requests for this interface only, laid over the model-level `defaultHeaders`. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
 
 **Example**
 
@@ -188,6 +190,43 @@ Each value is an object with the following fields:
     }
 }
 ```
+
+#### models.<model_name>.defaultHeaders
+
+An object of HTTP header names and values applied to a request that does not already carry a header of that name, the way `defaults` applies to body parameters. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-UPSTREAM-*`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
+
+A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request — so `X-DIAL-CACHE-POLICY` set this way drives upstream cache pinning, not just what the adapter receives — and forwards it under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
+
+The model-level `defaultHeaders` apply to every interface the model serves. `interfaces.<type>.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other model-level header still applies.
+
+Defaults are applied once per request, when it enters the model: with `interceptors` configured that is the hop to the first interceptor, from where they travel down the chain. An interceptor's own `defaultHeaders` are applied on the hop that calls it and take precedence over the model's.
+
+**Example**
+
+```json
+"models": {
+    "openai-gpt-5.4-mini": {
+        "type": "chat",
+        "defaultHeaders": {
+            "x-dial-cache-policy": "cache-priority",
+            "x-dial-custom-header": "foo-bar"
+        },
+        "interfaces": {
+            "openaiChatCompletions": { "base_url": "http://dial-openai-adapter" },
+            "openaiResponses": { "base_url": "http://dial-openai-adapter" },
+            "anthropicMessages": {
+                "base_url": "http://dial-anthropic-adapter",
+                "defaultHeaders": {
+                    "x-dial-custom-header": "foo-bar-2",
+                    "x-dial-custom-header-2": "some-value"
+                }
+            }
+        }
+    }
+}
+```
+
+The effective headers are `x-dial-cache-policy: cache-priority` and `x-dial-custom-header: foo-bar` for `chat/completions`, `embeddings` and the Responses API, and `x-dial-cache-policy: cache-priority`, `x-dial-custom-header: foo-bar-2`, `x-dial-custom-header-2: some-value` for the Anthropic Messages API.
 
 #### models.<model_name>.limits
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -195,7 +195,7 @@ Each value is an object with the following fields:
 
 An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-UPSTREAM-*`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.
 
-A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request — so `X-DIAL-CACHE-POLICY` set this way drives upstream cache pinning, not just what the adapter receives — and forwards it under the same rules as a client header. Headers DIAL Core never forwards are not forwarded here either: hop-by-hop headers, `Api-Key`/`x-api-key`, and `Authorization` unless `forwardAuthToken` is set.
+A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request — so `X-DIAL-CACHE-POLICY` set this way drives upstream cache pinning, not just what the adapter receives — and forwards it under the same rules as a client header. That cuts both ways: a name DIAL Core strips on the way to the model — a hop-by-hop header, `Api-Key`/`x-api-key`, `traceparent`/`tracestate`, or `Authorization` unless `forwardAuthToken` is set — is stripped when it comes from `defaultHeaders` too, even though DIAL Core itself still sees it on the incoming request.
 
 The model-level `defaultHeaders` apply to every interface the model serves. `interfaces.<type>.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other model-level header still applies.
 

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -13531,6 +13531,8 @@ components:
           format: uri
         overrideName:
           type: string
+        defaultHeaders:
+          $ref: "#/components/schemas/MapStringString"
     ApplicationData:
       type: object
       properties:
@@ -14941,6 +14943,8 @@ components:
       properties:
         base_url:
           type: string
+        defaultHeaders:
+          $ref: "#/components/schemas/MapStringString"
     EmbeddingResponse:
       required:
       - data
@@ -15433,6 +15437,8 @@ components:
           format: uri
         overrideName:
           type: string
+        defaultHeaders:
+          $ref: "#/components/schemas/MapStringString"
     Invitation:
       type: object
       properties:
@@ -15837,6 +15843,8 @@ components:
         catalogSchemaId:
           type: string
           format: uri
+        defaultHeaders:
+          $ref: "#/components/schemas/MapStringString"
     ModelData:
       type: object
       properties:
@@ -16899,6 +16907,8 @@ components:
           format: uri
         overrideName:
           type: string
+        defaultHeaders:
+          $ref: "#/components/schemas/MapStringString"
     ToolSetData:
       type: object
       properties:

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
@@ -25,7 +25,7 @@ public class ChatCompletionInterceptorController extends BaseInterceptorControll
 
     public ChatCompletionInterceptorController(Proxy proxy, ProxyContext context, int interceptorIndex) {
         super(proxy, context, interceptorIndex, List.of(
-                new ApplyDefaultDeploymentSettingsFn(proxy, context),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS),
                 new EnhanceDeploymentRequestFn(proxy, context),
                 new CollectRequestStandardAttachmentsFn(proxy, context),
                 new AutoShareDeploymentFn(proxy, context)));

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -62,12 +62,18 @@ import static com.epam.aidial.core.server.Proxy.HEADER_UPSTREAM_ID;
 
 @Slf4j
 public class DeploymentPostController extends BaseDeploymentPostController {
-    private final List<BaseRequestFunction<RequestObject>> enhancementFunctions;
 
     public DeploymentPostController(Proxy proxy, ProxyContext context) {
         super(proxy, context);
-        this.enhancementFunctions = List.of(new CollectRequestStandardAttachmentsFn(proxy, context),
-                new ApplyDefaultDeploymentSettingsFn(proxy, context),
+    }
+
+    /**
+     * Built when the request body is handled rather than at construction: the chain is parameterized by
+     * {@link #requestedInterface()}, which reads the request path.
+     */
+    private List<BaseRequestFunction<RequestObject>> buildEnhancementFunctions() {
+        return List.of(new CollectRequestStandardAttachmentsFn(proxy, context),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, requestedInterface()),
                 new EnhanceDeploymentRequestFn(proxy, context),
                 new CollectRequestApplicationFilesFn(proxy, context),
                 new BuildUpstreamCacheFn(proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS),
@@ -317,7 +323,7 @@ public class DeploymentPostController extends BaseDeploymentPostController {
         try {
             RequestObject request = new ChatCompletionRequest(ProxyUtil.parseObject(requestBody));
             context.setStreamingRequest(request.isStreaming());
-            if (ProxyUtil.processChain(request, enhancementFunctions)) {
+            if (ProxyUtil.processChain(request, buildEnhancementFunctions())) {
                 context.setRequestBody(Buffer.buffer(request.serialize()));
             }
             proxy.getApiKeyStore().assignPerRequestApiKey(context.getProxyApiKeyData());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -68,7 +68,7 @@ public class ResponsesController extends BaseDeploymentPostController {
         super(proxy, context);
         this.enhancementFunctions = List.of(
                 new CollectRequestStandardAttachmentsFn(proxy, context),
-                new ApplyDefaultDeploymentSettingsFn(proxy, context),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_RESPONSES),
                 new EnhanceDeploymentRequestFn(proxy, context),
                 new CollectRequestApplicationFilesFn(proxy, context),
                 new BuildUpstreamCacheFn(proxy, context, InterfaceType.OPENAI_RESPONSES),

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesInterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesInterceptorController.java
@@ -36,7 +36,7 @@ public class ResponsesInterceptorController extends BaseInterceptorController {
 
     private static List<BaseRequestFunction<RequestObject>> defaultEnhancementFunctions(Proxy proxy, ProxyContext context) {
         return List.of(
-                new ApplyDefaultDeploymentSettingsFn(proxy, context),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_RESPONSES),
                 new CollectRequestStandardAttachmentsFn(proxy, context),
                 new AutoShareDeploymentFn(proxy, context));
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -69,7 +69,7 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
     protected List<BaseRequestFunction<RequestObject>> buildEnhancementFunctions() {
         return List.of(
                 new CollectRequestStandardAttachmentsFn(proxy, context),
-                new ApplyDefaultDeploymentSettingsFn(proxy, context),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.ANTHROPIC_MESSAGES),
                 new EnhanceDeploymentRequestFn(proxy, context),
                 new CollectRequestApplicationFilesFn(proxy, context),
                 new CollectDeploymentsFn(proxy, context));

--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
@@ -2,18 +2,25 @@ package com.epam.aidial.core.server.function.enhancement;
 
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.Interceptor;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.function.BaseRequestFunction;
 import com.epam.aidial.core.server.function.request.RequestObject;
+import io.vertx.core.MultiMap;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
 
 @Slf4j
 public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<RequestObject> {
 
-    public ApplyDefaultDeploymentSettingsFn(Proxy proxy, ProxyContext context) {
+    private final InterfaceType interfaceType;
+
+    public ApplyDefaultDeploymentSettingsFn(Proxy proxy, ProxyContext context, InterfaceType interfaceType) {
         super(proxy, context);
+        this.interfaceType = interfaceType;
     }
 
     @Override
@@ -27,7 +34,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
         request.clearInterceptorSettings();
         Deployment deployment = context.getDeployment();
         if (deployment instanceof Interceptor) {
-            request.applyDefaults(deployment);
+            applyDefaults(request, deployment);
         }
     }
 
@@ -38,8 +45,37 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
                 String deploymentId = context.getInitialDeployment();
                 deployment = proxy.getDeploymentService().findDeployment(context, deploymentId);
             }
-            request.applyDefaults(deployment);
+            applyDefaults(request, deployment);
         }
+    }
+
+    /**
+     * Default body params and default headers land together, and neither replaces a value the request
+     * already carries. At the first interceptor that means the interceptor's own settings, applied first,
+     * take precedence over the ones of the deployment it fronts.
+     */
+    private void applyDefaults(RequestObject request, Deployment deployment) {
+        request.applyDefaults(deployment);
+        applyDefaultHeaders(deployment);
+    }
+
+    /**
+     * Adds the deployment's default headers to the inbound request under every name it does not already
+     * carry. They land on the inbound request, not on the outgoing one, so that they behave exactly as if
+     * the client had sent them: the core's own header reads see them, and they reach the deployment
+     * through the same copy - and the same exclusions - as client headers.
+     */
+    private void applyDefaultHeaders(Deployment deployment) {
+        Map<String, String> defaultHeaders = deployment.resolveDefaultHeaders(interfaceType);
+        if (defaultHeaders.isEmpty()) {
+            return;
+        }
+        MultiMap headers = context.getRequest().headers();
+        defaultHeaders.forEach((name, value) -> {
+            if (!headers.contains(name)) {
+                headers.set(name, value);
+            }
+        });
     }
 
     /**

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentPostApiTest.java
@@ -193,6 +193,73 @@ public class DeploymentPostApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testDefaultHeadersSentForChatCompletions() {
+        String answer = "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1,\"model\":\"gpt-35-turbo\","
+                + "\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}";
+        MutableObject<RecordedRequest> captured = new MutableObject<>();
+        try (TestWebServer server = new TestWebServer(4848)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                captured.setValue(request);
+                return TestWebServer.createResponse(200, answer, "Content-Type", "application/json");
+            });
+
+            Response response = send(HttpMethod.POST, "/openai/deployments/default-headers-model/chat/completions", null,
+                    "{\"model\":\"default-headers-model\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                    "content-type", "application/json");
+
+            verify(response, 200);
+            RecordedRequest upstream = captured.getValue();
+            assertEquals("cache-priority", upstream.getHeader("x-dial-cache-policy"));
+            assertEquals("foo-bar", upstream.getHeader("x-dial-custom-header"));
+            // the anthropicMessages overlay belongs to that interface only
+            assertNull(upstream.getHeader("x-dial-custom-header-2"));
+        }
+    }
+
+    @Test
+    public void testDefaultHeadersDoNotOverrideClientHeaders() {
+        String answer = "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1,\"model\":\"gpt-35-turbo\","
+                + "\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}";
+        MutableObject<RecordedRequest> captured = new MutableObject<>();
+        try (TestWebServer server = new TestWebServer(4848)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                captured.setValue(request);
+                return TestWebServer.createResponse(200, answer, "Content-Type", "application/json");
+            });
+
+            Response response = send(HttpMethod.POST, "/openai/deployments/default-headers-model/chat/completions", null,
+                    "{\"model\":\"default-headers-model\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                    "content-type", "application/json", "X-DIAL-CUSTOM-HEADER", "from-client");
+
+            verify(response, 200);
+            RecordedRequest upstream = captured.getValue();
+            // spelled in another case by the client, and still not defaulted over
+            assertEquals("from-client", upstream.getHeader("x-dial-custom-header"));
+            assertEquals("cache-priority", upstream.getHeader("x-dial-cache-policy"));
+        }
+    }
+
+    @Test
+    public void testDefaultHeadersSentForEmbeddings() {
+        String answer = "{\"object\":\"list\",\"model\":\"ada\",\"data\":[],\"usage\":{\"prompt_tokens\":5,\"total_tokens\":5}}";
+        MutableObject<RecordedRequest> captured = new MutableObject<>();
+        try (TestWebServer server = new TestWebServer(4848)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                captured.setValue(request);
+                return TestWebServer.createResponse(200, answer, "Content-Type", "application/json");
+            });
+
+            // the pre-interfaces endpoint serves embeddings too, and the deployment-level headers reach it
+            Response response = send(HttpMethod.POST, "/openai/deployments/default-headers-model/embeddings", null,
+                    "{\"input\":\"hello\"}", "content-type", "application/json");
+
+            verify(response, 200);
+            assertEquals("cache-priority", captured.getValue().getHeader("x-dial-cache-policy"));
+            assertEquals("foo-bar", captured.getValue().getHeader("x-dial-custom-header"));
+        }
+    }
+
+    @Test
     public void testEmbeddings_NotAffectedByUsagePerModelInjection() {
         String answer = "{\"object\":\"list\",\"model\":\"ada\",\"data\":[{\"object\":\"embedding\",\"index\":0,\"embedding\":[0.1,0.2]}],"
                 + "\"usage\":{\"prompt_tokens\":5,\"total_tokens\":5}}";

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -313,6 +314,62 @@ public class MessagesApiTest extends ResourceBaseTest {
 
             assertEquals(200, response.status());
             assertNotNull(captured.get().getHeader("X-DIAL-DEPLOYMENT-FEATURES"));
+        }
+    }
+
+    @Test
+    public void testInterfaceDefaultHeadersOverrideDeploymentLevelOnes() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("default-headers-model", false),
+                    "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            RecordedRequest upstream = captured.get();
+            // inherited from the deployment level ...
+            assertEquals("cache-priority", upstream.getHeader("x-dial-cache-policy"));
+            // ... overridden by the anthropicMessages overlay ...
+            assertEquals("foo-bar-2", upstream.getHeader("x-dial-custom-header"));
+            // ... and added by it
+            assertEquals("some-value", upstream.getHeader("x-dial-custom-header-2"));
+        }
+    }
+
+    @Test
+    public void testDefaultHeadersCannotOverrideTheHeadersCoreSetsItself() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            // claude-header-spoof declares a defaultHeader for every header the core sets on the way out
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-header-spoof", false),
+                    "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            RecordedRequest upstream = captured.get();
+            // the defaults were in force for this request ...
+            assertEquals("applied", upstream.getHeader("x-dial-custom-header"));
+            // ... and none of them displaced a header the core owns
+            assertEquals("http://messages-upstream/v1/messages", upstream.getHeader("X-UPSTREAM-ENDPOINT"));
+            assertEquals("modelKey", upstream.getHeader("X-UPSTREAM-KEY"));
+            assertEquals("{\"a\":1}", upstream.getHeader("X-UPSTREAM-EXTRA-DATA"));
+            assertEquals("claude-header-spoof", upstream.getHeader("X-DIAL-DEPLOYMENT-ID"));
+            assertEquals("claude-sonnet-4-5-20250929", upstream.getHeader("X-DIAL-OVERRIDE-NAME"));
+            assertNotNull(ProxyUtil.convertToObject(upstream.getHeader("X-DIAL-DEPLOYMENT-FEATURES"), FeaturesData.class));
+            // the per-request key is the only Api-Key upstream sees, and it is not the spoofed one
+            assertEquals(1, upstream.getHeaders().values("Api-Key").size());
+            assertNotEquals("spoofed-api-key", upstream.getHeader("Api-Key"));
+            // single-valued throughout: a default never lands next to the core's value
+            assertEquals(1, upstream.getHeaders().values("X-UPSTREAM-KEY").size());
+            assertEquals(1, upstream.getHeaders().values("X-DIAL-OVERRIDE-NAME").size());
         }
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.core.server.function.enhancement;
 
+import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Interceptor;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
@@ -10,9 +12,11 @@ import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -23,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,8 +40,12 @@ public class ApplyDefaultDeploymentSettingsFnTest {
     @Mock
     private ProxyContext context;
 
-    @InjectMocks
     private ApplyDefaultDeploymentSettingsFn fn;
+
+    @BeforeEach
+    public void setUp() {
+        fn = new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS);
+    }
 
     @Test
     public void testWithModelWithoutInterceptors() throws JsonProcessingException {
@@ -189,5 +199,140 @@ public class ApplyDefaultDeploymentSettingsFnTest {
 
         assertTrue(fn.apply(new ChatCompletionRequest(result)));
         assertEquals("{}", result.toString());
+    }
+
+    @Test
+    public void testDefaultHeaders_WhenModelWithoutInterceptors() throws JsonProcessingException {
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar"));
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+        when(context.getDeployment()).thenReturn(model);
+        MultiMap headers = stubRequestHeaders();
+
+        fn.apply(new ChatCompletionRequest(emptyBody()));
+
+        assertEquals("cache-priority", headers.get("x-dial-cache-policy"));
+        assertEquals("foo-bar", headers.get("x-dial-custom-header"));
+    }
+
+    @Test
+    public void testDefaultHeaders_WhenRequestAlreadyCarriesTheHeader() throws JsonProcessingException {
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority"));
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+        when(context.getDeployment()).thenReturn(model);
+        // the client spells it in another case, which must still count as present
+        MultiMap headers = stubRequestHeaders("X-DIAL-CACHE-POLICY", "availability-priority");
+
+        fn.apply(new ChatCompletionRequest(emptyBody()));
+
+        assertEquals(1, headers.size());
+        assertEquals("availability-priority", headers.get("x-dial-cache-policy"));
+    }
+
+    @Test
+    public void testDefaultHeaders_WhenInterfaceOverridesDeploymentLevel() throws JsonProcessingException {
+        DeploymentInterface anthropic = new DeploymentInterface("http://anthropic");
+        anthropic.setDefaultHeaders(Map.of("x-dial-custom-header", "foo-bar-2", "x-dial-custom-header-2", "some-value"));
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar"));
+        model.setInterfaces(Map.of(InterfaceType.ANTHROPIC_MESSAGES.getValue(), anthropic));
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+        when(context.getDeployment()).thenReturn(model);
+        MultiMap headers = stubRequestHeaders();
+
+        new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.ANTHROPIC_MESSAGES)
+                .apply(new ChatCompletionRequest(emptyBody()));
+
+        assertEquals("cache-priority", headers.get("x-dial-cache-policy"));
+        assertEquals("foo-bar-2", headers.get("x-dial-custom-header"));
+        assertEquals("some-value", headers.get("x-dial-custom-header-2"));
+    }
+
+    @Test
+    public void testDefaultHeaders_AtFirstInterceptor() throws JsonProcessingException {
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "from-model"));
+        ApiKeyData proxyApiKeyData = new ApiKeyData();
+        proxyApiKeyData.setInterceptors(List.of("interceptor1", "interceptor2"));
+        proxyApiKeyData.setInterceptorIndex(0);
+        Interceptor interceptor = new Interceptor();
+        interceptor.setName("interceptor1");
+        interceptor.setDefaultHeaders(Map.of("x-dial-custom-header", "from-interceptor"));
+        when(context.getDeployment()).thenReturn(interceptor);
+        when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
+        when(context.getInitialDeployment()).thenReturn("model");
+        DeploymentService deploymentService = mock(DeploymentService.class);
+        when(proxy.getDeploymentService()).thenReturn(deploymentService);
+        when(deploymentService.findDeployment(eq(context), eq("model"))).thenReturn(model);
+        MultiMap headers = stubRequestHeaders();
+
+        fn.apply(new ChatCompletionRequest(emptyBody()));
+
+        // the fronted deployment's headers travel down the chain from its first hop ...
+        assertEquals("cache-priority", headers.get("x-dial-cache-policy"));
+        // ... and the interceptor's own take precedence over them
+        assertEquals("from-interceptor", headers.get("x-dial-custom-header"));
+    }
+
+    @Test
+    public void testDefaultHeaders_AtSecondInterceptor() throws JsonProcessingException {
+        ApiKeyData proxyApiKeyData = new ApiKeyData();
+        proxyApiKeyData.setInterceptors(List.of("interceptor1", "interceptor2"));
+        proxyApiKeyData.setInterceptorIndex(1);
+        when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
+        Interceptor interceptor = new Interceptor();
+        interceptor.setName("interceptor2");
+        interceptor.setDefaultHeaders(Map.of("x-dial-custom-header", "from-interceptor2"));
+        when(context.getDeployment()).thenReturn(interceptor);
+        MultiMap headers = stubRequestHeaders();
+
+        fn.apply(new ChatCompletionRequest(emptyBody()));
+
+        // only its own: the deployment's landed at the first interceptor and were forwarded from there
+        assertEquals(1, headers.size());
+        assertEquals("from-interceptor2", headers.get("x-dial-custom-header"));
+    }
+
+    @Test
+    public void testDefaultHeaders_WhenDeploymentIsCalledAfterInterceptors() throws JsonProcessingException {
+        Model model = new Model();
+        model.setName("model");
+        model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority"));
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setInterceptors(List.of("interceptor1"));
+        apiKeyData.setInterceptorIndex(0);
+        apiKeyData.setPerRequestKey("perRequestKey");
+        apiKeyData.setInitialDeployment("model");
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getProxyApiKeyData()).thenReturn(new ApiKeyData());
+        when(context.getInitialDeployment()).thenReturn("model");
+        when(context.getDeployment()).thenReturn(model);
+
+        fn.apply(new ChatCompletionRequest(emptyBody()));
+
+        // nothing to re-apply on the last hop, so the inbound request is not even touched
+        verify(context, never()).getRequest();
+    }
+
+    private static ObjectNode emptyBody() throws JsonProcessingException {
+        return (ObjectNode) ProxyUtil.MAPPER.readTree("{}");
+    }
+
+    private MultiMap stubRequestHeaders(String... headers) {
+        MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap();
+        for (int i = 0; i < headers.length; i += 2) {
+            requestHeaders.set(headers[i], headers[i + 1]);
+        }
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.headers()).thenReturn(requestHeaders);
+        when(context.getRequest()).thenReturn(request);
+        return requestHeaders;
     }
 }

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -182,6 +182,23 @@
         {"endpoint": "http://chat/completions", "responsesEndpoint": "http://responses", "key": "modelKey", "id": "responses-upstream"}
       ]
     },
+    "default-headers-model": {
+      "type": "chat",
+      "endpoint" : "http://localhost:4848/chat/completions",
+      "defaultHeaders": {
+        "x-dial-cache-policy": "cache-priority",
+        "x-dial-custom-header": "foo-bar"
+      },
+      "interfaces": {
+        "anthropicMessages": {
+          "base_url": "http://localhost:4848",
+          "defaultHeaders": {
+            "x-dial-custom-header": "foo-bar-2",
+            "x-dial-custom-header-2": "some-value"
+          }
+        }
+      }
+    },
     "model-iface-only": {
       "type": "chat",
       "displayName": "Model configured via interfaces only",
@@ -239,6 +256,24 @@
       "type": "chat",
       "overrideName": "claude-sonnet-4-5-20250929",
       "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+    },
+    "claude-header-spoof": {
+      "type": "chat",
+      "overrideName": "claude-sonnet-4-5-20250929",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
+      "defaultHeaders": {
+        "X-UPSTREAM-ENDPOINT": "http://spoofed",
+        "X-UPSTREAM-KEY": "spoofed-key",
+        "X-UPSTREAM-EXTRA-DATA": "spoofed-extra-data",
+        "Api-Key": "spoofed-api-key",
+        "X-DIAL-DEPLOYMENT-ID": "spoofed-deployment",
+        "X-DIAL-OVERRIDE-NAME": "spoofed-override",
+        "X-DIAL-DEPLOYMENT-FEATURES": "spoofed-features",
+        "x-dial-custom-header": "applied"
+      },
+      "upstreams": [
+        {"endpoint": "http://messages-upstream/v1/messages", "key": "modelKey", "extraData": {"a": 1}, "id": "messages-upstream"}
+      ]
     },
     "claude-no-iface": {
       "type": "chat",
@@ -337,6 +372,7 @@
         "calculator": {},
         "app": {},
         "gpt-3-turbo": {"minute": "100", "day": "1000"},
+        "default-headers-model": {"minute": "100000", "day": "10000000"},
         "claude-ns": {"minute": "100000", "day": "10000000"},
         "claude-stream": {"minute": "100000", "day": "10000000"},
         "claude-count": {"minute": "100000", "day": "10000000"},
@@ -344,6 +380,7 @@
         "claude-limited": {"minute": "10", "day": "10"},
         "claude-upstream": {"minute": "100000", "day": "10000000"},
         "claude-override": {"minute": "100000", "day": "10000000"},
+        "claude-header-spoof": {"minute": "100000", "day": "10000000"},
         "claude-no-iface": {"minute": "100000", "day": "10000000"},
         "claude-to-chat-completions": {"minute": "100000", "day": "10000000"},
         "claude-to-responses": {"minute": "100000", "day": "10000000"}


### PR DESCRIPTION
### Applicable issues

- 

### Description of changes

Adds `defaultHeaders` to models, applications and interceptors — the header counterpart of `defaults`.

- Deployment-level `defaultHeaders` apply to every interface the deployment serves; `interfaces.<type>.defaultHeaders` is laid over them for that interface only (overrides a repeated name, adds new ones, keeps the rest). Names are matched case-insensitively.
- A header the request already carries is never replaced — a client-sent value always wins.
- The headers are materialized on the inbound request, so DIAL Core reads them as if the client had sent them (`X-DIAL-CACHE-POLICY` set this way drives upstream cache pinning, not just what the adapter receives) and they reach the deployment under the same copy rules and exclusions as client headers.
- Headers DIAL Core sets itself always win: they are written after the client headers are copied, with `putHeader`.
- Applied once per request at the head of the chain — with interceptors configured that is the hop to the first interceptor, from where they travel down the chain. An interceptor's own `defaultHeaders` are applied on the hop that calls it and take precedence.

Covers `chat/completions`, `completions`, `embeddings`, `POST /openai/v1/responses`, `POST /anthropic/v1/messages` (+ `count_tokens`) and both interceptor controllers. Documented in `docs/dynamic-settings/{models,applications,interceptors}.md`; `docs/open_api_core.yaml` regenerated.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (`./gradlew test` green, checkstyle clean, OpenAPI spec regenerated)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.