### PR TITLE
feat: derive secret AAD through a named helper #1863

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/config/SecretFieldProcessor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/SecretFieldProcessor.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.config;
 import com.epam.aidial.core.config.annotation.EncryptedField;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.encryption.CredentialEncryptionService;
+import com.epam.aidial.core.server.security.ResourceSecretAad;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -40,7 +41,7 @@ public class SecretFieldProcessor {
         if (entity == null) {
             return;
         }
-        byte[] aad = descriptor.getAbsoluteFilePath().getBytes(StandardCharsets.UTF_8);
+        byte[] aad = ResourceSecretAad.deriveFor(descriptor);
         walk(entity, aad, true);
     }
 
@@ -48,7 +49,7 @@ public class SecretFieldProcessor {
         if (entity == null) {
             return;
         }
-        byte[] aad = descriptor.getAbsoluteFilePath().getBytes(StandardCharsets.UTF_8);
+        byte[] aad = ResourceSecretAad.deriveFor(descriptor);
         walk(entity, aad, false);
     }
 
@@ -57,7 +58,7 @@ public class SecretFieldProcessor {
             return null;
         }
         if (value.startsWith(ENC_PREFIX) && value.endsWith(ENC_SUFFIX)) {
-            byte[] aad = descriptor.getAbsoluteFilePath().getBytes(StandardCharsets.UTF_8);
+            byte[] aad = ResourceSecretAad.deriveFor(descriptor);
             return decryptEnvelope(value, aad, "value");
         }
         return value;

--- a/server/src/main/java/com/epam/aidial/core/server/security/ResourceSecretAad.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/ResourceSecretAad.java
@@ -1,0 +1,27 @@
+package com.epam.aidial.core.server.security;
+
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Derives the additional authenticated data that binds an encrypted field to the resource holding it.
+ *
+ * <p>The AAD is the resource's physical path, so ciphertext is only readable at the path it was written
+ * to: re-addressing a resource without re-encrypting it makes its secrets unrecoverable. Anything that
+ * moves encrypted resources has to decrypt with the source path and encrypt with the destination one,
+ * which is why the path overload exists alongside the descriptor one.
+ */
+public final class ResourceSecretAad {
+
+    private ResourceSecretAad() {
+    }
+
+    public static byte[] deriveFor(ResourceDescriptor descriptor) {
+        return deriveFor(descriptor.getAbsoluteFilePath());
+    }
+
+    public static byte[] deriveFor(String absoluteFilePath) {
+        return absoluteFilePath.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/service/BackgroundJobService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/BackgroundJobService.java
@@ -16,6 +16,7 @@ import com.epam.aidial.core.server.limiter.RateLimiter;
 import com.epam.aidial.core.server.log.AnalyticsLogContext;
 import com.epam.aidial.core.server.log.LogStore;
 import com.epam.aidial.core.server.security.ApiKeyStore;
+import com.epam.aidial.core.server.security.ResourceSecretAad;
 import com.epam.aidial.core.server.token.TokenStatsTracker;
 import com.epam.aidial.core.server.token.TokenUsage;
 import com.epam.aidial.core.server.token.UsagePerModel;
@@ -274,14 +275,14 @@ public class BackgroundJobService {
 
     private String encryptKey(ResourceDescriptor descriptor, String key) {
         BucketInfo bucketInfo = new BucketInfo(descriptor.getBucketName(), descriptor.getBucketLocation());
-        byte[] aad = descriptor.getAbsoluteFilePath().getBytes(StandardCharsets.UTF_8);
+        byte[] aad = ResourceSecretAad.deriveFor(descriptor);
         byte[] cipher = encryptionService.encrypt(bucketInfo, key.getBytes(StandardCharsets.UTF_8), aad);
         return Base64.getEncoder().encodeToString(cipher);
     }
 
     private String decryptKey(ResourceDescriptor descriptor, String key) {
         BucketInfo bucketInfo = new BucketInfo(descriptor.getBucketName(), descriptor.getBucketLocation());
-        byte[] aad = descriptor.getAbsoluteFilePath().getBytes(StandardCharsets.UTF_8);
+        byte[] aad = ResourceSecretAad.deriveFor(descriptor);
         byte[] raw = Base64.getDecoder().decode(key);
         return new String(encryptionService.decrypt(bucketInfo, raw, aad), StandardCharsets.UTF_8);
     }

--- a/server/src/test/java/com/epam/aidial/core/server/security/ResourceSecretAadTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/security/ResourceSecretAadTest.java
@@ -1,0 +1,37 @@
+package com.epam.aidial.core.server.security;
+
+import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import com.epam.aidial.core.storage.resource.ResourceTypes;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ResourceSecretAadTest {
+
+    private static final ResourceDescriptor RESOURCE = new ResourceDescriptor(ResourceTypes.APPLICATION, "app",
+            List.of("catalog"), "bucket", "Users/u1/", false);
+
+    @Test
+    public void testAadIsResourcePath() {
+        assertArrayEquals("Users/u1/applications/catalog/app".getBytes(StandardCharsets.UTF_8),
+                ResourceSecretAad.deriveFor(RESOURCE));
+    }
+
+    @Test
+    public void testDescriptorAndPathAgree() {
+        assertArrayEquals(ResourceSecretAad.deriveFor(RESOURCE.getAbsoluteFilePath()),
+                ResourceSecretAad.deriveFor(RESOURCE));
+    }
+
+    @Test
+    public void testDifferentPathsProduceDifferentAad() {
+        byte[] legacy = ResourceSecretAad.deriveFor("Users/u1/applications/catalog/app");
+        byte[] tenantRooted = ResourceSecretAad.deriveFor(".org/default/.users/u1/.applications/catalog/app");
+
+        assertFalse(java.util.Arrays.equals(legacy, tenantRooted));
+    }
+}


### PR DESCRIPTION
Part 2 of 2 for #1863. Part 1 is #1866.

## Why

Encrypted fields are bound to the resource's **physical path**: the path is the AES-GCM additional authenticated data. AAD has to match byte for byte at decrypt, so a re-addressed resource is not stale — its secrets are **unopenable**, and unrecoverable without the old path.

That affects config secrets (`SecretFieldProcessor`), external-service credentials, and background-job payloads. Five call sites derived the AAD inline, which made the coupling invisible.

## What

`ResourceSecretAad` — one named place the AAD comes from, with two overloads:

- `deriveFor(ResourceDescriptor)` — what the five sites use today.
- `deriveFor(String absoluteFilePath)` — so a caller that **moves** an encrypted resource can decrypt with the source path and encrypt with the destination one.

## Invariant

Same bytes as before; no behaviour change. `ResourceSecretAadTest` asserts the descriptor and path forms agree, and that different paths produce different AAD.

## Notes for review

This is a prerequisite for migrating encrypted resources, not the migration itself. Two things are deliberately **not** here:

- The **key** axis is untouched — `CredentialEncryptionService` still resolves the CEK internally, so this does not enable key rotation.
- The three services still derive the AAD at their public entry points; path-accepting entry points would be needed before a migrator can drive both sides.

Both belong in the migration work, with their own review.
