### PR TITLE
feat: support baseUrl and mode in deployment interfaces config

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Application.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Application.java
@@ -179,6 +179,7 @@ public class Application extends Deployment {
         this.setInvalid(source.getInvalid());
         this.setName(source.getName());
         this.setEndpoint(source.getEndpoint());
+        this.setBaseUrl(source.getBaseUrl());
         this.setInterfaces(source.getInterfaces());
         this.setDisplayName(source.getDisplayName());
         this.setDisplayVersion(source.getDisplayVersion());

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -18,6 +18,14 @@ public abstract class Deployment extends RoleBasedEntity {
     private String endpoint;
     private String responsesEndpoint;
     /**
+     * Source (adapter) root shared by every {@link #interfaces} entry declaring no {@code base_url} of its
+     * own — in the common case one adapter serves all of them and only the ingress path differs. It stands
+     * for no interface by itself: {@code interfaces} alone says which ones the deployment serves.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonAlias({"baseUrl", "base_url"})
+    private String baseUrl;
+    /**
      * Supported LLM API interfaces keyed by interface-type value. Peer of endpoint/responsesEndpoint.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -18,9 +18,9 @@ public abstract class Deployment extends RoleBasedEntity {
     private String endpoint;
     private String responsesEndpoint;
     /**
-     * Source (adapter) root shared by every {@link #interfaces} entry declaring no {@code base_url} of its
-     * own — in the common case one adapter serves all of them and only the ingress path differs. It stands
-     * for no interface by itself: {@code interfaces} alone says which ones the deployment serves.
+     * Root url shared by every {@link #interfaces} entry declaring no {@code base_url} of its own — in the
+     * common case a single root serves all of them and only the ingress path differs. It stands for no
+     * interface by itself: {@code interfaces} alone says which ones the deployment serves.
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonAlias({"baseUrl", "base_url"})

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -1,10 +1,10 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
@@ -13,14 +13,23 @@ import java.util.Map;
  * future per-interface options (auth mode, defaults, ...) go here.
  */
 @Data
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DeploymentInterface {
 
     /**
-     * Source (adapter) root the matching ingress path is appended to at request time.
+     * Source (adapter) root the matching ingress path is appended to at request time. Optional: an entry
+     * declaring none is served by the deployment-level {@link Deployment#getBaseUrl()}.
      */
     @JsonProperty("base_url")
+    @JsonAlias({"baseUrl", "base_url"})
     private String baseUrl;
+
+    /**
+     * Whether the interface is forwarded as it arrived or translated first. Absent means
+     * {@link InterfaceMode#PASSTHROUGH}, which is what every pre-{@code mode} config is.
+     */
+    private InterfaceMode mode;
 
     /**
      * Headers added to a request for this interface that carries none under that name, laid over the
@@ -30,15 +39,7 @@ public class DeploymentInterface {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> defaultHeaders = Map.of();
 
-    @JsonCreator
-    public DeploymentInterface(
-            @JsonProperty(value = "base_url", required = true)
-            @JsonAlias({"baseUrl", "base_url"})
-            String baseUrl
-    ) {
-        if (baseUrl == null || baseUrl.isEmpty()) {
-            throw new IllegalArgumentException("baseUrl cannot be null or empty");
-        }
+    public DeploymentInterface(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -18,8 +18,8 @@ import java.util.Map;
 public class DeploymentInterface {
 
     /**
-     * Source (adapter) root the matching ingress path is appended to at request time. Optional: an entry
-     * declaring none is served by the deployment-level {@link Deployment#getBaseUrl()}.
+     * Root url the matching ingress path is appended to at request time. Optional: an entry declaring
+     * none is served by the deployment-level {@link Deployment#getBaseUrl()}.
      */
     @JsonProperty("base_url")
     @JsonAlias({"baseUrl", "base_url"})

--- a/config/src/main/java/com/epam/aidial/core/config/InterfaceMode.java
+++ b/config/src/main/java/com/epam/aidial/core/config/InterfaceMode.java
@@ -1,0 +1,26 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+/**
+ * How a deployment serves one {@link InterfaceType}: the request is forwarded in the shape it arrived in,
+ * or handed to a translator that converts it to an API the deployment does speak.
+ */
+@Getter
+public enum InterfaceMode {
+
+    PASSTHROUGH("passthrough"),
+    /**
+     * The translator calls Core back with the converted request, so the completion is served — and its
+     * tokens counted towards limits — by that inner request rather than this one.
+     */
+    TRANSLATOR("translator");
+
+    @JsonValue
+    private final String value;
+
+    InterfaceMode(String value) {
+        this.value = value;
+    }
+}

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -11,7 +11,6 @@ import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -23,9 +22,73 @@ public class DeploymentTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
-    void baseUrlIsRequired() {
-        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface(null));
-        assertThrows(IllegalArgumentException.class, () -> new DeploymentInterface(""));
+    void interfaceParsesWithoutBaseUrl() throws Exception {
+        String json = """
+                {
+                    "baseUrl": "http://adapter",
+                    "interfaces": {
+                        "openaiChatCompletions": {"mode": "passthrough"},
+                        "anthropicMessages": {"mode": "translator", "base_url": "http://translator"}
+                    }
+                }
+                """;
+        Model model = MAPPER.readValue(json, Model.class);
+
+        assertEquals("http://adapter", model.getBaseUrl());
+        // the deployment-level base url is not copied into the entry: it is resolved per request
+        assertNull(model.getInterfaces().get(OPENAI_CHAT_COMPLETIONS.getValue()).getBaseUrl());
+        assertEquals(InterfaceMode.PASSTHROUGH, model.getInterfaces().get(OPENAI_CHAT_COMPLETIONS.getValue()).getMode());
+        assertEquals("http://translator", model.getInterfaces().get(ANTHROPIC_MESSAGES.getValue()).getBaseUrl());
+        assertEquals(InterfaceMode.TRANSLATOR, model.getInterfaces().get(ANTHROPIC_MESSAGES.getValue()).getMode());
+    }
+
+    @Test
+    void interfaceMappedToNullParses() throws Exception {
+        String json = """
+                {
+                    "baseUrl": "http://adapter",
+                    "interfaces": {
+                        "openaiChatCompletions": {},
+                        "openaiResponses": null
+                    }
+                }
+                """;
+        Model model = MAPPER.readValue(json, Model.class);
+
+        // an explicit null declares the interface unsupported, exactly as leaving it out does
+        assertTrue(model.getInterfaces().containsKey(OPENAI_RESPONSES.getValue()));
+        assertNull(model.getInterfaces().get(OPENAI_RESPONSES.getValue()));
+        assertNull(model.getInterfaces().get(OPENAI_CHAT_COMPLETIONS.getValue()).getMode());
+    }
+
+    @Test
+    void modeIsOmittedWhenAbsentAndBaseUrlKeepsItsSnakeCaseName() throws Exception {
+        Model model = new Model();
+        model.setBaseUrl("http://adapter");
+        model.setInterfaces(Map.of(OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://responses-adapter")));
+
+        String json = MAPPER.writeValueAsString(model);
+
+        assertTrue(json.contains("\"base_url\":\"http://responses-adapter\""), json);
+        assertTrue(json.contains("\"baseUrl\":\"http://adapter\""), json);
+        assertFalse(json.contains("\"mode\""), json);
+    }
+
+    @Test
+    void baseUrlIsOmittedWhenUnset() throws Exception {
+        Model model = new Model();
+        model.setEndpoint("http://host/chat/completions");
+
+        assertFalse(MAPPER.writeValueAsString(model).contains("baseUrl"));
+    }
+
+    @Test
+    void applicationCopyConstructorPreservesBaseUrl() {
+        Application source = new Application();
+        source.setName("app1");
+        source.setBaseUrl("http://adapter");
+
+        assertEquals("http://adapter", new Application(source).getBaseUrl());
     }
 
     @Test

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -28,7 +28,7 @@ An object containing parameters for each [application](#applications).
 * `applications.<application_name>.applicationTypeSchemaId`: The identifier of a JSON schema that application is based upon. The shema ID must exist in the DIAL Core config property `applicationTypeSchemas`. Refer to [DIAL Documentation](https://docs.dialx.ai/platform/core/apps#application-types) to learn more about schema-rich apps.
 * `applications.<application_name>.applicationProperties`: Properties of a schema-rich application. Specified properties must conform to the JSON schema referenced by `applicationTypeSchemaId`. Refer to [DIAL Documentation](https://docs.dialx.ai/platform/core/apps#application-types) to learn more about schema-rich apps.
 * `endpoint`: The application's API endpoint for chat completion requests.
-* `baseUrl`: The application adapter root shared by every `interfaces` entry that declares no `base_url` of its own.
+* `baseUrl`: The root URL shared by every `interfaces` entry that declares no `base_url` of its own.
 * `interfaces`: A typed alternative to the flat `endpoint` field for declaring the routing target. For applications, only the `openaiChatCompletions` interface is supported; the Responses API and other interfaces are not. Refer to [applications.<application_name>.interfaces](#applicationsapplication_nameinterfaces).
 * `overrideName`: If set, the application is called under this name: the outgoing chat completion request body's `model` field (and the `X-DIAL-OVERRIDE-NAME` header) are rewritten to this value before the request reaches the application's endpoint. Doesn't change routing — only the value the endpoint receives.
 * `iconUrl`: A string with URL of the icon to display for the app in the UI.
@@ -155,7 +155,7 @@ Applications support only one interface type:
 
 Each value is an object with the following fields:
 
-* `base_url`: The application adapter root that the matching ingress path is appended to. Optional — the application-level `baseUrl` serves an entry that omits it.
+* `base_url`: The root URL that the matching ingress path is appended to. Optional — the application-level `baseUrl` serves an entry that omits it.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the application-level `defaultHeaders`. Refer to [applications.<application_name>.defaultHeaders](#applicationsapplication_namedefaultheaders).
 
 **Example**

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -28,6 +28,7 @@ An object containing parameters for each [application](#applications).
 * `applications.<application_name>.applicationTypeSchemaId`: The identifier of a JSON schema that application is based upon. The shema ID must exist in the DIAL Core config property `applicationTypeSchemas`. Refer to [DIAL Documentation](https://docs.dialx.ai/platform/core/apps#application-types) to learn more about schema-rich apps.
 * `applications.<application_name>.applicationProperties`: Properties of a schema-rich application. Specified properties must conform to the JSON schema referenced by `applicationTypeSchemaId`. Refer to [DIAL Documentation](https://docs.dialx.ai/platform/core/apps#application-types) to learn more about schema-rich apps.
 * `endpoint`: The application's API endpoint for chat completion requests.
+* `baseUrl`: The application adapter root shared by every `interfaces` entry that declares no `base_url` of its own.
 * `interfaces`: A typed alternative to the flat `endpoint` field for declaring the routing target. For applications, only the `openaiChatCompletions` interface is supported; the Responses API and other interfaces are not. Refer to [applications.<application_name>.interfaces](#applicationsapplication_nameinterfaces).
 * `overrideName`: If set, the application is called under this name: the outgoing chat completion request body's `model` field (and the `X-DIAL-OVERRIDE-NAME` header) are rewritten to this value before the request reaches the application's endpoint. Doesn't change routing — only the value the endpoint receives.
 * `iconUrl`: A string with URL of the icon to display for the app in the UI.
@@ -154,7 +155,7 @@ Applications support only one interface type:
 
 Each value is an object with the following fields:
 
-* `base_url`: The application adapter root that the matching ingress path is appended to.
+* `base_url`: The application adapter root that the matching ingress path is appended to. Optional — the application-level `baseUrl` serves an entry that omits it.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the application-level `defaultHeaders`. Refer to [applications.<application_name>.defaultHeaders](#applicationsapplication_namedefaultheaders).
 
 **Example**

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -34,6 +34,7 @@ An object containing deployed DIAL Interceptors and their [parameters](#intercep
 An object containing parameters for each [interceptor](#interceptors).
 
 * `endpoint`: The URL of the interceptor service. This URL is used to handle requests and responses for the interceptor. **Required** unless `interfaces` is used instead.
+* `baseUrl`: The interceptor service root shared by every `interfaces` entry that declares no `base_url` of its own.
 * `interfaces`: A typed alternative to the flat `endpoint` field for declaring the interceptor service target. For interceptors, only the `openaiChatCompletions` interface is supported; the Responses API and other interfaces are not. Refer to [interceptors.<interceptor_name>.interfaces](#interceptorsinterceptor_nameinterfaces).
 * `overrideName`: If set, the interceptor is called under this name: the outgoing chat completion request body's `model` field (and the `X-DIAL-OVERRIDE-NAME` header) are rewritten to this value before the request reaches the interceptor's endpoint. Only applied when the interceptor is invoked as part of a chat-completions request; interceptors are also invoked when processing Responses API requests, but that flow ignores `overrideName`. Doesn't change routing — only the value the endpoint receives.
 * `iconUrl`: A string with the URL with the icon location to display for the interceptor on UI.
@@ -62,7 +63,7 @@ Interceptors support only one interface type:
 
 Each value is an object with the following fields:
 
-* `base_url`: The interceptor service root that the matching ingress path is appended to.
+* `base_url`: The interceptor service root that the matching ingress path is appended to. Optional — the interceptor-level `baseUrl` serves an entry that omits it.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the interceptor-level `defaultHeaders`. Refer to [interceptors.<interceptor_name>.defaultHeaders](#interceptorsinterceptor_namedefaultheaders).
 
 **Example**

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -51,7 +51,7 @@ An object containing parameters for each [model](#models).
   DIAL Core rewrites upstream response IDs to stable `resp_dial_*` identifiers and uses sticky routing to ensure follow-up requests are forwarded to the same upstream instance that handled the original request. `previous_response_id`, conversations, prompts, and files are not supported.
 * `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API.
 * `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them, for every interface the model serves. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
-* `baseUrl`: The model adapter root shared by every `interfaces` entry that declares no `base_url` of its own. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
+* `baseUrl`: The root URL shared by every `interfaces` entry that declares no `base_url` of its own. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interfaces`: An alternative to the flat `endpoint`/`responsesEndpoint` fields for declaring routing targets, keyed by interface type. Both shapes are first-class — pick whichever you prefer per model. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interceptors`: A list of interceptors to be triggered for the given model. Refer to [Interceptors](https://github.com/epam/ai-dial/blob/main/docs/platform/3.core/6.interceptors.md) to learn more.
 * `fieldsHashingOrder`: **Deprecated, no longer has any effect.** It used to let `POST /openai/deployments/{deployment_name}/chat/completions` customize the order in which request components are hashed for upstream-cache pinning. DIAL Core now always uses a built-in, non-configurable order per interface, fixed by that API's wire format — the same mechanism `POST /anthropic/v1/messages` and `POST /openai/v1/responses` use:
@@ -157,7 +157,7 @@ The two shapes route differently:
 The base URL serving an interface is resolved in this order:
 
 1. `interfaces.<interface_type>.base_url`, when the entry declares one.
-2. The model-level `baseUrl`. Usually one adapter serves every interface and only the path differs (`/openai/deployments/{name}/chat/completions`, `/openai/v1/responses`, `/anthropic/v1/messages`), so declaring it once at the model level and listing the supported interfaces with no `base_url` of their own is enough; an entry that does declare one overrides it for that interface only.
+2. The model-level `baseUrl`. Usually a single root serves every interface and only the path differs (`/openai/deployments/{name}/chat/completions`, `/openai/v1/responses`, `/anthropic/v1/messages`), so declaring it once at the model level and listing the supported interfaces with no `base_url` of their own is enough; an entry that does declare one overrides it for that interface only.
 3. `endpoint`/`responsesEndpoint`, for interface types the `interfaces` map does not declare at all.
 
 `interfaces` is the whitelist of what the model serves: a model-level `baseUrl` on its own declares no interface, and an interface listed with neither base URL is answered with `503`. If both `interfaces` and a legacy field are declared for the same interface type, `interfaces` takes precedence; the legacy field is left untouched in config and ignored for routing.
@@ -177,7 +177,7 @@ Only the interface types a model declares are reported in the `interfaces` array
 
 Each value is an object with the following fields:
 
-* `base_url`: The model adapter root that the matching ingress path is appended to. Optional — the model-level `baseUrl` serves an entry that omits it.
+* `base_url`: The root URL that the matching ingress path is appended to. Optional — the model-level `baseUrl` serves an entry that omits it.
 * `mode`: `passthrough` (default) or `translator`. It declares whether the request is forwarded in the shape it arrived in, or handed to a service that translates it into an API the model does speak. A `translator` interface does not charge its tokens to the model's [limits](#modelsmodel_namelimits): the translator calls DIAL Core back to have the completion served, and that inner request is what carries the usage to the limits, so charging both would count it twice.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the model-level `defaultHeaders`. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -51,6 +51,7 @@ An object containing parameters for each [model](#models).
   DIAL Core rewrites upstream response IDs to stable `resp_dial_*` identifiers and uses sticky routing to ensure follow-up requests are forwarded to the same upstream instance that handled the original request. `previous_response_id`, conversations, prompts, and files are not supported.
 * `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API.
 * `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them, for every interface the model serves. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
+* `baseUrl`: The model adapter root shared by every `interfaces` entry that declares no `base_url` of its own. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interfaces`: An alternative to the flat `endpoint`/`responsesEndpoint` fields for declaring routing targets, keyed by interface type. Both shapes are first-class — pick whichever you prefer per model. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interceptors`: A list of interceptors to be triggered for the given model. Refer to [Interceptors](https://github.com/epam/ai-dial/blob/main/docs/platform/3.core/6.interceptors.md) to learn more.
 * `fieldsHashingOrder`: **Deprecated, no longer has any effect.** It used to let `POST /openai/deployments/{deployment_name}/chat/completions` customize the order in which request components are hashed for upstream-cache pinning. DIAL Core now always uses a built-in, non-configurable order per interface, fixed by that API's wire format — the same mechanism `POST /anthropic/v1/messages` and `POST /openai/v1/responses` use:
@@ -151,9 +152,17 @@ An optional, typed alternative to the flat `endpoint`/`responsesEndpoint` fields
 The two shapes route differently:
 
 * `endpoint`/`responsesEndpoint` are forwarded **verbatim** — the configured URL is used as-is and the ingress path is not appended.
-* An `interfaces` entry declares a `base_url`, and DIAL Core forwards each request to `base_url` + **the exact ingress path it was received on** (e.g. `POST /openai/v1/responses` is routed to `<base_url>/openai/v1/responses`). A trailing slash on `base_url` is normalized.
+* An `interfaces` entry is served by a base URL, and DIAL Core forwards each request to that base URL + **the exact ingress path it was received on** (e.g. `POST /openai/v1/responses` is routed to `<base_url>/openai/v1/responses`). A trailing slash is normalized.
 
-If both `interfaces` and a legacy field are declared for the same interface type, `interfaces` takes precedence; the legacy field is left untouched in config and ignored for routing.
+The base URL serving an interface is resolved in this order:
+
+1. `interfaces.<interface_type>.base_url`, when the entry declares one.
+2. The model-level `baseUrl`. Usually one adapter serves every interface and only the path differs (`/openai/deployments/{name}/chat/completions`, `/openai/v1/responses`, `/anthropic/v1/messages`), so declaring it once at the model level and listing the supported interfaces with no `base_url` of their own is enough; an entry that does declare one overrides it for that interface only.
+3. `endpoint`/`responsesEndpoint`, for interface types the `interfaces` map does not declare at all.
+
+`interfaces` is the whitelist of what the model serves: a model-level `baseUrl` on its own declares no interface, and an interface listed with neither base URL is answered with `503`. If both `interfaces` and a legacy field are declared for the same interface type, `interfaces` takes precedence; the legacy field is left untouched in config and ignored for routing.
+
+An interface mapped to `null` reads exactly as an absent one — `"openaiResponses": null` documents that the model does not serve the Responses API.
 
 Supported interface types for models:
 
@@ -168,7 +177,8 @@ Only the interface types a model declares are reported in the `interfaces` array
 
 Each value is an object with the following fields:
 
-* `base_url`: The model adapter root that the matching ingress path is appended to.
+* `base_url`: The model adapter root that the matching ingress path is appended to. Optional — the model-level `baseUrl` serves an entry that omits it.
+* `mode`: `passthrough` (default) or `translator`. It declares whether the request is forwarded in the shape it arrived in, or handed to a service that translates it into an API the model does speak. A `translator` interface does not charge its tokens to the model's [limits](#modelsmodel_namelimits): the translator calls DIAL Core back to have the completion served, and that inner request is what carries the usage to the limits, so charging both would count it twice.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the model-level `defaultHeaders`. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
 
 **Example**
@@ -180,6 +190,19 @@ Each value is an object with the following fields:
         "interfaces": {
             "openaiChatCompletions": { "base_url": "http://localhost:7005" },
             "openaiResponses": { "base_url": "http://localhost:7005" }
+        }
+    },
+    "openai-gpt-5.4-mini": {
+        "type": "chat",
+        "overrideName": "gpt-5.4-mini",
+        "baseUrl": "http://dial-openai-adapter",
+        "interfaces": {
+            "openaiChatCompletions": { "mode": "passthrough" },
+            "openaiResponses": null,
+            "anthropicMessages": {
+                "mode": "passthrough",
+                "base_url": "http://dial-bedrock-adapter"
+            }
         }
     },
     "text-embedding-3-small": {

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -13571,6 +13571,8 @@ components:
           type: string
         defaultHeaders:
           $ref: "#/components/schemas/MapStringString"
+        baseUrl:
+          type: string
     ApplicationData:
       type: object
       properties:
@@ -15025,6 +15027,8 @@ components:
           type: string
         defaultHeaders:
           $ref: "#/components/schemas/MapStringString"
+        mode:
+          $ref: "#/components/schemas/InterfaceMode"
     EmbeddingResponse:
       required:
       - data
@@ -15519,6 +15523,13 @@ components:
           type: string
         defaultHeaders:
           $ref: "#/components/schemas/MapStringString"
+        baseUrl:
+          type: string
+    InterfaceMode:
+      type: string
+      enum:
+      - PASSTHROUGH
+      - TRANSLATOR
     Invitation:
       type: object
       properties:
@@ -15929,6 +15940,8 @@ components:
           format: uri
         defaultHeaders:
           $ref: "#/components/schemas/MapStringString"
+        baseUrl:
+          type: string
     ModelData:
       type: object
       properties:
@@ -17013,6 +17026,8 @@ components:
           type: string
         defaultHeaders:
           $ref: "#/components/schemas/MapStringString"
+        baseUrl:
+          type: string
     ToolSetData:
       type: object
       properties:

--- a/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/BaseDeploymentPostController.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.controller;
 
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceMode;
 import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Pricing;
@@ -188,11 +189,8 @@ public class BaseDeploymentPostController {
                 tokenUsage = new TokenUsage();
             }
             context.setTokenUsage(tokenUsage);
-            String bucket = BucketBuilder.buildInitiatorBucket(context);
             TokenUsage usage = context.getTokenUsage();
-            return proxy.getRateLimiter().increase(
-                    context.getDeployment(), bucket, usage, context.getRequestBody(), context.getResponseBody(),
-                    interfaceType(), context.getPricingUsageNode())
+            return increaseLimits(usage)
                     .transform(result -> {
                         if (result.failed()) {
                             log.warn("Failed to increase limit", result.cause());
@@ -210,6 +208,23 @@ public class BaseDeploymentPostController {
         // capture it alongside whatever its descendant Model spans already reported.
         TokenUsage ownUsage = parseTokenUsage(responseBody);
         return trackDeploymentStats(context.getDeployment().getName(), ownUsage, true);
+    }
+
+    /**
+     * Charges the request's usage to the initiator's token and cost limits, unless the interface it arrived
+     * on is served by a translator: the translator calls Core back to have the completion served, and that
+     * inner request is what carries the usage to the limits. Charging here as well would count it twice.
+     */
+    private Future<Void> increaseLimits(TokenUsage usage) {
+        Deployment deployment = context.getDeployment();
+        InterfaceType type = interfaceType();
+        if (DeploymentEndpointUtil.resolveMode(deployment, type) == InterfaceMode.TRANSLATOR) {
+            return Future.succeededFuture();
+        }
+        return proxy.getRateLimiter().increase(
+                deployment, BucketBuilder.buildInitiatorBucket(context), usage,
+                context.getRequestBody(), context.getResponseBody(), type, context.getPricingUsageNode()
+        );
     }
 
     /**

--- a/server/src/main/java/com/epam/aidial/core/server/util/DeploymentEndpointUtil.java
+++ b/server/src/main/java/com/epam/aidial/core/server/util/DeploymentEndpointUtil.java
@@ -2,6 +2,7 @@ package com.epam.aidial.core.server.util;
 
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.DeploymentInterface;
+import com.epam.aidial.core.config.InterfaceMode;
 import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
@@ -18,6 +19,9 @@ import javax.annotation.Nullable;
  * advertises. A deployment carries two configuration shapes: the typed {@code interfaces} map, whose
  * {@code base_url} is a root the ingress path is appended to, and the pre-{@code interfaces} {@code endpoint}
  * and {@code responsesEndpoint} fields, which hold a complete url that already carries the route.
+ *
+ * <p>Within the map, the interface's own {@code base_url} wins over the deployment-level one, and the
+ * pre-{@code interfaces} fields are read only for a type the map does not declare.
  */
 @UtilityClass
 public class DeploymentEndpointUtil {
@@ -88,18 +92,44 @@ public class DeploymentEndpointUtil {
     }
 
     /**
-     * The {@code base_url} declared for the type, trailing slash stripped, or null when the type is not in
-     * the {@code interfaces} map.
+     * How the deployment serves the type. Both an interface declaring no {@code mode} and a type served by
+     * a pre-{@code interfaces} endpoint are {@link InterfaceMode#PASSTHROUGH}.
+     */
+    public InterfaceMode resolveMode(Deployment deployment, InterfaceType type) {
+        DeploymentInterface deploymentInterface = findInterface(deployment, type);
+        InterfaceMode mode = deploymentInterface == null ? null : deploymentInterface.getMode();
+        return mode == null ? InterfaceMode.PASSTHROUGH : mode;
+    }
+
+    /**
+     * The base url serving the type, trailing slash stripped: the interface's own {@code base_url}, the
+     * deployment-level {@code baseUrl} it falls back to, or null when the type is not in the
+     * {@code interfaces} map or neither declares one. A deployment-level {@code baseUrl} on its own serves
+     * nothing — an interface has to be declared to claim it.
      */
     @Nullable
     private String resolveInterfaceBaseUrl(Deployment deployment, InterfaceType type) {
-        Map<String, DeploymentInterface> interfaces = deployment.getInterfaces();
-        DeploymentInterface deploymentInterface = interfaces == null ? null : interfaces.get(type.getValue());
+        DeploymentInterface deploymentInterface = findInterface(deployment, type);
         if (deploymentInterface == null) {
             return null;
         }
-        String baseUrl = deploymentInterface.getBaseUrl();
+        String baseUrl = deploymentInterface.getBaseUrl() != null
+                ? deploymentInterface.getBaseUrl()
+                : deployment.getBaseUrl();
+        if (baseUrl == null) {
+            return null;
+        }
         return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    }
+
+    /**
+     * The {@code interfaces} entry for the type, or null when the map has none — an interface mapped to an
+     * explicit {@code null} reads the same as an absent one.
+     */
+    @Nullable
+    private DeploymentInterface findInterface(Deployment deployment, InterfaceType type) {
+        Map<String, DeploymentInterface> interfaces = deployment.getInterfaces();
+        return interfaces == null ? null : interfaces.get(type.getValue());
     }
 
     /**

--- a/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/DeploymentPostControllerTest.java
@@ -5,6 +5,7 @@ import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Features;
+import com.epam.aidial.core.config.InterfaceMode;
 import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
@@ -45,6 +46,9 @@ import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -744,6 +748,76 @@ public class DeploymentPostControllerTest {
         ArgumentCaptor<InterfaceType> interfaceTypeCaptor = ArgumentCaptor.forClass(InterfaceType.class);
         verify(rateLimiter).increase(eq(model), any(), any(), any(), any(), interfaceTypeCaptor.capture(), any());
         assertEquals(InterfaceType.OPENAI_EMBEDDINGS, interfaceTypeCaptor.getValue());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EnumSource(value = InterfaceMode.class, names = "PASSTHROUGH")
+    public void testHandleResponse_Model_PassthroughInterfaceIsCharged(InterfaceMode mode) {
+        Model model = new Model();
+        DeploymentInterface chatCompletions = new DeploymentInterface("http://adapter");
+        chatCompletions.setMode(mode);
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), chatCompletions));
+        when(context.getDeployment()).thenReturn(model);
+        when(context.getUserId()).thenReturn("test-user");
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(context.getResponse()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(HttpStatus.OK.getCode());
+        when(proxy.getRateLimiter()).thenReturn(rateLimiter);
+        when(proxy.getLogStore()).thenReturn(logStore);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
+        when(context.getResponseBody()).thenReturn(Buffer.buffer());
+        when(proxy.getTokenStatsTracker()).thenReturn(tokenStatsTracker);
+        when(rateLimiter.increase(any(), any(), any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(context.getRequest()).thenReturn(request);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.uri()).thenReturn("/test");
+        when(request.path()).thenReturn("/openai/deployments/name/chat/completions");
+        when(request.headers()).thenReturn(new HeadersMultiMap());
+        when(context.getProxyResponse()).thenReturn(mock(HttpClientResponse.class));
+        BufferingReadStream bufferingReadStream = mock(BufferingReadStream.class);
+
+        controller.handleResponse(bufferingReadStream);
+
+        // an interface declaring no mode is what every config written before mode existed is: still charged
+        verify(rateLimiter).increase(
+                eq(model), any(), any(), any(), any(), eq(InterfaceType.OPENAI_CHAT_COMPLETIONS), any());
+    }
+
+    @Test
+    public void testHandleResponse_Model_TranslatedInterfaceIsNotCharged() {
+        Model model = new Model();
+        DeploymentInterface translated = new DeploymentInterface("http://translator");
+        translated.setMode(InterfaceMode.TRANSLATOR);
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), translated));
+        when(context.getDeployment()).thenReturn(model);
+        when(context.getUserId()).thenReturn("test-user");
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(context.getResponse()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(HttpStatus.OK.getCode());
+        when(proxy.getLogStore()).thenReturn(logStore);
+        UpstreamRoute upstreamRoute = mock(UpstreamRoute.class, RETURNS_DEEP_STUBS);
+        when(context.getUpstreamRoute()).thenReturn(upstreamRoute);
+        when(context.getResponseBody()).thenReturn(Buffer.buffer());
+        when(proxy.getTokenStatsTracker()).thenReturn(tokenStatsTracker);
+        when(context.getRequest()).thenReturn(request);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.uri()).thenReturn("/test");
+        when(request.path()).thenReturn("/openai/deployments/name/chat/completions");
+        when(request.headers()).thenReturn(new HeadersMultiMap());
+        when(context.getProxyResponse()).thenReturn(mock(HttpClientResponse.class));
+        BufferingReadStream bufferingReadStream = mock(BufferingReadStream.class);
+
+        controller.handleResponse(bufferingReadStream);
+
+        // the translator calls Core back for the completion; that inner request carries the usage to limits
+        verify(rateLimiter, never()).increase(any(), any(), any(), any(), any(), any(), any());
+        verify(context).setTokenUsage(any(TokenUsage.class));
+        verify(logStore).save(any(AnalyticsLogContext.class));
+        verify(bufferingReadStream).end(response);
     }
 
     @Test

--- a/server/src/test/java/com/epam/aidial/core/server/util/DeploymentEndpointUtilTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/util/DeploymentEndpointUtilTest.java
@@ -3,6 +3,7 @@ package com.epam.aidial.core.server.util;
 import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.DeploymentInterface;
 import com.epam.aidial.core.config.Interceptor;
+import com.epam.aidial.core.config.InterfaceMode;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.ModelType;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
 import static com.epam.aidial.core.config.InterfaceType.OPENAI_EMBEDDINGS;
 import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static com.epam.aidial.core.server.util.DeploymentEndpointUtil.isInterfaceDeclared;
+import static com.epam.aidial.core.server.util.DeploymentEndpointUtil.resolveMode;
 import static com.epam.aidial.core.server.util.DeploymentEndpointUtil.resolveRequestUri;
 import static com.epam.aidial.core.server.util.DeploymentEndpointUtil.resolveResponsesBaseUri;
 import static com.epam.aidial.core.server.util.DeploymentEndpointUtil.resolveServingEndpoint;
@@ -54,6 +56,71 @@ public class DeploymentEndpointUtilTest {
 
         assertEquals("http://adapter:5000", resolveServingEndpoint(model, OPENAI_CHAT_COMPLETIONS));
         assertTrue(isInterfaceDeclared(model, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void interfacesFallBackToTheDeploymentBaseUrl() {
+        Model model = new Model();
+        model.setBaseUrl("http://adapter:5000/");
+        model.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface(),
+                OPENAI_RESPONSES.getValue(), new DeploymentInterface()));
+
+        assertEquals("http://adapter:5000", resolveServingEndpoint(model, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://adapter:5000", resolveServingEndpoint(model, OPENAI_RESPONSES));
+        assertTrue(isInterfaceDeclared(model, OPENAI_CHAT_COMPLETIONS));
+        assertTrue(isInterfaceDeclared(model, OPENAI_RESPONSES));
+    }
+
+    @Test
+    void interfaceBaseUrlOverridesTheDeploymentOne() {
+        Model model = new Model();
+        model.setBaseUrl("http://openai-adapter");
+        model.setInterfaces(Map.of(
+                OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface(),
+                ANTHROPIC_MESSAGES.getValue(), new DeploymentInterface("http://bedrock-adapter/")));
+
+        assertEquals("http://openai-adapter", resolveServingEndpoint(model, OPENAI_CHAT_COMPLETIONS));
+        assertEquals("http://bedrock-adapter", resolveServingEndpoint(model, ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void deploymentBaseUrlServesOnlyDeclaredInterfaces() {
+        Model model = new Model();
+        model.setBaseUrl("http://adapter");
+        model.setEndpoint("http://legacy/chat/completions");
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new DeploymentInterface()));
+
+        // interfaces is the whitelist; a base url alone declares nothing
+        assertNull(resolveServingEndpoint(model, OPENAI_RESPONSES));
+        assertFalse(isInterfaceDeclared(model, OPENAI_RESPONSES));
+        // an undeclared type still reads the legacy field, which the base url never stands in for
+        assertEquals("http://legacy/chat/completions", resolveServingEndpoint(model, OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void interfaceWithoutAnyBaseUrlIsNotServed() {
+        Model model = new Model();
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new DeploymentInterface()));
+
+        assertNull(resolveServingEndpoint(model, ANTHROPIC_MESSAGES));
+        assertFalse(isInterfaceDeclared(model, ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void modeDefaultsToPassthrough() {
+        Model model = new Model();
+        model.setEndpoint("http://legacy/chat/completions");
+        DeploymentInterface translated = new DeploymentInterface("http://translator");
+        translated.setMode(InterfaceMode.TRANSLATOR);
+        model.setInterfaces(Map.of(
+                OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter"),
+                ANTHROPIC_MESSAGES.getValue(), translated));
+
+        assertEquals(InterfaceMode.TRANSLATOR, resolveMode(model, ANTHROPIC_MESSAGES));
+        // declared without a mode, and served by the legacy endpoint, are both pass-through
+        assertEquals(InterfaceMode.PASSTHROUGH, resolveMode(model, OPENAI_RESPONSES));
+        assertEquals(InterfaceMode.PASSTHROUGH, resolveMode(model, OPENAI_CHAT_COMPLETIONS));
     }
 
     @Test


### PR DESCRIPTION
### Description of changes

Deployment-level counterpart of #1864: a `baseUrl` on the deployment, and a `mode` on each `interfaces` entry.

- **`baseUrl` on the deployment** — the adapter root shared by every `interfaces` entry that declares no `base_url` of its own. In most pass-through cases one adapter serves every interface and only the path differs (`/openai/deployments/{name}/chat/completions`, `/openai/v1/responses`, `/anthropic/v1/messages`), so the supported interfaces can simply be listed with no url each.
- **`interfaces.<type>.base_url` is now optional** and overrides the deployment-level one for that interface only. A base url is resolved as: interface `base_url` → deployment `baseUrl` → legacy `endpoint`/`responsesEndpoint`.
- **`interfaces` stays the whitelist.** A deployment `baseUrl` on its own declares no interface, and an entry with no base url at either level is neither served (503) nor advertised in `/v1/deployments`. An interface mapped to `null` reads exactly like an absent one.
- **`mode`: `passthrough` | `translator`** — makes explicit whether the interface is forwarded as it arrived or handed to a translator. Absent means `passthrough` and is omitted from serialized config, so every config written before this keeps its behaviour and is not rewritten on round-trip.
- **A `translator` interface does not charge its tokens to limits.** The translator calls Core back to have the completion served, and that inner request already carries the usage to the same initiator bucket, so charging both would count it twice.

```json
{
  "models": {
    "openai-gpt-5.4-mini": {
      "overrideName": "gpt-5.4-mini",
      "type": "chat",
      "baseUrl": "http://dial-openai-adapter/",
      "interfaces": {
        "openaiChatCompletions": { "mode": "passthrough" },
        "openaiResponses": null,
        "anthropicMessages": {
          "mode": "passthrough",
          "baseUrl": "http://dial-bedrock-adapter/"
        }
      },
      "upstreams": []
    }
  }
}
```

The root-level `translators` config and the per-interface `translator` field are **not** part of this PR. When they land, translator routing slots into the resolution chain between the deployment-`baseUrl` fallback and the legacy fallback, and `isInterfaceDeclared` needs the same branch so translated interfaces stay visible in the deployment listing.

Docs updated: `docs/dynamic-settings/models.md` (resolution order, `baseUrl`, `mode`, example), plus the inherited `baseUrl` in `applications.md` and `interceptors.md`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass — `DeploymentEndpointUtilTest` (+5 cases), `DeploymentTest` (+5), `DeploymentPostControllerTest` (+3: translator not charged, passthrough charged with and without an explicit mode), full `./gradlew test` suite, checkstyle clean

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.