### PR TITLE
feat: support interfaces and baseUrl in upstream config

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/InterfaceType.java
+++ b/config/src/main/java/com/epam/aidial/core/config/InterfaceType.java
@@ -14,17 +14,40 @@ import java.util.List;
 public enum InterfaceType {
 
     @JsonAlias({"openai_chat_completions"})
-    OPENAI_CHAT_COMPLETIONS("openaiChatCompletions", List.of("prefix.body.tools", "prefix.body.messages")),
+    OPENAI_CHAT_COMPLETIONS(
+            "openaiChatCompletions",
+            "/v1/chat/completions",
+            List.of("prefix.body.tools", "prefix.body.messages")
+    ),
     // an embeddings request carries no prompt prefix to cache, so it contributes no cache keys
     @JsonAlias({"openai_embeddings"})
-    OPENAI_EMBEDDINGS("openaiEmbeddings", List.of()),
+    OPENAI_EMBEDDINGS(
+            "openaiEmbeddings",
+            "/v1/embeddings",
+            List.of()
+    ),
     @JsonAlias({"openai_responses"})
-    OPENAI_RESPONSES("openaiResponses", List.of("prefix.body.tools", "prefix.body.instructions", "prefix.body.input")),
+    OPENAI_RESPONSES(
+            "openaiResponses",
+            "/v1/responses",
+            List.of("prefix.body.tools", "prefix.body.instructions", "prefix.body.input")
+    ),
     @JsonAlias({"anthropic_messages"})
-    ANTHROPIC_MESSAGES("anthropicMessages", List.of("prefix.body.tools", "prefix.body.system", "prefix.body.messages"));
+    ANTHROPIC_MESSAGES(
+            "anthropicMessages",
+            "/v1/messages",
+            List.of("prefix.body.tools", "prefix.body.system", "prefix.body.messages")
+    );
 
     @JsonValue
     private final String value;
+
+    /**
+     * The path this interface's own API spec serves it at, with no DIAL ingress keyword
+     * ({@code /openai}, {@code /anthropic}) in front of it. Appended to {@code Upstream#baseUrl}
+     * to address a provider that hosts the API where its spec says it should be.
+     */
+    private final String apiPath;
 
     /**
      * The node order used to build upstream cache keys, hardcoded per the wire format of this
@@ -33,8 +56,9 @@ public enum InterfaceType {
      */
     private final List<String> fieldsHashingOrder;
 
-    InterfaceType(String value, List<String> fieldsHashingOrder) {
+    InterfaceType(String value, String apiPath, List<String> fieldsHashingOrder) {
         this.value = value;
+        this.apiPath = apiPath;
         this.fieldsHashingOrder = fieldsHashingOrder;
     }
 

--- a/config/src/main/java/com/epam/aidial/core/config/Upstream.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Upstream.java
@@ -11,6 +11,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.util.Map;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -43,4 +45,18 @@ public class Upstream {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonAlias({"id", "dial:id"})
     private String id;
+    /**
+     * Root url that every {@link #interfaces} entry declaring no {@code endpoint} of its own hangs
+     * {@link InterfaceType#getApiPath()} off. Unlike a deployment's {@code base_url}, the ingress
+     * path plays no part — an upstream is addressed where its own API spec says it lives.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonAlias({"baseUrl", "base_url", "dial:baseUrl"})
+    private String baseUrl;
+    /**
+     * Provider urls keyed by interface-type value. Peer of endpoint/responsesEndpoint.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonAlias({"interfaces", "dial:interfaces"})
+    private Map<String, UpstreamInterface> interfaces = Map.of();
 }

--- a/config/src/main/java/com/epam/aidial/core/config/UpstreamInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/UpstreamInterface.java
@@ -1,0 +1,52 @@
+package com.epam.aidial.core.config;
+
+import com.epam.aidial.core.config.annotation.EncryptedField;
+import com.epam.aidial.core.config.databind.JsonToStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Per-interface configuration for an {@link Upstream}. The peer of {@link DeploymentInterface}, but
+ * carrying a complete {@code endpoint} rather than a base url: an upstream is the provider itself,
+ * not an adapter Core routes an ingress path into.
+ *
+ * <p>Every field overrides its {@link Upstream}-level namesake for this interface only; a field left
+ * unset here falls back to the upstream's value.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpstreamInterface {
+
+    /**
+     * The complete provider url for this interface. When absent, it is formed from
+     * {@link Upstream#getBaseUrl()} and {@link InterfaceType#getApiPath()}.
+     */
+    @JsonAlias({"endpoint", "dial:endpoint"})
+    private String endpoint;
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @EncryptedField
+    @JsonAlias({"key", "dial:key"})
+    private String key;
+    @JsonDeserialize(using = JsonToStringDeserializer.class)
+    @JsonAlias({"extraData", "dial:extraData"})
+    private String extraData;
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @EncryptedField
+    @JsonDeserialize(using = JsonToStringDeserializer.class)
+    @JsonAlias({"secretExtraData", "dial:secretExtraData"})
+    private String secretExtraData;
+
+    public UpstreamInterface(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/UpstreamTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/UpstreamTest.java
@@ -1,0 +1,140 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.epam.aidial.core.config.InterfaceType.ANTHROPIC_MESSAGES;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * State and serialization of an upstream. Which url, key and extra data serve an interface type
+ * belongs to {@code UpstreamInterfaceUtil} and is covered by its own test.
+ */
+public class UpstreamTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void interfacesParseWithAndWithoutTheirOwnEndpoint() throws Exception {
+        String json = """
+                {
+                    "baseUrl": "https://api.fireworks.ai/inference",
+                    "key": "modelKey",
+                    "interfaces": {
+                        "openaiChatCompletions": {},
+                        "openaiResponses": {},
+                        "anthropicMessages": {"endpoint": "https://api.fireworks.ai/inference/something-else/v1/messages"}
+                    }
+                }
+                """;
+        Upstream upstream = MAPPER.readValue(json, Upstream.class);
+
+        assertEquals("https://api.fireworks.ai/inference", upstream.getBaseUrl());
+        assertEquals(3, upstream.getInterfaces().size());
+        assertNull(upstream.getInterfaces().get(OPENAI_CHAT_COMPLETIONS.getValue()).getEndpoint());
+        assertNull(upstream.getInterfaces().get(OPENAI_RESPONSES.getValue()).getEndpoint());
+        assertEquals("https://api.fireworks.ai/inference/something-else/v1/messages",
+                upstream.getInterfaces().get(ANTHROPIC_MESSAGES.getValue()).getEndpoint());
+    }
+
+    @Test
+    void baseUrlAcceptsTheSnakeCaseAlias() throws Exception {
+        Upstream upstream = MAPPER.readValue("{\"base_url\": \"https://provider\"}", Upstream.class);
+
+        assertEquals("https://provider", upstream.getBaseUrl());
+    }
+
+    @Test
+    void unknownInterfaceKeysAreTolerated() throws Exception {
+        String json = """
+                {
+                    "endpoint": "http://host/v1/chat/completions",
+                    "interfaces": {"geminiGenerateContent": {"endpoint": "http://gemini"}}
+                }
+                """;
+        Upstream upstream = MAPPER.readValue(json, Upstream.class);
+
+        // unknown keys parse and are kept, they simply never match a known interface type
+        assertEquals("http://gemini", upstream.getInterfaces().get("geminiGenerateContent").getEndpoint());
+        assertEquals("http://host/v1/chat/completions", upstream.getEndpoint());
+    }
+
+    @Test
+    void interfaceOverridesParse() throws Exception {
+        String json = """
+                {
+                    "key": "sk-proj-shared",
+                    "extraData": {"region": "us-east-1"},
+                    "baseUrl": "https://api.fireworks.ai/inference",
+                    "interfaces": {
+                        "openaiChatCompletions": {},
+                        "anthropicMessages": {
+                            "key": "foo-bar-another",
+                            "secretExtraData": {"region": "us-east-3"}
+                        }
+                    }
+                }
+                """;
+        Upstream upstream = MAPPER.readValue(json, Upstream.class);
+
+        UpstreamInterface anthropic = upstream.getInterfaces().get(ANTHROPIC_MESSAGES.getValue());
+        assertEquals("foo-bar-another", anthropic.getKey());
+        // objects are captured verbatim as strings, matching the upstream-level fields
+        assertEquals("{\"region\":\"us-east-3\"}", anthropic.getSecretExtraData());
+        assertNull(anthropic.getExtraData());
+        assertNull(upstream.getInterfaces().get(OPENAI_CHAT_COMPLETIONS.getValue()).getKey());
+    }
+
+    @Test
+    void interfaceSecretsAreWriteOnly() throws Exception {
+        UpstreamInterface anthropic = new UpstreamInterface("https://provider/v1/messages");
+        anthropic.setKey("super-secret");
+        anthropic.setSecretExtraData("{\"token\":\"x\"}");
+        anthropic.setExtraData("{\"region\":\"us\"}");
+        Upstream upstream = new Upstream();
+        upstream.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        String serialized = MAPPER.writeValueAsString(upstream);
+
+        // the same guarantee the upstream-level key/secretExtraData carry: never serialized back out
+        assertFalse(serialized.contains("super-secret"), serialized);
+        assertFalse(serialized.contains("token"), serialized);
+        assertTrue(serialized.contains("us"), serialized);
+    }
+
+    @Test
+    void roundTripLegacy() throws Exception {
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("http://host/v1/chat/completions");
+        upstream.setResponsesEndpoint("http://host/v1/responses");
+
+        Upstream restored = MAPPER.readValue(MAPPER.writeValueAsString(upstream), Upstream.class);
+
+        assertEquals("http://host/v1/chat/completions", restored.getEndpoint());
+        assertEquals("http://host/v1/responses", restored.getResponsesEndpoint());
+        assertNull(restored.getBaseUrl());
+        assertTrue(restored.getInterfaces().isEmpty());
+    }
+
+    @Test
+    void roundTripInterfaces() throws Exception {
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("http://host/v1/chat/completions");
+        upstream.setBaseUrl("https://provider");
+        upstream.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface()));
+
+        Upstream restored = MAPPER.readValue(MAPPER.writeValueAsString(upstream), Upstream.class);
+
+        // legacy field is not stripped, interfaces survive
+        assertEquals("http://host/v1/chat/completions", restored.getEndpoint());
+        assertEquals("https://provider", restored.getBaseUrl());
+        assertTrue(restored.getInterfaces().containsKey(ANTHROPIC_MESSAGES.getValue()));
+    }
+}

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -329,13 +329,79 @@ Some models adapters expose specialized HTTP endpoints for tokenization, rate es
 }
 ```
 
+#### models.<model_name>.upstreams.interfaces
+
+A typed alternative to the flat `endpoint`/`responsesEndpoint` fields, declaring the upstream backend URL per LLM API rather than per field. Both shapes are first-class and fully supported — choose whichever you prefer per upstream. Use `interfaces` when a provider serves several APIs for the same model (for example, Fireworks exposes both the OpenAI and the Anthropic API), so that one model deployment can front all of them instead of one deployment per API.
+
+The interface types are the same as on the [model level](#modelsmodel_nameinterfaces) — `openaiChatCompletions`, `openaiEmbeddings`, `openaiResponses`, `anthropicMessages` — but each value carries a complete `endpoint` rather than a `base_url`, because an upstream is the provider itself and no ingress path is routed into it.
+
+Each value is an object with the following fields, every one of which overrides its upstream-level namesake for that interface alone:
+
+* `endpoint`: The complete upstream backend URL for this interface. Optional when the upstream declares a `baseUrl`.
+* `key`: API key, token, or credential for this interface. Falls back to the upstream's `key`.
+* `extraData`: Additional metadata for this interface. Falls back to the upstream's `extraData`.
+* `secretExtraData`: Secret additional metadata for this interface. Falls back to the upstream's `secretExtraData`.
+
+Each field falls back independently, so an interface overriding only `key` still inherits `extraData`. `extraData` and `secretExtraData` are then merged into the single `X-UPSTREAM-EXTRA-DATA` header exactly as at the upstream level, with `secretExtraData` winning on shared keys. Declaring the same key in *both* halves of one level is rejected as ambiguous, but an interface's half overriding the upstream's is the point of the feature and is allowed.
+
+An entry with no `endpoint` is completed from the upstream's `baseUrl` plus the path the interface's own API spec serves it at, ignoring the `/openai` and `/anthropic` ingress keywords:
+
+| Interface type          | Path appended to `baseUrl` |
+|-------------------------|----------------------------|
+| `openaiChatCompletions` | `/v1/chat/completions`     |
+| `openaiEmbeddings`      | `/v1/embeddings`           |
+| `openaiResponses`       | `/v1/responses`            |
+| `anthropicMessages`     | `/v1/messages`             |
+
+This is the one difference from `interfaces.<interface_type>.base_url` on the model level, which is instead concatenated with the ingress path the request reached DIAL Core on (`/openai/v1/responses`, `/openai/deployments/{name}/chat/completions`, `/anthropic/v1/messages`, ...).
+
+`baseUrl` applies only to the interface types the upstream declares: `interfaces` is a whitelist, not a default. An interface type absent from the map falls back to the legacy field serving it — `responsesEndpoint` for `openaiResponses`, `endpoint` for every other type — so upstreams configured before the split keep working unchanged.
+
+Two rules are enforced on load, and a model violating either is rejected:
+
+* Every declared interface must resolve to a URL — its own `endpoint`, or the upstream's `baseUrl`.
+* The upstream must declare an `id`. Without `interfaces`, an upstream falls back to its `endpoint` as its identifier for `X-UPSTREAM-ID` routing and prompt-cache pinning; this shape has no `endpoint`, so the `id` has to be explicit.
+
+**Example**
+
+```json
+"models": {
+        "openai-gpt-5.4-mini": {
+            "overrideName": "gpt-5.4-mini",
+            "type": "chat",
+            "upstreams": [
+                {
+                    "id": "fireworks",
+                    "key": "modelKey1",
+                    "extraData": {"region": "us-east-1"},
+                    "baseUrl": "https://api.fireworks.ai/inference",
+                    "interfaces": {
+                        "openaiChatCompletions": {},
+                        "openaiResponses": {},
+                        "anthropicMessages": {
+                            "endpoint": "https://api.fireworks.ai/inference/something-else/v1/messages",
+                            "key": "anthropicKey1"
+                        }
+                    }
+                }
+            ]
+        }
+}
+```
+
+Here `openaiChatCompletions` resolves to `https://api.fireworks.ai/inference/v1/chat/completions`, `openaiResponses` to `https://api.fireworks.ai/inference/v1/responses`, and `anthropicMessages` to the explicit URL, which wins over `baseUrl`. All three send `{"region": "us-east-1"}` as extra data, inherited from the upstream; the first two authenticate with `modelKey1` and `anthropicMessages` with `anthropicKey1`.
+
+The legacy fields coexist with the map, yielding only for the types it declares. Given an upstream that sets `endpoint`, `responsesEndpoint` and `interfaces: {"openaiChatCompletions": {}, "anthropicMessages": {}}`, chat completions and Anthropic Messages are served by the map (from `baseUrl`), while the Responses API — which the map does not declare — still uses `responsesEndpoint`.
+
 #### models.<model_name>.upstreams
 
 Upstreams configurations. Use to configure [load balancing](https://docs.dialx.ai/platform/core/load-balancer).
 
-* `endpoint`: The upstream backend URL for the chat completions API. Passed to the model adapter in the `X-UPSTREAM-ENDPOINT` header.
+* `endpoint`: The upstream backend URL for the chat completions API. Passed to the model adapter in the `X-UPSTREAM-ENDPOINT` header. It also backs the embeddings and Anthropic Messages APIs — prefer `interfaces` to configure those explicitly.
 * `responsesEndpoint`: The upstream backend URL for the Responses API. Passed to the model adapter in the `X-UPSTREAM-ENDPOINT` header when routing Responses API requests.
-* `id`: A stable identifier for this upstream. Clients can set the `X-UPSTREAM-ID` request header to this value to pin a request to a specific upstream (supported in chat completions and Responses API). When the Responses API is enabled (via the model-level `responsesEndpoint`), `id` is required — it is used to route Responses API follow-up requests (retrieve, cancel, delete) back to the same upstream that handled the initial request.
+* `interfaces`: A typed alternative to `endpoint`/`responsesEndpoint`, declaring one upstream backend URL per LLM API. Refer to [models.<model_name>.upstreams.interfaces](#modelsmodel_nameupstreamsinterfaces).
+* `baseUrl`: The provider root that completes every `interfaces` entry declaring no `endpoint` of its own. Refer to [models.<model_name>.upstreams.interfaces](#modelsmodel_nameupstreamsinterfaces).
+* `id`: A stable identifier for this upstream. Clients can set the `X-UPSTREAM-ID` request header to this value to pin a request to a specific upstream (supported in chat completions and Responses API). When the Responses API is enabled (via the model-level `responsesEndpoint`), `id` is required — it is used to route Responses API follow-up requests (retrieve, cancel, delete) back to the same upstream that handled the initial request. `id` is also required on any upstream declaring `interfaces`, because that shape has no `endpoint` to fall back on as an identifier.
 * `key`: API key, token, or credential passed to the upstream.
 * `weight`: Weight for upstream endpoint; positive number represents an endpoint capacity, zero or negative disables this endpoint from routing. Higher = more traffic share. Default value: 1.
 * `tier`: Specifies tier group for the endpoint. Only positive numbers allowed. All requests will be routed to the endpoints with the highest tier (the lowest tier value), other endpoints (with lower tier/higher tier value) may be used only if the highest tier endpoints are unavailable. Default value: 0 - highest tier. Refer to [load balancing](https://docs.dialx.ai/platform/core/load-balancer) to learn more.

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -15789,6 +15789,10 @@ components:
       type: object
       additionalProperties:
         $ref: "#/components/schemas/ToolSet"
+    MapStringUpstreamInterface:
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/UpstreamInterface"
     McpMcpApps:
       type: object
       properties:
@@ -17146,6 +17150,23 @@ components:
           type: integer
         weight:
           type: integer
+        baseUrl:
+          type: string
+        interfaces:
+          $ref: "#/components/schemas/MapStringUpstreamInterface"
+    UpstreamInterface:
+      type: object
+      properties:
+        endpoint:
+          type: string
+        extraData:
+          type: string
+        key:
+          type: string
+          writeOnly: true
+        secretExtraData:
+          type: string
+          writeOnly: true
     UserInfoResponse:
       type: object
       properties:

--- a/sample/aidial.config.json
+++ b/sample/aidial.config.json
@@ -200,6 +200,35 @@
                 }
             },
             "userRoles": ["role3"]
+        },
+        "gpt-5.4-mini-multi-api-upstream": {
+            "type": "chat",
+            "overrideName": "gpt-5.4-mini",
+            "displayName": "GPT-5.4 mini (multi-API upstream)",
+            "interfaces": {
+                "openaiChatCompletions": {
+                    "base_url": "http://localhost:7005"
+                },
+                "anthropicMessages": {
+                    "base_url": "http://localhost:7005"
+                }
+            },
+            "upstreams": [
+                {
+                    "id": "fireworks",
+                    "key": "modelKey5",
+                    "extraData": {"region": "us-east-1"},
+                    "baseUrl": "https://api.fireworks.ai/inference",
+                    "interfaces": {
+                        "openaiChatCompletions": {},
+                        "anthropicMessages": {
+                            "endpoint": "https://api.fireworks.ai/inference/something-else/v1/messages",
+                            "key": "modelKey6"
+                        }
+                    }
+                }
+            ],
+            "userRoles": ["role1"]
         }
     },
     "toolsets": {

--- a/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
@@ -13,6 +13,8 @@ import com.epam.aidial.core.config.Role;
 import com.epam.aidial.core.config.RoleBasedEntity;
 import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
 import com.epam.aidial.core.credentials.service.ResourceAuthSettingsChangeMode;
 import com.epam.aidial.core.credentials.validation.AuthSettingsValidator;
 import com.epam.aidial.core.credentials.validation.AuthSettingsValidatorFactory;
@@ -132,6 +134,7 @@ public final class ConfigPostProcessor {
         model.setName(mapKey);
         List<ValidationWarning> warnings = new ArrayList<>();
         validatePricing(model, warnings);
+        validateUpstreamInterfaces(model, warnings);
         if (onSkip != null) {
             validateCrossReferences(model, config, warnings);
         }
@@ -228,6 +231,7 @@ public final class ConfigPostProcessor {
             log.debug("Loading {}", model);
             List<ValidationWarning> warnings = new ArrayList<>();
             validatePricing(model, warnings);
+            validateUpstreamInterfaces(model, warnings);
             // Cross-ref check is skip-mode-only — file-loaded abort-mode path (onSkip == null)
             // preserves design 02 §4.2's allowance for pre-existing file-side inconsistency.
             // Strict-mode 422 is enforced at the write controller, not here. Pricing validation
@@ -283,6 +287,40 @@ public final class ConfigPostProcessor {
         if (hasCacheRate && !"token".equals(pricing.getUnit())) {
             warnings.add(new ValidationWarning("pricing",
                     "cacheRead/cacheWrite pricing requires pricing.unit = \"token\""));
+        }
+    }
+
+    /**
+     * Validates an upstream declaring {@code interfaces}. Every entry must resolve to a provider url —
+     * an entry with no {@code endpoint} of its own needs the upstream's {@code baseUrl} to complete it,
+     * or it declares an interface the upstream cannot serve and silently sends no
+     * {@code X-UPSTREAM-ENDPOINT}. The upstream must also carry an {@code id}: {@code endpoint} is what
+     * identifies an upstream to {@code X-UPSTREAM-ID} routing and to prompt-cache pinning, and this
+     * shape does not have one.
+     */
+    public static void validateUpstreamInterfaces(Model model, List<ValidationWarning> warnings) {
+        List<Upstream> upstreams = model.getUpstreams();
+        for (int i = 0; i < upstreams.size(); i++) {
+            Upstream upstream = upstreams.get(i);
+            Map<String, UpstreamInterface> interfaces = upstream.getInterfaces();
+            if (interfaces == null || interfaces.isEmpty()) {
+                continue;
+            }
+            if (upstream.getId() == null || upstream.getId().isBlank()) {
+                warnings.add(new ValidationWarning("upstreams[" + i + "].id",
+                        "An upstream declaring interfaces requires an id"));
+            }
+            if (upstream.getBaseUrl() != null) {
+                continue;
+            }
+            for (Map.Entry<String, UpstreamInterface> entry : interfaces.entrySet()) {
+                if (entry.getValue().getEndpoint() == null) {
+                    warnings.add(new ValidationWarning("upstreams[" + i + "].interfaces." + entry.getKey(),
+                            "Interface '" + entry.getKey() + "' declares no endpoint and the upstream "
+                                    + "declares no baseUrl")
+                    );
+                }
+            }
         }
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/config/SecretFieldProcessor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/SecretFieldProcessor.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -94,6 +95,14 @@ public class SecretFieldProcessor {
                     }
                 }
             }
+            Class<?> valueType = valueClassWithEncryptedField(field);
+            if (valueType != null && target.get(name) instanceof ObjectNode entries) {
+                for (JsonNode entry : entries) {
+                    if (entry instanceof ObjectNode entryObj) {
+                        applyStrip(entryObj, valueType);
+                    }
+                }
+            }
         }
     }
 
@@ -134,6 +143,24 @@ public class SecretFieldProcessor {
                 if (targetArr instanceof ArrayNode targets && sourceArr instanceof ArrayNode sources) {
                     mergeArray(targets, sources, nestedType);
                 }
+            }
+            Class<?> valueType = valueClassWithEncryptedField(field);
+            if (valueType != null
+                    && target.get(name) instanceof ObjectNode targetEntries
+                    && source.get(name) instanceof ObjectNode sourceEntries) {
+                mergeMap(targetEntries, sourceEntries, valueType);
+            }
+        }
+    }
+
+    // A map keys itself, so entries pair by name rather than by the arrays' endpoint/index matching.
+    private void mergeMap(ObjectNode targets, ObjectNode sources, Class<?> valueType) {
+        Iterator<String> names = targets.fieldNames();
+        while (names.hasNext()) {
+            String name = names.next();
+            if (targets.get(name) instanceof ObjectNode targetEntry
+                    && sources.get(name) instanceof ObjectNode sourceEntry) {
+                mergeInto(targetEntry, sourceEntry, valueType);
             }
         }
     }
@@ -336,6 +363,29 @@ public class SecretFieldProcessor {
         }
         if (args[0] instanceof Class<?> elementClass && classHasEncryptedField(elementClass)) {
             return elementClass;
+        }
+        return null;
+    }
+
+    /**
+     * The value type of a {@code Map}-valued field carrying encrypted members, e.g.
+     * {@code Upstream.interfaces}. Its JSON shape is an object keyed by name, so the JsonNode-level
+     * passes have to descend into it the same way they descend into arrays.
+     */
+    private static Class<?> valueClassWithEncryptedField(Field field) {
+        java.lang.reflect.Type generic = field.getGenericType();
+        if (!(generic instanceof java.lang.reflect.ParameterizedType pt)) {
+            return null;
+        }
+        if (!Map.class.isAssignableFrom(field.getType())) {
+            return null;
+        }
+        java.lang.reflect.Type[] args = pt.getActualTypeArguments();
+        if (args.length != 2) {
+            return null;
+        }
+        if (args[1] instanceof Class<?> valueClass && classHasEncryptedField(valueClass)) {
+            return valueClass;
         }
         return null;
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -23,6 +23,7 @@ import com.epam.aidial.core.server.util.DeploymentEndpointUtil;
 import com.epam.aidial.core.server.util.JsonUtil;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.UpstreamExtraDataMerger;
+import com.epam.aidial.core.server.util.UpstreamInterfaceUtil;
 import com.epam.aidial.core.server.util.UsagePerModelInjector;
 import com.epam.aidial.core.server.vertx.stream.BufferingReadStream;
 import com.epam.aidial.core.storage.http.HttpException;
@@ -302,8 +303,7 @@ public class BaseDeploymentPostController {
         );
     }
 
-    protected Future<HttpClientResponse> sendProxyRequest(
-            HttpClientRequest proxyRequest, Function<Upstream, String> upstreamSelector) {
+    protected Future<HttpClientResponse> sendProxyRequest(HttpClientRequest proxyRequest, InterfaceType type) {
         log.info("Connected to origin. Deployment: {}. Address: {}",
                 context.getDeployment().getName(),
                 proxyRequest.connection().remoteAddress());
@@ -325,9 +325,9 @@ public class BaseDeploymentPostController {
 
         if (context.getDeployment() instanceof Model model && !model.getUpstreams().isEmpty()) {
             Upstream upstream = Objects.requireNonNull(context.getUpstreamRoute().get());
-            proxyRequest.putHeader(Proxy.HEADER_UPSTREAM_ENDPOINT, upstreamSelector.apply(upstream))
-                    .putHeader(Proxy.HEADER_UPSTREAM_KEY, upstream.getKey())
-                    .putHeader(Proxy.HEADER_UPSTREAM_EXTRA_DATA, UpstreamExtraDataMerger.merge(upstream))
+            proxyRequest.putHeader(Proxy.HEADER_UPSTREAM_ENDPOINT, UpstreamInterfaceUtil.resolveEndpoint(upstream, type))
+                    .putHeader(Proxy.HEADER_UPSTREAM_KEY, UpstreamInterfaceUtil.resolveKey(upstream, type))
+                    .putHeader(Proxy.HEADER_UPSTREAM_EXTRA_DATA, UpstreamExtraDataMerger.merge(upstream, type))
                     .putHeader(Proxy.HEADER_CACHE_BREAKPOINT_PATH, context.getUpstreamRoute().getBreakpointPath())
                     .putHeader(Proxy.HEADER_CACHE_EXTRA_METADATA, context.getUpstreamRoute().getExtraMetadata());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -360,7 +360,7 @@ public class DeploymentPostController extends BaseDeploymentPostController {
         context.setProxyRequest(proxyRequest);
         context.setProxyConnectTimestamp(System.currentTimeMillis());
 
-        sendProxyRequest(proxyRequest, Upstream::getEndpoint)
+        sendProxyRequest(proxyRequest, requestedInterface())
                 .onSuccess(this::handleProxyResponse)
                 .onFailure(this::handleProxyResponseError);
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ResponsesController.java
@@ -273,7 +273,7 @@ public class ResponsesController extends BaseDeploymentPostController {
         context.setProxyRequest(proxyRequest);
         context.setProxyConnectTimestamp(System.currentTimeMillis());
 
-        sendProxyRequest(proxyRequest, Upstream::getResponsesEndpoint)
+        sendProxyRequest(proxyRequest, InterfaceType.OPENAI_RESPONSES)
                 .onSuccess(this::handleProxyResponse)
                 .onFailure(this::handleProxyResponseError);
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/MessagesBaseController.java
@@ -193,7 +193,7 @@ abstract class MessagesBaseController extends BaseDeploymentPostController {
         context.setProxyRequest(proxyRequest);
         context.setProxyConnectTimestamp(System.currentTimeMillis());
 
-        sendProxyRequest(proxyRequest, Upstream::getEndpoint)
+        sendProxyRequest(proxyRequest, InterfaceType.ANTHROPIC_MESSAGES)
                 .onSuccess(this::handleProxyResponse)
                 .onFailure(this::handleProxyResponseError);
     }

--- a/server/src/main/java/com/epam/aidial/core/server/service/ResponsesApiClient.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ResponsesApiClient.java
@@ -1,10 +1,12 @@
 package com.epam.aidial.core.server.service;
 
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.token.TokenUsage;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.UpstreamExtraDataMerger;
+import com.epam.aidial.core.server.util.UpstreamInterfaceUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.Future;
@@ -32,10 +34,14 @@ public class ResponsesApiClient {
                 .setIdleTimeout(clientOptions.getIdleTimeout());
         return httpClient.request(options)
                 .compose(request -> request
-                        .putHeader(Proxy.HEADER_UPSTREAM_KEY, upstream.getKey())
-                        .putHeader(Proxy.HEADER_UPSTREAM_ENDPOINT, upstream.getResponsesEndpoint())
-                        .putHeader(Proxy.HEADER_UPSTREAM_EXTRA_DATA, UpstreamExtraDataMerger.merge(upstream))
-                        .send());
+                        .putHeader(Proxy.HEADER_UPSTREAM_KEY,
+                                UpstreamInterfaceUtil.resolveKey(upstream, InterfaceType.OPENAI_RESPONSES))
+                        .putHeader(Proxy.HEADER_UPSTREAM_ENDPOINT,
+                                UpstreamInterfaceUtil.resolveEndpoint(upstream, InterfaceType.OPENAI_RESPONSES))
+                        .putHeader(Proxy.HEADER_UPSTREAM_EXTRA_DATA,
+                                UpstreamExtraDataMerger.merge(upstream, InterfaceType.OPENAI_RESPONSES))
+                        .send()
+                );
     }
 
     private static boolean isTerminal(String status) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/UpstreamCacheService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/UpstreamCacheService.java
@@ -125,7 +125,10 @@ public class UpstreamCacheService {
     public void updateEntry(String hash, CachedUpstreamEntry entry, Model model, String expireAtStr) {
         String key = getEntryKey(model.getName(), hash);
         Map<String, String> fields = new HashMap<>();
-        fields.put(UPSTREAM_ENDPOINT_FIELD, entry.endpoint());
+        // an upstream configured through interfaces carries no legacy endpoint, and Redis rejects a null value
+        if (entry.endpoint() != null) {
+            fields.put(UPSTREAM_ENDPOINT_FIELD, entry.endpoint());
+        }
         fields.put(PREFIX_PATH_FIELD, entry.prefixPath());
         if (entry.id() != null) {
             fields.put(UPSTREAM_ID_FIELD, entry.id());

--- a/server/src/main/java/com/epam/aidial/core/server/service/config/ConfigApplyService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/config/ConfigApplyService.java
@@ -249,6 +249,7 @@ public class ConfigApplyService {
         Model model = ConfigEntityCodec.treeToEntity(entry.spec(), Model.class);
         List<ValidationWarning> warnings = new ArrayList<>();
         ConfigPostProcessor.validatePricing(model, warnings);
+        ConfigPostProcessor.validateUpstreamInterfaces(model, warnings);
         ConfigPostProcessor.validateCrossReferences(model, scratch, warnings);
         UpstreamExtraDataMerger.validateNoOverlap(model);
         boolean invalid = !warnings.isEmpty();

--- a/server/src/main/java/com/epam/aidial/core/server/service/config/ConfigValidationService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/config/ConfigValidationService.java
@@ -59,6 +59,7 @@ public class ConfigValidationService {
                     Model model = ConfigEntityCodec.treeToEntity(entry.spec(), Model.class);
                     List<ValidationWarning> warnings = new ArrayList<>();
                     ConfigPostProcessor.validatePricing(model, warnings);
+                    ConfigPostProcessor.validateUpstreamInterfaces(model, warnings);
                     ConfigPostProcessor.validateCrossReferences(model, scratch, warnings);
                     UpstreamExtraDataMerger.validateNoOverlap(model);
                     if (!warnings.isEmpty() && !softValidation) {

--- a/server/src/main/java/com/epam/aidial/core/server/util/UpstreamExtraDataMerger.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/UpstreamExtraDataMerger.java
@@ -1,7 +1,9 @@
 package com.epam.aidial.core.server.util;
 
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -10,15 +12,28 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.experimental.UtilityClass;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
 @UtilityClass
 public class UpstreamExtraDataMerger {
 
+    /**
+     * The extra data an upstream serves the interface type with. Each half is resolved independently
+     * against the interface's overrides, so an interface supplying only {@code secretExtraData} still
+     * merges over the upstream's {@code extraData}.
+     */
+    public static String merge(Upstream upstream, InterfaceType type) {
+        return merge(UpstreamInterfaceUtil.resolveExtraData(upstream, type),
+                UpstreamInterfaceUtil.resolveSecretExtraData(upstream, type));
+    }
+
     public static String merge(Upstream upstream) {
-        String extraData = upstream.getExtraData();
-        String secretExtraData = upstream.getSecretExtraData();
+        return merge(upstream.getExtraData(), upstream.getSecretExtraData());
+    }
+
+    private static String merge(String extraData, String secretExtraData) {
         if (extraData == null && secretExtraData == null) {
             return null;
         }
@@ -40,9 +55,22 @@ public class UpstreamExtraDataMerger {
         }
     }
 
+    /**
+     * Checks the upstream's own pair and each interface's own pair. Overlap across the two levels is
+     * legal and is the point of an override — only a single level declaring the same key twice is
+     * ambiguous.
+     */
     public static void validateNoOverlap(Upstream upstream) {
-        String extraData = upstream.getExtraData();
-        String secretExtraData = upstream.getSecretExtraData();
+        validateNoOverlap(upstream.getExtraData(), upstream.getSecretExtraData());
+        Map<String, UpstreamInterface> interfaces = upstream.getInterfaces();
+        if (interfaces != null) {
+            for (UpstreamInterface upstreamInterface : interfaces.values()) {
+                validateNoOverlap(upstreamInterface.getExtraData(), upstreamInterface.getSecretExtraData());
+            }
+        }
+    }
+
+    private static void validateNoOverlap(String extraData, String secretExtraData) {
         if (extraData == null || secretExtraData == null) {
             return;
         }

--- a/server/src/main/java/com/epam/aidial/core/server/util/UpstreamInterfaceUtil.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/UpstreamInterfaceUtil.java
@@ -1,0 +1,100 @@
+package com.epam.aidial.core.server.util;
+
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
+import lombok.experimental.UtilityClass;
+
+import java.util.Map;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * Resolves the configuration an upstream serves one interface type with — the values forwarded to the
+ * adapter as {@code X-UPSTREAM-ENDPOINT}, {@code X-UPSTREAM-KEY} and {@code X-UPSTREAM-EXTRA-DATA}.
+ * An upstream carries two configuration shapes: the typed {@code interfaces} map, whose entries
+ * override the upstream's own fields for that interface alone, and the pre-{@code interfaces}
+ * {@code endpoint} and {@code responsesEndpoint} fields, which serve whatever interface asks for them.
+ */
+@UtilityClass
+public class UpstreamInterfaceUtil {
+
+    /**
+     * The provider url for the type, or null when the upstream has nothing serving it — the header is
+     * then omitted and the adapter falls back to its own configuration.
+     */
+    @Nullable
+    public String resolveEndpoint(Upstream upstream, InterfaceType type) {
+        UpstreamInterface upstreamInterface = findInterface(upstream, type);
+        if (upstreamInterface == null) {
+            return resolveLegacyEndpoint(upstream, type);
+        }
+        String endpoint = upstreamInterface.getEndpoint();
+        return endpoint != null ? endpoint : appendApiPath(upstream.getBaseUrl(), type);
+    }
+
+    /**
+     * The credential for the type: the interface's own key when it declares one, the upstream's otherwise.
+     */
+    @Nullable
+    public String resolveKey(Upstream upstream, InterfaceType type) {
+        return resolveOverridable(upstream, type, UpstreamInterface::getKey, upstream.getKey());
+    }
+
+    @Nullable
+    public String resolveExtraData(Upstream upstream, InterfaceType type) {
+        return resolveOverridable(upstream, type, UpstreamInterface::getExtraData, upstream.getExtraData());
+    }
+
+    @Nullable
+    public String resolveSecretExtraData(Upstream upstream, InterfaceType type) {
+        return resolveOverridable(upstream, type, UpstreamInterface::getSecretExtraData, upstream.getSecretExtraData());
+    }
+
+    /**
+     * The interface's own value for the field, falling back to the upstream's. Each field falls back
+     * independently, so an interface overriding only {@code key} still inherits {@code extraData}.
+     */
+    @Nullable
+    private String resolveOverridable(
+            Upstream upstream,
+            InterfaceType type,
+            Function<UpstreamInterface, String> field,
+            @Nullable String fallback
+    ) {
+        UpstreamInterface upstreamInterface = findInterface(upstream, type);
+        String override = upstreamInterface == null ? null : field.apply(upstreamInterface);
+        return override != null ? override : fallback;
+    }
+
+    @Nullable
+    private UpstreamInterface findInterface(Upstream upstream, InterfaceType type) {
+        Map<String, UpstreamInterface> interfaces = upstream.getInterfaces();
+        return interfaces == null ? null : interfaces.get(type.getValue());
+    }
+
+    /**
+     * The url {@code baseUrl} implies for the type, or null when the upstream declares no base url.
+     */
+    @Nullable
+    private String appendApiPath(@Nullable String baseUrl, InterfaceType type) {
+        if (baseUrl == null) {
+            return null;
+        }
+        String root = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return root + type.getApiPath();
+    }
+
+    /**
+     * The pre-{@code interfaces} field serving the type. {@code endpoint} predates the split into typed
+     * interfaces, so every non-Responses interface has been reading it — the Anthropic Messages API
+     * included, which is what {@code interfaces} exists to disentangle.
+     */
+    @Nullable
+    private String resolveLegacyEndpoint(Upstream upstream, InterfaceType type) {
+        return switch (type) {
+            case OPENAI_CHAT_COMPLETIONS, OPENAI_EMBEDDINGS, ANTHROPIC_MESSAGES -> upstream.getEndpoint();
+            case OPENAI_RESPONSES -> upstream.getResponsesEndpoint();
+        };
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/MessagesApiTest.java
@@ -224,6 +224,62 @@ public class MessagesApiTest extends ResourceBaseTest {
     }
 
     @Test
+    public void testUpstreamBaseUrlFormsTheEndpointHeaderFromTheApiPath() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH, requestBody("claude-upstream-interfaces", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            // the upstream declares anthropicMessages with no endpoint, so baseUrl + the API's own path serves it
+            assertEquals("http://messages-upstream/inference/v1/messages", captured.get().getHeader("X-UPSTREAM-ENDPOINT"));
+            assertEquals("modelKey", captured.get().getHeader("X-UPSTREAM-KEY"));
+        }
+    }
+
+    @Test
+    public void testUpstreamInterfaceEndpointOverridesTheBaseUrl() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH,
+                    requestBody("claude-upstream-interface-endpoint", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            assertEquals("http://messages-upstream/something-else/v1/messages", captured.get().getHeader("X-UPSTREAM-ENDPOINT"));
+        }
+    }
+
+    @Test
+    public void testUpstreamInterfaceOverridesKeyAndExtraDataHeaders() throws IOException {
+        AtomicReference<RecordedRequest> captured = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {
+            server.map(HttpMethod.POST, MESSAGES_PATH, request -> {
+                captured.set(request);
+                return TestWebServer.createResponse(200, NON_STREAM_RESPONSE, "Content-Type", "application/json");
+            });
+
+            Response response = post(client, MESSAGES_PATH,
+                    requestBody("claude-upstream-overrides", false), "api-key", "proxyKey1");
+
+            assertEquals(200, response.status());
+            // the interface's own key wins over the upstream's shared one ...
+            assertEquals("anthropic-only-key", captured.get().getHeader("X-UPSTREAM-KEY"));
+            // ... while extraData, which the interface does not override, is still inherited and
+            // merged with the interface's own secretExtraData
+            assertEquals("{\"region\":\"us-east-3\"}", captured.get().getHeader("X-UPSTREAM-EXTRA-DATA"));
+        }
+    }
+
+    @Test
     public void testDeploymentIdHeaderCarriesRequestedModel() throws IOException {
         AtomicReference<RecordedRequest> captured = new AtomicReference<>();
         try (TestWebServer server = new TestWebServer(4848); CloseableHttpClient client = newClient()) {

--- a/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/config/ConfigPostProcessorTest.java
@@ -9,6 +9,8 @@ import com.epam.aidial.core.config.Pricing;
 import com.epam.aidial.core.config.Role;
 import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.config.ToolSet;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import org.junit.jupiter.api.Test;
 
@@ -161,6 +163,69 @@ public class ConfigPostProcessorTest {
         pricing.setCacheRead("0.01");
         pricing.setCacheWrite("0.02");
         model.setPricing(pricing);
+        config.getModels().put("model", model);
+
+        ConfigPostProcessor.processSemantic(config, null, Map.of(), Map.of(), null);
+
+        assertTrue(config.getModels().containsKey("model"));
+    }
+
+    @Test
+    void testSemanticAbortThrowsOnUpstreamInterfaceWithNothingToResolveTo() {
+        Config config = newMutableConfig();
+        Model model = new Model();
+        Upstream upstream = new Upstream();
+        upstream.setId("no-base-url");
+        upstream.setInterfaces(Map.of("openaiChatCompletions", new UpstreamInterface()));
+        model.setUpstreams(List.of(upstream));
+        config.getModels().put("model", model);
+
+        assertThrows(InvalidEntityException.class,
+                () -> ConfigPostProcessor.processSemantic(config, null, Map.of(), Map.of(), null));
+    }
+
+    @Test
+    void testSemanticAllowsUpstreamInterfaceCompletedByEndpointOrBaseUrl() {
+        Config config = newMutableConfig();
+        Model model = new Model();
+        Upstream explicit = new Upstream();
+        explicit.setId("explicit");
+        explicit.setInterfaces(Map.of("anthropicMessages", new UpstreamInterface("https://provider/v1/messages")));
+        Upstream derived = new Upstream();
+        derived.setId("derived");
+        derived.setBaseUrl("https://provider");
+        derived.setInterfaces(Map.of("openaiResponses", new UpstreamInterface()));
+        model.setUpstreams(List.of(explicit, derived));
+        config.getModels().put("model", model);
+
+        ConfigPostProcessor.processSemantic(config, null, Map.of(), Map.of(), null);
+
+        assertTrue(config.getModels().containsKey("model"));
+    }
+
+    @Test
+    void testSemanticAbortThrowsOnUpstreamInterfacesWithoutId() {
+        // endpoint is what identifies an upstream when id is absent, and this shape has none
+        Config config = newMutableConfig();
+        Model model = new Model();
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://provider");
+        upstream.setInterfaces(Map.of("anthropicMessages", new UpstreamInterface()));
+        model.setUpstreams(List.of(upstream));
+        config.getModels().put("model", model);
+
+        assertThrows(InvalidEntityException.class,
+                () -> ConfigPostProcessor.processSemantic(config, null, Map.of(), Map.of(), null));
+    }
+
+    @Test
+    void testSemanticAllowsLegacyUpstreamWithoutId() {
+        // the id requirement is scoped to the interfaces shape; legacy upstreams are identified by endpoint
+        Config config = newMutableConfig();
+        Model model = new Model();
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("https://provider/v1/chat/completions");
+        model.setUpstreams(List.of(upstream));
         config.getModels().put("model", model);
 
         ConfigPostProcessor.processSemantic(config, null, Map.of(), Map.of(), null);

--- a/server/src/test/java/com/epam/aidial/core/server/config/SecretFieldProcessorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/config/SecretFieldProcessorTest.java
@@ -3,8 +3,10 @@ package com.epam.aidial.core.server.config;
 import com.epam.aidial.core.config.Key;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.encryption.CredentialEncryptionService;
+import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
@@ -19,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -154,6 +157,65 @@ class SecretFieldProcessorTest {
 
         assertEquals("plain-up-cipher", model.getUpstreams().get(0).getKey());
         assertEquals("plain-xd-cipher", model.getUpstreams().get(0).getSecretExtraData());
+    }
+
+    @Test
+    void decryptFields_walksIntoUpstreamInterfaces() {
+        UpstreamInterface anthropic = new UpstreamInterface();
+        anthropic.setKey("ENC[" + Base64.getEncoder().encodeToString("iface-cipher".getBytes(StandardCharsets.UTF_8)) + "]");
+        Upstream up = new Upstream();
+        up.setInterfaces(Map.of("anthropicMessages", anthropic));
+        Model model = new Model();
+        model.setUpstreams(List.of(up));
+        when(encryptionService.decrypt(eq(BUCKET), any(byte[].class), any(byte[].class)))
+                .thenAnswer(inv -> {
+                    byte[] in = inv.getArgument(1);
+                    return ("plain-" + new String(in, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8);
+                });
+
+        processor.decryptFields(model, descriptor);
+
+        assertEquals("plain-iface-cipher",
+                model.getUpstreams().get(0).getInterfaces().get("anthropicMessages").getKey());
+    }
+
+    @Test
+    void stripEncryptedFields_dropsSecretsNestedInUpstreamInterfaces() {
+        ObjectNode payload = ProxyUtil.MAPPER.createObjectNode();
+        ObjectNode upstream = payload.putArray("upstreams").addObject();
+        upstream.put("key", "ENC[up]");
+        ObjectNode anthropic = upstream.putObject("interfaces").putObject("anthropicMessages");
+        anthropic.put("endpoint", "http://anthropic/v1/messages");
+        anthropic.put("key", "ENC[iface]");
+        anthropic.put("secretExtraData", "ENC[iface-xd]");
+
+        ObjectNode stripped = SecretFieldProcessor.stripEncryptedFields(payload, Model.class);
+
+        ObjectNode strippedInterface = (ObjectNode) stripped.get("upstreams").get(0)
+                .get("interfaces").get("anthropicMessages");
+        assertFalse(strippedInterface.has("key"));
+        assertFalse(strippedInterface.has("secretExtraData"));
+        // non-secret members survive
+        assertEquals("http://anthropic/v1/messages", strippedInterface.get("endpoint").asText());
+    }
+
+    @Test
+    void mergePreservingOmittedSecrets_preservesSecretsNestedInUpstreamInterfaces() {
+        ObjectNode existing = ProxyUtil.MAPPER.createObjectNode();
+        ObjectNode existingUpstream = existing.putArray("upstreams").addObject();
+        existingUpstream.put("endpoint", "http://provider");
+        existingUpstream.putObject("interfaces").putObject("anthropicMessages").put("key", "ENC[prior]");
+
+        ObjectNode request = ProxyUtil.MAPPER.createObjectNode();
+        ObjectNode requestUpstream = request.putArray("upstreams").addObject();
+        requestUpstream.put("endpoint", "http://provider");
+        requestUpstream.putObject("interfaces").putObject("anthropicMessages")
+                .put("endpoint", "http://anthropic/v1/messages");
+
+        ObjectNode merged = processor.mergePreservingOmittedSecrets(existing, request, Model.class);
+
+        assertEquals("ENC[prior]", merged.get("upstreams").get(0)
+                .get("interfaces").get("anthropicMessages").get("key").asText());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -384,6 +384,7 @@ public class DeploymentPostControllerTest {
         Buffer requestBody = Buffer.buffer();
         when(context.getRequestBody()).thenReturn(requestBody);
 
+        when(request.path()).thenReturn("/openai/deployments/app1/chat/completions");
         controller.handleProxyRequest(proxyRequest);
 
         assertNull(proxyHeaders.get(AUTHORIZATION));
@@ -394,7 +395,7 @@ public class DeploymentPostControllerTest {
     public void testHandleRequestBody_OverrideModelName() throws IOException {
         when(context.getRequest()).thenReturn(request);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, null, 0, 0, null));
+        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, null, 0, 0, null, null, null));
         when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
         HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
         when(context.getRequest()).thenReturn(request);
@@ -437,7 +438,7 @@ public class DeploymentPostControllerTest {
     public void testHandleRequestBody_NotOverrideModelName() throws IOException {
         when(context.getRequest()).thenReturn(request);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, null, 0, 0, null));
+        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, null, 0, 0, null, null, null));
         when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
         HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
         when(context.getRequest()).thenReturn(request);
@@ -479,7 +480,7 @@ public class DeploymentPostControllerTest {
     public void testHandleRequestBody_OverrideModelName_Application() throws IOException {
         when(context.getRequest()).thenReturn(request);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, null, 0, 0, null));
+        when(upstreamRoute.next()).thenReturn(new Upstream("endpoint", null, null, null, null, 0, 0, null, null, null));
         when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
         HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
         when(context.getRequest()).thenReturn(request);
@@ -671,6 +672,7 @@ public class DeploymentPostControllerTest {
         proxyApiKeyData.setPerRequestKey("key1");
         when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
 
+        when(request.path()).thenReturn("/openai/deployments/app1/chat/completions");
         controller.handleProxyRequest(proxyRequest);
 
         assertEquals("key1", proxyHeaders.get(HEADER_API_KEY));
@@ -805,6 +807,7 @@ public class DeploymentPostControllerTest {
             return null;
         }).when(applicationSchemaService).consumeMetadataProperties(eq(application), any(ApplicationSchemaService.MetadataPropertiesConsumer.class));
 
+        when(request.path()).thenReturn("/openai/deployments/app1/chat/completions");
         controller.handleProxyRequest(proxyRequest);
 
         verify(proxyRequest).putHeader(eq(HEADER_APPLICATION_ID), eq("customApp"));
@@ -834,6 +837,7 @@ public class DeploymentPostControllerTest {
         Buffer requestBody = Buffer.buffer("{}");
         when(context.getRequestBody()).thenReturn(requestBody);
 
+        when(request.path()).thenReturn("/openai/deployments/app1/chat/completions");
         controller.handleProxyRequest(proxyRequest);
 
         verify(proxyRequest, never()).putHeader(eq(HEADER_APPLICATION_ID), anyString());
@@ -875,6 +879,7 @@ public class DeploymentPostControllerTest {
             return null;
         }).when(applicationSchemaService).consumeMetadataProperties(eq(application), any(ApplicationSchemaService.MetadataPropertiesConsumer.class));
 
+        when(request.path()).thenReturn("/openai/deployments/app1/chat/completions");
         controller.handleProxyRequest(proxyRequest);
 
         verify(proxyRequest).putHeader(eq(HEADER_APPLICATION_ID), eq("customApp"));
@@ -912,6 +917,7 @@ public class DeploymentPostControllerTest {
         Buffer requestBody = Buffer.buffer("{}");
         when(context.getRequestBody()).thenReturn(requestBody);
 
+        when(request.path()).thenReturn("/openai/deployments/app1/chat/completions");
         controller.handleProxyRequest(proxyRequest);
 
         verify(proxyRequest).putHeader(eq(HEADER_APPLICATION_ID), eq("customApp"));

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponseItemControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponseItemControllerTest.java
@@ -144,7 +144,7 @@ public class ResponseItemControllerTest {
         Model deployment = new Model();
         deployment.setName("test-deployment");
         deployment.setResponsesEndpoint("http://adapter/responses");
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
         Buffer responseBody = Buffer.buffer("{\"id\":\"upstream-id-123\",\"status\":\"completed\"}");
@@ -197,7 +197,7 @@ public class ResponseItemControllerTest {
         deployment.setName("test-deployment");
         deployment.setInterfaces(Map.of(
                 InterfaceType.OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
         Buffer responseBody = Buffer.buffer("{\"id\":\"upstream-id-123\",\"status\":\"completed\"}");
@@ -242,7 +242,7 @@ public class ResponseItemControllerTest {
         Model deployment = new Model();
         deployment.setName("test-deployment");
         deployment.setResponsesEndpoint("http://adapter/responses");
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
         Buffer responseBody = Buffer.buffer("{\"id\":\"upstream-id-123\",\"status\":\"cancelled\"}");
@@ -287,7 +287,7 @@ public class ResponseItemControllerTest {
         Model deployment = new Model();
         deployment.setName("test-deployment");
         deployment.setResponsesEndpoint("http://adapter/responses");
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
 
@@ -328,7 +328,7 @@ public class ResponseItemControllerTest {
         Model deployment = new Model();
         deployment.setName("test-deployment");
         deployment.setResponsesEndpoint("http://adapter/responses");
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
 
@@ -457,7 +457,7 @@ public class ResponseItemControllerTest {
         Model deployment = new Model();
         deployment.setName("test-deployment");
         deployment.setResponsesEndpoint("http://adapter/responses");
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
 
@@ -500,7 +500,7 @@ public class ResponseItemControllerTest {
         Model deployment = new Model();
         deployment.setName("test-deployment");
         deployment.setResponsesEndpoint("http://adapter/responses");
-        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", "api-key", null, null, 0, 0, null, null, null);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
 

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ResponsesControllerTest.java
@@ -249,7 +249,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint");
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint", null, null);
         ApiKeyData apiKeyData = new ApiKeyData();
         apiKeyData.setSourceDeployment("test-deployment");
         apiKeyData.setPerRequestKey(PER_REQUEST_KEY);
@@ -406,7 +406,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint");
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint", null, null);
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
         Buffer requestBody = Buffer.buffer("{\"model\":\"test\"}");
@@ -551,7 +551,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint");
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint", null, null);
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
         Buffer requestBody = Buffer.buffer("{\"model\":\"test\",\"background\":true}");
@@ -640,7 +640,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint");
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint", null, null);
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
         String upstreamId = "upstream-resp-stream";
@@ -758,7 +758,7 @@ public class ResponsesControllerTest {
         deployment.setResponsesEndpoint("http://adapter/responses");
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, null);
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, null, null, null);
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
 
@@ -805,7 +805,7 @@ public class ResponsesControllerTest {
         ApiKeyStore apiKeyStore = mock(ApiKeyStore.class);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
         HttpClientResponse proxyResponse = mock(HttpClientResponse.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint");
+        Upstream upstream = new Upstream(null, "endpoint", null, null, null, 0, 0, "endpoint", null, null);
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setPerRequestKey(PER_REQUEST_KEY);
         Buffer requestBody = Buffer.buffer("{\"model\":\"test\",\"background\":true}");
@@ -930,7 +930,7 @@ public class ResponsesControllerTest {
 
         HttpClient httpClient = mock(HttpClient.class, RETURNS_DEEP_STUBS);
         UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
-        Upstream upstream = new Upstream(null, "http://actual-model/responses", null, null, null, 0, 0, "endpoint");
+        Upstream upstream = new Upstream(null, "http://actual-model/responses", null, null, null, 0, 0, "endpoint", null, null);
 
         when(request.getHeader(HttpHeaders.CONTENT_TYPE)).thenReturn(HEADER_CONTENT_TYPE_APPLICATION_JSON);
         when(request.body()).thenReturn(Future.succeededFuture(Buffer.buffer("{\"model\":\"ignored\"}")));

--- a/server/src/test/java/com/epam/aidial/core/server/service/UpstreamCacheServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/UpstreamCacheServiceTest.java
@@ -90,6 +90,41 @@ public class UpstreamCacheServiceTest {
     }
 
     @Test
+    public void testUpdateEntryWithoutEndpointPinsById() throws JsonProcessingException {
+        // an upstream configured through interfaces carries no legacy endpoint; Redis rejects a null value,
+        // so the field is omitted and the id alone identifies the pinned upstream
+        service = new UpstreamCacheService(redissonClient, lockService, System::currentTimeMillis, null);
+        String body = """
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "hello",
+                            "custom_fields": {
+                                "cache_breakpoint": {}
+                            }
+                        }
+                    ]
+                }
+                """;
+        RequestObject request = new ChatCompletionRequest((ObjectNode) ProxyUtil.MAPPER.readTree(body));
+        Model model = new Model();
+        model.setName("interfaces-model");
+
+        CacheBreakpointContext context = service.buildCacheBreakpointContext(
+                request, CachePolicy.AVAILABILITY_PRIORITY, model, InterfaceType.OPENAI_CHAT_COMPLETIONS);
+        String breakpoint = context.breakpoints().get(context.breakpoints().size() - 1);
+
+        service.updateEntry(context.prefixToHash().get(breakpoint),
+                new CachedUpstreamEntry(null, "up-1", breakpoint, null), model, null);
+
+        CachedUpstreamEntry entry = service.getCacheEntry(context, model);
+        assertNotNull(entry);
+        assertNull(entry.endpoint());
+        assertEquals("up-1", entry.id());
+    }
+
+    @Test
     public void testBuildCacheBreakpointContext_withBreakpoints() throws JsonProcessingException {
         service = new UpstreamCacheService(redissonClient, lockService, System::currentTimeMillis, null);
         String body = """

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/RandomizedWeightedBalancerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/RandomizedWeightedBalancerTest.java
@@ -23,10 +23,10 @@ public class RandomizedWeightedBalancerTest {
     @Test
     void testWeightedLoadBalancer() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 0, null),
-                new Upstream("endpoint2", null, null, null, null, 2, 0, null),
-                new Upstream("endpoint3", null, null, null, null, 3, 0, null),
-                new Upstream("endpoint4", null, null, null, null, 4, 0, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 0, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 2, 0, null, null, null),
+                new Upstream("endpoint3", null, null, null, null, 3, 0, null, null, null),
+                new Upstream("endpoint4", null, null, null, null, 4, 0, null, null, null)
         );
 
         RandomizedWeightedBalancer balancer = new RandomizedWeightedBalancer("model1", upstreams, generator);
@@ -60,8 +60,8 @@ public class RandomizedWeightedBalancerTest {
     @Test
     void testZeroWeightLoadBalancer() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, null, 0, 1, null),
-                new Upstream("endpoint2", null, null, null, null, -9, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 0, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, -9, 1, null, null, null)
         );
         RandomizedWeightedBalancer balancer = new RandomizedWeightedBalancer("model1", upstreams, generator);
 

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/TieredBalancerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/TieredBalancerTest.java
@@ -47,8 +47,8 @@ public class TieredBalancerTest {
     @Test
     void testTierPriority() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 0, null),
-                new Upstream("endpoint2", null, null, null, null, 9, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 0, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 9, 1, null, null, null)
         );
         TieredBalancer balancer = new TieredBalancer("model1", upstreams, generator);
 
@@ -63,8 +63,8 @@ public class TieredBalancerTest {
     @Test
     void testFail() throws InterruptedException {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 0, null),
-                new Upstream("endpoint2", null, null, null, null, 9, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 0, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 9, 1, null, null, null)
         );
         TieredBalancer balancer = new TieredBalancer("model1", upstreams, generator);
 
@@ -93,8 +93,8 @@ public class TieredBalancerTest {
     @Test
     void test5xxErrorsHandling() {
         List<Upstream> upstreams = List.of(
-                new Upstream("endpoint0", null, null, null, null, 1, 0, null),
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint0", null, null, null, null, 1, 0, null, null, null),
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null)
         );
         TieredBalancer balancer = new TieredBalancer("model1", upstreams, generator);
 
@@ -118,7 +118,7 @@ public class TieredBalancerTest {
         Model model = new Model();
         model.setName("model1");
         List<Upstream> upstreams = Stream.of(1, 2, 3, 4)
-                .map(index  -> new Upstream("endpoint" + index, null, null, null, null, 1, 1, null))
+                .map(index  -> new Upstream("endpoint" + index, null, null, null, null, 1, 1, null, null, null))
                 .toList();
         model.setUpstreams(upstreams);
         AtomicInteger counter = new AtomicInteger(-1);

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
@@ -1,8 +1,10 @@
 package com.epam.aidial.core.server.upstream;
 
 import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
 import com.epam.aidial.core.server.data.cache.CacheBreakpointContext;
 import com.epam.aidial.core.server.data.cache.CachePolicy;
 import com.epam.aidial.core.server.data.cache.CachedUpstreamEntry;
@@ -169,6 +171,27 @@ public class UpstreamRouteProviderTest {
         HttpException ex = assertThrows(HttpException.class, () -> provider.get(model, null, "missing"));
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
         assertEquals("Unknown upstream id missing", ex.getMessage());
+    }
+
+    @Test
+    public void testGet_UpstreamId_MatchesInterfacesConfiguredUpstreamById() {
+        // an upstream configured through interfaces carries no endpoint, so its id is what addresses it
+        Model model = new Model();
+        model.setName("model");
+        Upstream legacy = new Upstream();
+        legacy.setId("alpha");
+        legacy.setEndpoint("ep1");
+        Upstream interfaced = new Upstream();
+        interfaced.setId("fireworks");
+        interfaced.setBaseUrl("https://provider");
+        interfaced.setInterfaces(Map.of(
+                InterfaceType.ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface()));
+        model.setUpstreams(List.of(legacy, interfaced));
+
+        UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
+
+        assertEquals(interfaced, provider.get(model, null, "fireworks").next());
+        assertEquals(legacy, provider.get(model, null, "alpha").next());
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteTest.java
@@ -58,10 +58,10 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint3", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint4", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint3", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint4", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -108,8 +108,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -141,8 +141,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -165,8 +165,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -189,8 +189,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -222,8 +222,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -255,8 +255,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 1, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 1, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
@@ -285,8 +285,8 @@ public class UpstreamRouteTest {
         Model model = new Model();
         model.setName("model1");
         model.setUpstreams(List.of(
-                new Upstream("endpoint1", null, null, null, null, 1, 1, null),
-                new Upstream("endpoint2", null, null, null, null, 1, 0, null)
+                new Upstream("endpoint1", null, null, null, null, 1, 1, null, null, null),
+                new Upstream("endpoint2", null, null, null, null, 1, 0, null, null, null)
         ));
 
         UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);

--- a/server/src/test/java/com/epam/aidial/core/server/util/UpstreamExtraDataMergerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/UpstreamExtraDataMergerTest.java
@@ -1,11 +1,16 @@
 package com.epam.aidial.core.server.util;
 
 import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
 import com.epam.aidial.core.storage.http.HttpException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
+import static com.epam.aidial.core.config.InterfaceType.ANTHROPIC_MESSAGES;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,5 +106,44 @@ class UpstreamExtraDataMergerTest {
         HttpException ex = assertThrows(HttpException.class,
                 () -> UpstreamExtraDataMerger.validateNoOverlap(upstream("\"a\"", "\"b\"")));
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, ex.getStatus());
+    }
+
+    @Test
+    void mergeForInterfaceCombinesInheritedExtraDataWithOverriddenSecret() throws Exception {
+        Upstream up = upstream("{\"region\":\"us-east-1\",\"tenant\":\"acme\"}", null);
+        UpstreamInterface anthropic = new UpstreamInterface();
+        anthropic.setSecretExtraData("{\"region\":\"us-east-3\"}");
+        up.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        JsonNode merged = ProxyUtil.MAPPER.readTree(UpstreamExtraDataMerger.merge(up, ANTHROPIC_MESSAGES));
+
+        // the override shadows the inherited key, and leaves the rest of the inherited object intact
+        assertEquals("us-east-3", merged.get("region").asText());
+        assertEquals("acme", merged.get("tenant").asText());
+        // a sibling interface sees the upstream's data untouched
+        assertEquals("{\"region\":\"us-east-1\",\"tenant\":\"acme\"}",
+                UpstreamExtraDataMerger.merge(up, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void validateNoOverlapCheckedWithinEachInterfaceButNotAcrossLevels() {
+        // an interface declaring both halves with the same key is as ambiguous as an upstream doing it
+        Upstream ambiguous = upstream(null, null);
+        UpstreamInterface both = new UpstreamInterface();
+        both.setExtraData("{\"k\":\"a\"}");
+        both.setSecretExtraData("{\"k\":\"b\"}");
+        ambiguous.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), both));
+
+        HttpException ex = assertThrows(HttpException.class,
+                () -> UpstreamExtraDataMerger.validateNoOverlap(ambiguous));
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, ex.getStatus());
+
+        // across levels the same key is an override, not an ambiguity
+        Upstream overriding = upstream("{\"k\":\"a\"}", null);
+        UpstreamInterface secretOnly = new UpstreamInterface();
+        secretOnly.setSecretExtraData("{\"k\":\"b\"}");
+        overriding.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), secretOnly));
+
+        UpstreamExtraDataMerger.validateNoOverlap(overriding);
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/util/UpstreamInterfaceUtilTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/UpstreamInterfaceUtilTest.java
@@ -1,0 +1,229 @@
+package com.epam.aidial.core.server.util;
+
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Upstream;
+import com.epam.aidial.core.config.UpstreamInterface;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.epam.aidial.core.config.InterfaceType.ANTHROPIC_MESSAGES;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_EMBEDDINGS;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
+import static com.epam.aidial.core.server.util.UpstreamInterfaceUtil.resolveEndpoint;
+import static com.epam.aidial.core.server.util.UpstreamInterfaceUtil.resolveExtraData;
+import static com.epam.aidial.core.server.util.UpstreamInterfaceUtil.resolveKey;
+import static com.epam.aidial.core.server.util.UpstreamInterfaceUtil.resolveSecretExtraData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class UpstreamInterfaceUtilTest {
+
+    @Test
+    void legacyEndpointServesEveryInterfaceButResponses() {
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("http://host/openai/deployments/gpt/chat/completions");
+
+        assertEquals(upstream.getEndpoint(), resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertEquals(upstream.getEndpoint(), resolveEndpoint(upstream, OPENAI_EMBEDDINGS));
+        // the confusion interfaces exists to remove: the untyped endpoint has been serving Anthropic too
+        assertEquals(upstream.getEndpoint(), resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+        assertNull(resolveEndpoint(upstream, OPENAI_RESPONSES));
+    }
+
+    @Test
+    void legacyResponsesEndpoint() {
+        Upstream upstream = new Upstream();
+        upstream.setResponsesEndpoint("http://host/openai/v1/responses");
+
+        assertEquals("http://host/openai/v1/responses", resolveEndpoint(upstream, OPENAI_RESPONSES));
+        assertNull(resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void neitherDeclared() {
+        Upstream upstream = new Upstream();
+
+        assertNull(resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertNull(resolveEndpoint(upstream, OPENAI_EMBEDDINGS));
+        assertNull(resolveEndpoint(upstream, OPENAI_RESPONSES));
+        assertNull(resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void explicitInterfaceEndpointsRouteEachApiToItsOwnUrl() {
+        Upstream upstream = new Upstream();
+        upstream.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface("https://api.fireworks.ai/inference/v1/chat/completions"),
+                OPENAI_RESPONSES.getValue(), new UpstreamInterface("https://api.fireworks.ai/inference/v1/responses"),
+                ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface("https://api.fireworks.ai/inference/v1/messages")));
+
+        assertEquals("https://api.fireworks.ai/inference/v1/chat/completions", resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("https://api.fireworks.ai/inference/v1/responses", resolveEndpoint(upstream, OPENAI_RESPONSES));
+        assertEquals("https://api.fireworks.ai/inference/v1/messages", resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+        // the map is a whitelist: an undeclared interface falls through to the legacy fields
+        assertNull(resolveEndpoint(upstream, OPENAI_EMBEDDINGS));
+    }
+
+    @Test
+    void baseUrlCompletesTheInterfacesThatDeclareNoEndpoint() {
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://api.fireworks.ai/inference");
+        upstream.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface(),
+                OPENAI_RESPONSES.getValue(), new UpstreamInterface(),
+                OPENAI_EMBEDDINGS.getValue(), new UpstreamInterface(),
+                ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface()));
+
+        assertEquals("https://api.fireworks.ai/inference/v1/chat/completions", resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("https://api.fireworks.ai/inference/v1/responses", resolveEndpoint(upstream, OPENAI_RESPONSES));
+        assertEquals("https://api.fireworks.ai/inference/v1/embeddings", resolveEndpoint(upstream, OPENAI_EMBEDDINGS));
+        assertEquals("https://api.fireworks.ai/inference/v1/messages", resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void interfaceEndpointWinsOverBaseUrl() {
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://api.fireworks.ai/inference");
+        upstream.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface(),
+                ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface("https://api.fireworks.ai/inference/something-else/v1/messages")));
+
+        assertEquals("https://api.fireworks.ai/inference/v1/chat/completions", resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("https://api.fireworks.ai/inference/something-else/v1/messages", resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void baseUrlStripsTrailingSlash() {
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://api.fireworks.ai/inference/");
+        upstream.setInterfaces(Map.of(OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface()));
+
+        assertEquals("https://api.fireworks.ai/inference/v1/chat/completions", resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void baseUrlAppliesOnlyToDeclaredInterfaces() {
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://api.fireworks.ai/inference");
+        upstream.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface()));
+
+        assertEquals("https://api.fireworks.ai/inference/v1/messages", resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+        assertNull(resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void interfacesWinOverLegacyFieldsPerType() {
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("http://legacy/v1/chat/completions");
+        upstream.setResponsesEndpoint("http://legacy/v1/responses");
+        upstream.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new UpstreamInterface("http://anthropic/v1/messages")));
+
+        assertEquals("http://anthropic/v1/messages", resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+        // the legacy fields keep serving the types the map says nothing about
+        assertEquals("http://legacy/v1/chat/completions", resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://legacy/v1/responses", resolveEndpoint(upstream, OPENAI_RESPONSES));
+    }
+
+    @Test
+    void declaredInterfaceWithoutEndpointOrBaseUrlResolvesToNothing() {
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("http://legacy/v1/chat/completions");
+        upstream.setInterfaces(Map.of(OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface()));
+
+        // declaring the interface opts out of the legacy field, so nothing is left to complete it
+        assertNull(resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void keyAndExtraDataFallBackToTheUpstreamLevel() {
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://api.fireworks.ai/inference");
+        upstream.setKey("sk-proj-shared");
+        upstream.setExtraData("{\"region\":\"us-east-1\"}");
+        upstream.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface(),
+                OPENAI_RESPONSES.getValue(), new UpstreamInterface()));
+
+        for (InterfaceType type : new InterfaceType[] {OPENAI_CHAT_COMPLETIONS, OPENAI_RESPONSES}) {
+            assertEquals("sk-proj-shared", resolveKey(upstream, type));
+            assertEquals("{\"region\":\"us-east-1\"}", resolveExtraData(upstream, type));
+            assertNull(resolveSecretExtraData(upstream, type));
+        }
+    }
+
+    @Test
+    void eachOverridableFieldFallsBackIndependently() {
+        // the spec's case: anthropicMessages overrides key and adds secretExtraData, and still
+        // inherits the upstream's extraData
+        Upstream upstream = new Upstream();
+        upstream.setBaseUrl("https://api.fireworks.ai/inference");
+        upstream.setKey("sk-proj-shared");
+        upstream.setExtraData("{\"region\":\"us-east-1\"}");
+        UpstreamInterface anthropic = new UpstreamInterface();
+        anthropic.setKey("foo-bar-another");
+        anthropic.setSecretExtraData("{\"region\":\"us-east-3\"}");
+        upstream.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new UpstreamInterface(),
+                ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        assertEquals("foo-bar-another", resolveKey(upstream, ANTHROPIC_MESSAGES));
+        assertEquals("{\"region\":\"us-east-1\"}", resolveExtraData(upstream, ANTHROPIC_MESSAGES));
+        assertEquals("{\"region\":\"us-east-3\"}", resolveSecretExtraData(upstream, ANTHROPIC_MESSAGES));
+
+        // the sibling interface is untouched by the override
+        assertEquals("sk-proj-shared", resolveKey(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertNull(resolveSecretExtraData(upstream, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void legacyFieldsYieldPerTypeToTheInterfacesThatSupersedeThem() throws Exception {
+        // the spec's backward-compatibility case, verbatim: endpoint is superseded by the declared
+        // openaiChatCompletions, while responsesEndpoint still serves the undeclared openaiResponses
+        String json = """
+                {
+                    "id": "1",
+                    "weight": 1,
+                    "tier": 1,
+                    "endpoint": "https://api.fireworks.ai/inference/v1/chat/completions",
+                    "responsesEndpoint": "https://api.fireworks.ai/inference/v1/responses",
+                    "key": "sk-proj-9UThW",
+                    "extraData": {"region": "us-east-1"},
+                    "baseUrl": "https://api.fireworks.ai/inference",
+                    "interfaces": {
+                        "openaiChatCompletions": {},
+                        "anthropicMessages": {}
+                    }
+                }
+                """;
+        Upstream upstream = new ObjectMapper().readValue(json, Upstream.class);
+
+        assertEquals("https://api.fireworks.ai/inference/v1/chat/completions",
+                resolveEndpoint(upstream, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("https://api.fireworks.ai/inference/v1/messages",
+                resolveEndpoint(upstream, ANTHROPIC_MESSAGES));
+        assertEquals("https://api.fireworks.ai/inference/v1/responses",
+                resolveEndpoint(upstream, OPENAI_RESPONSES));
+        // key and extraData are shared by every interface, declared or not
+        for (InterfaceType type : InterfaceType.values()) {
+            assertEquals("sk-proj-9UThW", resolveKey(upstream, type));
+            assertEquals("{\"region\":\"us-east-1\"}", resolveExtraData(upstream, type));
+        }
+    }
+
+    @Test
+    void overridesApplyOnlyToDeclaredInterfaces() {
+        Upstream upstream = new Upstream();
+        upstream.setEndpoint("http://legacy/v1/chat/completions");
+        upstream.setKey("upstream-key");
+        UpstreamInterface anthropic = new UpstreamInterface("http://anthropic/v1/messages");
+        anthropic.setKey("anthropic-key");
+        upstream.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        assertEquals("anthropic-key", resolveKey(upstream, ANTHROPIC_MESSAGES));
+        // an undeclared interface sees the upstream's own credential, untouched
+        assertEquals("upstream-key", resolveKey(upstream, OPENAI_CHAT_COMPLETIONS));
+    }
+}

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -243,6 +243,51 @@
         {"endpoint": "http://messages-upstream/v1/messages", "key": "modelKey", "id": "messages-upstream"}
       ]
     },
+    "claude-upstream-interfaces": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
+      "upstreams": [
+        {
+          "id": "messages-upstream-interfaces",
+          "baseUrl": "http://messages-upstream/inference",
+          "key": "modelKey",
+          "interfaces": { "openaiChatCompletions": {}, "anthropicMessages": {} }
+        }
+      ]
+    },
+    "claude-upstream-interface-endpoint": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
+      "upstreams": [
+        {
+          "id": "messages-upstream-endpoint",
+          "baseUrl": "http://messages-upstream/inference",
+          "key": "modelKey",
+          "interfaces": {
+            "anthropicMessages": {"endpoint": "http://messages-upstream/something-else/v1/messages"}
+          }
+        }
+      ]
+    },
+    "claude-upstream-overrides": {
+      "type": "chat",
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
+      "upstreams": [
+        {
+          "id": "messages-upstream-overrides",
+          "baseUrl": "http://messages-upstream/inference",
+          "key": "shared-key",
+          "extraData": {"region": "us-east-1"},
+          "interfaces": {
+            "openaiChatCompletions": {},
+            "anthropicMessages": {
+              "key": "anthropic-only-key",
+              "secretExtraData": {"region": "us-east-3"}
+            }
+          }
+        }
+      ]
+    },
     "claude-cache": {
       "type": "chat",
       "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
@@ -379,6 +424,9 @@
         "claude-xapikey": {"minute": "100000", "day": "10000000"},
         "claude-limited": {"minute": "10", "day": "10"},
         "claude-upstream": {"minute": "100000", "day": "10000000"},
+        "claude-upstream-interfaces": {"minute": "100000", "day": "10000000"},
+        "claude-upstream-interface-endpoint": {"minute": "100000", "day": "10000000"},
+        "claude-upstream-overrides": {"minute": "100000", "day": "10000000"},
         "claude-override": {"minute": "100000", "day": "10000000"},
         "claude-header-spoof": {"minute": "100000", "day": "10000000"},
         "claude-no-iface": {"minute": "100000", "day": "10000000"},


### PR DESCRIPTION
### Applicable issues

- 

### Description of changes

Model providers that expose several LLM APIs for the same model (Fireworks serves both the OpenAI and the Anthropic API) previously needed two model deployments in Core, because an upstream had one untyped `endpoint`. That field also silently backed the Anthropic Messages API, which is confusing given `endpoint` normally means the OpenAI ChatCompletions endpoint — and the same confusion would repeat for every future API.

This adds a typed `interfaces` map and a `baseUrl` to `upstreams[]`:

- **`upstreams[].interfaces`** keys the same types as the deployment-level map — `openaiChatCompletions`, `openaiResponses`, `openaiEmbeddings`, `anthropicMessages` — but each value carries a full `endpoint` rather than a base url, because an upstream is the provider itself and no ingress path is routed into it.
- **`upstreams[].baseUrl`** completes any declared interface that omits `endpoint`, appending the path from that API's own spec — `/v1/chat/completions`, `/v1/embeddings`, `/v1/responses`, `/v1/messages` — ignoring the `/openai` and `/anthropic` ingress keywords. This is the one difference from deployment-level `interfaces.{type}.base_url`, which is instead concatenated with the request path to Core.
- **`key`, `extraData` and `secretExtraData` are overridable per interface.** An interface-level value wins over the upstream-level one; each field falls back independently, so an interface overriding only `key` still inherits `extraData`. `extraData` and `secretExtraData` are merged into `X-UPSTREAM-EXTRA-DATA` as before.
- **Backward compatible.** `interfaces` is a whitelist, not a default: an interface type absent from the map still falls back to the legacy field serving it — `responsesEndpoint` for `openaiResponses`, `endpoint` for every other type — so existing upstreams keep working unchanged.

Two config-load rules are enforced, and a model violating either is rejected: every declared interface must resolve to a url (its own `endpoint`, or `baseUrl`), and an upstream declaring `interfaces` must declare an `id` — that shape has no `endpoint` to fall back on as its identifier for `X-UPSTREAM-ID` routing and prompt-cache pinning.

Also fixes two pre-existing NPEs that this shape makes easier to hit:

- `X-UPSTREAM-ID` lookup threw `NullPointerException` (500) when any upstream in the list had neither `id` nor `endpoint` — the documented Bedrock/VertexAI/direct-Anthropic shape, where the upstream carries only credentials. It now skips the unaddressable upstream and answers 400 for a genuinely unknown id.
- The prompt-cache entry write threw `NullPointerException: map value can't be null` in Redis when the upstream had no `endpoint`, silently losing every cache pin.

`SecretFieldProcessor` now also descends into map-valued fields, so the new per-interface `key`/`secretExtraData` are encrypted at rest, stripped from admin GET responses, and preserved on a PUT that omits them — the same guarantees the upstream-level secrets already had.

Docs updated in `docs/dynamic-settings/models.md` (new `models.<model_name>.upstreams.interfaces` section) and `sample/aidial.config.json`; `docs/open_api_core.yaml` regenerated via `./gradlew replaceSpec`.

### Checklist

- [x] Title of the pull request
  follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (full `./gradlew test` green; `checkstyleMain`/`checkstyleTest` clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.