### PR TITLE
feat: support Anthropic models listing #1876

### DIFF
--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -267,6 +267,88 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorData"
+  /anthropic/v1/models:
+    get:
+      tags:
+      - Deployment listing
+      summary: /anthropic/v1/models
+      operationId: getAnthropicModels
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnthropicModelListData"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+      parameters:
+      - name: after_id
+        in: query
+        description: ID of the model to use as a cursor; returns the page immediately after it.
+        required: false
+        schema:
+          type: string
+      - name: before_id
+        in: query
+        description: ID of the model to use as a cursor; returns the page immediately before it.
+        required: false
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Number of items to return per page. Defaults to 20. Ranges from 1 to 1000.
+        required: false
+        schema:
+          type: integer
+      - name: anthropic-beta
+        in: header
+        description: Optional beta feature opt-in header(s); DIAL accepts and ignores it for this endpoint.
+        required: false
+        schema:
+          type: string
+  /anthropic/v1/models/{model_name}:
+    get:
+      tags:
+      - Deployment listing
+      summary: "/anthropic/v1/models/{model_name}"
+      operationId: getAnthropicModel
+      parameters:
+      - name: model_name
+        in: path
+        description: The name of the model.
+        required: true
+        schema:
+          type: string
+      - name: anthropic-beta
+        in: header
+        description: Optional beta feature opt-in header(s); DIAL accepts and ignores it for this endpoint.
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnthropicModelData"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
   /openai/applications:
     get:
       tags:
@@ -13477,6 +13559,34 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/McpTool"
+    AnthropicModelData:
+      type: object
+      properties:
+        created_at:
+          type: string
+        display_name:
+          type: string
+        id:
+          type: string
+        type:
+          type: string
+        max_input_tokens:
+          type: integer
+        max_tokens:
+          type: integer
+    AnthropicModelListData:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnthropicModelData"
+        first_id:
+          type: string
+        has_more:
+          type: boolean
+        last_id:
+          type: string
     Application:
       type: object
       properties:

--- a/openapi-generator/src/main/java/com/epam/aidial/core/openapi/AnnotationEndpointCollector.java
+++ b/openapi-generator/src/main/java/com/epam/aidial/core/openapi/AnnotationEndpointCollector.java
@@ -50,6 +50,7 @@ import com.epam.aidial.core.server.controller.ToolSetRepairController;
 import com.epam.aidial.core.server.controller.ToolSetToolsController;
 import com.epam.aidial.core.server.controller.UploadFileController;
 import com.epam.aidial.core.server.controller.UserInfoController;
+import com.epam.aidial.core.server.controller.anthropic.AnthropicModelController;
 import com.epam.aidial.core.server.controller.anthropic.MessagesController;
 import com.epam.aidial.core.server.controller.anthropic.MessagesCountTokensController;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +67,7 @@ public final class AnnotationEndpointCollector {
             AdminApplyController.class,
             AdminHealthConfigController.class,
             AdminValidateController.class,
+            AnthropicModelController.class,
             ApplicationController.class,
             ApplicationMcpProxyController.class,
             McpResourceController.class,

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
@@ -5,6 +5,7 @@ import com.epam.aidial.core.config.Features;
 import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.config.MergedConfigStore;
+import com.epam.aidial.core.server.controller.anthropic.AnthropicModelController;
 import com.epam.aidial.core.server.controller.anthropic.MessagesController;
 import com.epam.aidial.core.server.controller.anthropic.MessagesCountTokensController;
 import com.epam.aidial.core.server.controller.route.ApplicationRouteController;
@@ -104,6 +105,15 @@ public class ControllerSelector {
         });
         get(RouteTemplate.MODELS, (proxy, context, pathMatcher) -> {
             ModelController controller = new ModelController(context);
+            return controller::getModels;
+        });
+        get(RouteTemplate.LLM_ANTHROPIC_MODEL, (proxy, context, pathMatcher) -> {
+            AnthropicModelController controller = new AnthropicModelController(context);
+            String modelId = UrlUtil.decodePath(pathMatcher.group(1));
+            return () -> controller.getModel(modelId);
+        });
+        get(RouteTemplate.LLM_ANTHROPIC_MODELS, (proxy, context, pathMatcher) -> {
+            AnthropicModelController controller = new AnthropicModelController(context);
             return controller::getModels;
         });
         get(RouteTemplate.APPLICATION, (proxy, context, pathMatcher) -> {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/AnthropicModelController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/anthropic/AnthropicModelController.java
@@ -1,0 +1,193 @@
+package com.epam.aidial.core.server.controller.anthropic;
+
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Model;
+import com.epam.aidial.core.config.TokenLimits;
+import com.epam.aidial.core.openapi.annotations.ApiOperation;
+import com.epam.aidial.core.openapi.annotations.ApiParameter;
+import com.epam.aidial.core.openapi.annotations.ApiResponse;
+import com.epam.aidial.core.openapi.annotations.ApiSchema;
+import com.epam.aidial.core.openapi.annotations.OpenApiDescriptions;
+import com.epam.aidial.core.openapi.annotations.ParameterIn;
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.anthropic.AnthropicModelData;
+import com.epam.aidial.core.server.data.anthropic.AnthropicModelListData;
+import com.epam.aidial.core.server.util.DeploymentEndpointUtil;
+import com.epam.aidial.core.storage.http.HttpStatus;
+import io.vertx.core.Future;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Anthropic-compatible models listing, scoped to the models that actually serve the
+ * {@link InterfaceType#ANTHROPIC_MESSAGES} interface (i.e. are reachable via {@link MessagesController}).
+ * Mirrors {@link com.epam.aidial.core.server.controller.ModelController}, shaped like Anthropic's
+ * <a href="https://platform.claude.com/docs/en/api/models/list">models list API</a>.
+ */
+@RequiredArgsConstructor
+public class AnthropicModelController {
+
+    private static final long DEFAULT_CREATED_AT_SECONDS = 1672534800L;
+    private static final int DEFAULT_PAGE_LIMIT = 20;
+    private static final int MIN_PAGE_LIMIT = 1;
+    private static final int MAX_PAGE_LIMIT = 1000;
+
+    private final ProxyContext context;
+
+    @ApiOperation(
+            method = "GET",
+            path = "/anthropic/v1/models/{model_name}",
+            operationId = "getAnthropicModel",
+            tags = {"Deployment listing"},
+            parameters = {
+                    @ApiParameter(name = "model_name", in = ParameterIn.PATH, required = true,
+                            description = OpenApiDescriptions.MODEL_NAME),
+                    @ApiParameter(name = "anthropic-beta", in = ParameterIn.HEADER, required = false,
+                            description = "Optional beta feature opt-in header(s); DIAL accepts and ignores it for this endpoint.")
+            },
+            responses = {
+                    @ApiResponse(code = 200, description = "Success", body = @ApiSchema(implementation = AnthropicModelData.class)),
+                    @ApiResponse(code = 403),
+                    @ApiResponse(code = 404)
+            }
+    )
+    public Future<?> getModel(String modelId) {
+        Config config = context.getConfig();
+        Model model = config.getModels().get(modelId);
+
+        if (model == null || !DeploymentEndpointUtil.isInterfaceDeclared(model, InterfaceType.ANTHROPIC_MESSAGES)) {
+            return context.respond(HttpStatus.NOT_FOUND);
+        }
+
+        if (!model.hasAccess(context.getUserRoles())) {
+            return context.respond(HttpStatus.FORBIDDEN);
+        }
+
+        AnthropicModelData data = createModel(model, config.getDefaultLocale());
+        return context.respond(HttpStatus.OK, data);
+    }
+
+    @ApiOperation(
+            method = "GET",
+            path = "/anthropic/v1/models",
+            operationId = "getAnthropicModels",
+            tags = {"Deployment listing"},
+            parameters = {
+                    @ApiParameter(name = "after_id", in = ParameterIn.QUERY, required = false,
+                            description = "ID of the model to use as a cursor; returns the page immediately after it."),
+                    @ApiParameter(name = "before_id", in = ParameterIn.QUERY, required = false,
+                            description = "ID of the model to use as a cursor; returns the page immediately before it."),
+                    @ApiParameter(name = "limit", in = ParameterIn.QUERY, required = false, schema = Integer.class,
+                            description = "Number of items to return per page. Defaults to 20. Ranges from 1 to 1000."),
+                    @ApiParameter(name = "anthropic-beta", in = ParameterIn.HEADER, required = false,
+                            description = "Optional beta feature opt-in header(s); DIAL accepts and ignores it for this endpoint.")
+            },
+            responses = {
+                    @ApiResponse(code = 200, description = "Success", body = @ApiSchema(implementation = AnthropicModelListData.class)),
+                    @ApiResponse(code = 400)
+            }
+    )
+    public Future<?> getModels() {
+        Config config = context.getConfig();
+        List<AnthropicModelData> models = new ArrayList<>();
+
+        for (Model model : config.getModels().values()) {
+            if (model.hasAccess(context.getUserRoles())
+                    && DeploymentEndpointUtil.isInterfaceDeclared(model, InterfaceType.ANTHROPIC_MESSAGES)) {
+                models.add(createModel(model, config.getDefaultLocale()));
+            }
+        }
+
+        String afterId = context.getRequest().getParam("after_id");
+        String beforeId = context.getRequest().getParam("before_id");
+
+        if (afterId != null && beforeId != null) {
+            return context.respond(HttpStatus.BAD_REQUEST, "Only one of after_id or before_id may be provided");
+        }
+
+        int limit;
+        try {
+            limit = Integer.parseInt(context.getRequest().getParam("limit", String.valueOf(DEFAULT_PAGE_LIMIT)));
+        } catch (NumberFormatException e) {
+            return context.respond(HttpStatus.BAD_REQUEST, "Limit must be an integer");
+        }
+        if (limit < MIN_PAGE_LIMIT || limit > MAX_PAGE_LIMIT) {
+            return context.respond(HttpStatus.BAD_REQUEST,
+                    "Limit is out of allowed range: [%d, %d]".formatted(MIN_PAGE_LIMIT, MAX_PAGE_LIMIT));
+        }
+
+        AnthropicModelListData list;
+        try {
+            list = paginate(models, afterId, beforeId, limit);
+        } catch (IllegalArgumentException e) {
+            return context.respond(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+
+        return context.respond(HttpStatus.OK, list);
+    }
+
+    private static AnthropicModelListData paginate(
+            List<AnthropicModelData> models, String afterId, String beforeId, int limit) {
+        AnthropicModelListData list = new AnthropicModelListData();
+        List<AnthropicModelData> page;
+        boolean hasMore;
+
+        if (afterId != null) {
+            int cursor = indexOf(models, afterId, "after_id");
+            int from = cursor + 1;
+            int to = Math.min(from + limit, models.size());
+            page = models.subList(from, to);
+            hasMore = to < models.size();
+        } else if (beforeId != null) {
+            int cursor = indexOf(models, beforeId, "before_id");
+            int to = cursor;
+            int from = Math.max(to - limit, 0);
+            page = models.subList(from, to);
+            hasMore = from > 0;
+        } else {
+            int to = Math.min(limit, models.size());
+            page = models.subList(0, to);
+            hasMore = to < models.size();
+        }
+
+        list.setData(page);
+        list.setHasMore(hasMore);
+        if (!page.isEmpty()) {
+            list.setFirstId(page.get(0).getId());
+            list.setLastId(page.get(page.size() - 1).getId());
+        }
+        return list;
+    }
+
+    private static int indexOf(List<AnthropicModelData> models, String id, String paramName) {
+        for (int i = 0; i < models.size(); i++) {
+            if (models.get(i).getId().equals(id)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("Invalid " + paramName + ": model not found");
+    }
+
+    static AnthropicModelData createModel(Model model, String defaultLocale) {
+        AnthropicModelData data = new AnthropicModelData();
+        data.setId(model.getName());
+        data.setDisplayName(model.getDisplayName() != null
+                ? model.getDisplayName().resolve(defaultLocale, defaultLocale)
+                : model.getName());
+
+        Long createdAt = model.getCreatedAt();
+        data.setCreatedAt(Instant.ofEpochSecond(createdAt != null ? createdAt : DEFAULT_CREATED_AT_SECONDS).toString());
+
+        TokenLimits limits = model.getLimits();
+        if (limits != null) {
+            data.setMaxInputTokens(limits.getMaxPromptTokens());
+            data.setMaxTokens(limits.getMaxCompletionTokens());
+        }
+
+        return data;
+    }
+}

--- a/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
@@ -19,6 +19,14 @@ public enum RouteTemplate {
             "^/+anthropic/v1/messages$",
             "/anthropic/v1/messages"
     ),
+    LLM_ANTHROPIC_MODEL(
+            "^/+anthropic/v1/models/(?<id>.+?)$",
+            "/anthropic/v1/models/{id}"
+    ),
+    LLM_ANTHROPIC_MODELS(
+            "^/+anthropic/v1/models$",
+            "/anthropic/v1/models"
+    ),
 
     // OpenAI API routes
     LLM_RESPONSES_API(

--- a/server/src/main/java/com/epam/aidial/core/server/data/anthropic/AnthropicModelData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/anthropic/AnthropicModelData.java
@@ -1,0 +1,18 @@
+package com.epam.aidial.core.server.data.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AnthropicModelData {
+    private String id;
+    private String type = "model";
+    private String displayName;
+    private String createdAt;
+    private Integer maxInputTokens;
+    private Integer maxTokens;
+}

--- a/server/src/main/java/com/epam/aidial/core/server/data/anthropic/AnthropicModelListData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/anthropic/AnthropicModelListData.java
@@ -1,0 +1,18 @@
+package com.epam.aidial.core.server.data.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AnthropicModelListData {
+    private List<AnthropicModelData> data = List.of();
+    private boolean hasMore = false;
+    private String firstId;
+    private String lastId;
+}

--- a/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ListingTest.java
@@ -9,9 +9,12 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Instant;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(VertxExtension.class)
 public class ListingTest extends ResourceBaseTest {
@@ -169,6 +172,145 @@ public class ListingTest extends ResourceBaseTest {
                     "custom_temperature_supported": true, "reasoning_efforts": []
                     }
                 """));
+    }
+
+    @Test
+    void testAnthropicModelsListing_includesOnlyAnthropicServableModels(Vertx vertx, VertxTestContext context) {
+        Consumer<String> checker = (str) -> {
+            JsonObject json = new JsonObject(str);
+            boolean foundClaude = false;
+            for (Object item : json.getJsonArray("data")) {
+                JsonObject elem = (JsonObject) item;
+                String id = elem.getString("id");
+                assertEquals("model", elem.getString("type"));
+                assertEquals(id, elem.getString("display_name"));
+                assertEquals(1672534800, Instant.parse(elem.getString("created_at")).getEpochSecond());
+                if (id.equals("claude-ns")) {
+                    foundClaude = true;
+                }
+                // an openai-only model must not be advertised under the anthropic listing
+                assertFalse(id.equals("test-model-v1"));
+            }
+            assertTrue(foundClaude);
+        };
+        checkResponse(vertx, context, "/anthropic/v1/models", checker);
+    }
+
+    @Test
+    void testAnthropicModel_notFoundForOpenAiOnlyModel(Vertx vertx, VertxTestContext context) {
+        WebClient client = WebClient.create(vertx);
+        client.get(serverPort, "localhost", "/anthropic/v1/models/test-model-v1")
+                .putHeader("Api-key", "proxyKey2")
+                .send(context.succeeding(response -> context.verify(() -> {
+                    assertEquals(404, response.statusCode());
+                    context.completeNow();
+                })));
+    }
+
+    @Test
+    void testAnthropicModel_okForAnthropicModel(Vertx vertx, VertxTestContext context) {
+        WebClient client = WebClient.create(vertx);
+        client.get(serverPort, "localhost", "/anthropic/v1/models/claude-ns")
+                .putHeader("Api-key", "proxyKey2")
+                .as(BodyCodec.jsonObject())
+                .send(context.succeeding(response -> context.verify(() -> {
+                    assertEquals(200, response.statusCode());
+                    assertEquals("claude-ns", response.body().getString("id"));
+                    assertEquals("model", response.body().getString("type"));
+                    context.completeNow();
+                })));
+    }
+
+    @Test
+    void testAnthropicModelsListing_limitTruncatesAndSetsHasMore(Vertx vertx, VertxTestContext context) {
+        Consumer<String> checker = (str) -> {
+            JsonObject json = new JsonObject(str);
+            assertEquals(1, json.getJsonArray("data").size());
+            String id = json.getJsonArray("data").getJsonObject(0).getString("id");
+            assertEquals("default-headers-model", id);
+            assertEquals(id, json.getString("first_id"));
+            assertEquals(id, json.getString("last_id"));
+            assertTrue(json.getBoolean("has_more"));
+        };
+        checkResponse(vertx, context, "/anthropic/v1/models?limit=1", checker);
+    }
+
+    @Test
+    void testAnthropicModelsListing_afterIdPaginatesForward(Vertx vertx, VertxTestContext context) {
+        Consumer<String> checker = (str) -> {
+            JsonObject json = new JsonObject(str);
+            assertEquals(2, json.getJsonArray("data").size());
+            assertEquals("claude-ns", json.getJsonArray("data").getJsonObject(0).getString("id"));
+            assertEquals("claude-stream", json.getJsonArray("data").getJsonObject(1).getString("id"));
+            assertEquals("claude-ns", json.getString("first_id"));
+            assertEquals("claude-stream", json.getString("last_id"));
+            assertTrue(json.getBoolean("has_more"));
+        };
+        checkResponse(vertx, context, "/anthropic/v1/models?after_id=default-headers-model&limit=2", checker);
+    }
+
+    @Test
+    void testAnthropicModelsListing_beforeIdPaginatesBackward(Vertx vertx, VertxTestContext context) {
+        Consumer<String> checker = (str) -> {
+            JsonObject json = new JsonObject(str);
+            assertEquals(2, json.getJsonArray("data").size());
+            assertEquals("default-headers-model", json.getJsonArray("data").getJsonObject(0).getString("id"));
+            assertEquals("claude-ns", json.getJsonArray("data").getJsonObject(1).getString("id"));
+            assertFalse(json.getBoolean("has_more"));
+        };
+        checkResponse(vertx, context, "/anthropic/v1/models?before_id=claude-stream&limit=2", checker);
+    }
+
+    @Test
+    void testAnthropicModelsListing_invalidLimitReturns400(Vertx vertx, VertxTestContext context) {
+        checkBadRequest(vertx, context, "/anthropic/v1/models?limit=abc");
+    }
+
+    @Test
+    void testAnthropicModelsListing_limitOutOfRangeReturns400(Vertx vertx, VertxTestContext context) {
+        checkBadRequest(vertx, context, "/anthropic/v1/models?limit=0");
+    }
+
+    @Test
+    void testAnthropicModelsListing_bothCursorsReturns400(Vertx vertx, VertxTestContext context) {
+        checkBadRequest(vertx, context, "/anthropic/v1/models?after_id=claude-ns&before_id=claude-stream");
+    }
+
+    @Test
+    void testAnthropicModelsListing_unknownCursorReturns400(Vertx vertx, VertxTestContext context) {
+        checkBadRequest(vertx, context, "/anthropic/v1/models?after_id=does-not-exist");
+    }
+
+    @Test
+    void testAnthropicModelsListing_mapsMaxInputTokensAndMaxTokens(Vertx vertx, VertxTestContext context) {
+        Consumer<String> checker = (str) -> {
+            JsonObject json = new JsonObject(str);
+            JsonObject limited = null;
+            JsonObject unlimited = null;
+            for (Object item : json.getJsonArray("data")) {
+                JsonObject elem = (JsonObject) item;
+                if (elem.getString("id").equals("claude-limited")) {
+                    limited = elem;
+                } else if (elem.getString("id").equals("claude-ns")) {
+                    unlimited = elem;
+                }
+            }
+            assertEquals(100000, limited.getInteger("max_input_tokens"));
+            assertEquals(8192, limited.getInteger("max_tokens"));
+            assertFalse(unlimited.containsKey("max_input_tokens"));
+            assertFalse(unlimited.containsKey("max_tokens"));
+        };
+        checkResponse(vertx, context, "/anthropic/v1/models", checker);
+    }
+
+    void checkBadRequest(Vertx vertx, VertxTestContext context, String uri) {
+        WebClient client = WebClient.create(vertx);
+        client.get(serverPort, "localhost", uri)
+                .putHeader("Api-key", "proxyKey2")
+                .send(context.succeeding(response -> context.verify(() -> {
+                    assertEquals(400, response.statusCode());
+                    context.completeNow();
+                })));
     }
 
     void checkResponse(Vertx vertx, VertxTestContext context, String uri, Consumer<String> checker) {

--- a/server/src/test/java/com/epam/aidial/core/server/controller/anthropic/AnthropicModelControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/anthropic/AnthropicModelControllerTest.java
@@ -1,0 +1,67 @@
+package com.epam.aidial.core.server.controller.anthropic;
+
+import com.epam.aidial.core.config.LocalizedValue;
+import com.epam.aidial.core.config.Model;
+import com.epam.aidial.core.config.TokenLimits;
+import com.epam.aidial.core.server.data.anthropic.AnthropicModelData;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AnthropicModelControllerTest {
+
+    @Test
+    void createModel_mapsIdAndDisplayNameAndCreatedAt() {
+        Model model = new Model();
+        model.setName("claude-3-5-sonnet");
+        model.setDisplayName(LocalizedValue.of("Claude 3.5 Sonnet"));
+        model.setCreatedAt(1_700_000_000L);
+
+        AnthropicModelData data = AnthropicModelController.createModel(model, "en");
+
+        assertEquals("claude-3-5-sonnet", data.getId());
+        assertEquals("model", data.getType());
+        assertEquals("Claude 3.5 Sonnet", data.getDisplayName());
+        assertEquals(Instant.ofEpochSecond(1_700_000_000L).toString(), data.getCreatedAt());
+    }
+
+    @Test
+    void createModel_fallsBackToNameAndDefaultCreatedAtWhenUnset() {
+        Model model = new Model();
+        model.setName("claude-3-haiku");
+
+        AnthropicModelData data = AnthropicModelController.createModel(model, "en");
+
+        assertEquals("claude-3-haiku", data.getDisplayName());
+        assertEquals(Instant.ofEpochSecond(1672534800L).toString(), data.getCreatedAt());
+    }
+
+    @Test
+    void createModel_mapsMaxInputTokensAndMaxTokensFromLimits() {
+        Model model = new Model();
+        model.setName("claude-limits");
+        TokenLimits limits = new TokenLimits();
+        limits.setMaxPromptTokens(100_000);
+        limits.setMaxCompletionTokens(8192);
+        model.setLimits(limits);
+
+        AnthropicModelData data = AnthropicModelController.createModel(model, "en");
+
+        assertEquals(100_000, data.getMaxInputTokens());
+        assertEquals(8192, data.getMaxTokens());
+    }
+
+    @Test
+    void createModel_omitsMaxInputTokensAndMaxTokensWhenLimitsUnset() {
+        Model model = new Model();
+        model.setName("claude-no-limits");
+
+        AnthropicModelData data = AnthropicModelController.createModel(model, "en");
+
+        assertNull(data.getMaxInputTokens());
+        assertNull(data.getMaxTokens());
+    }
+}

--- a/server/src/test/resources/aidial.config.json
+++ b/server/src/test/resources/aidial.config.json
@@ -234,7 +234,11 @@
     },
     "claude-limited": {
       "type": "chat",
-      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} }
+      "interfaces": { "anthropicMessages": {"base_url": "http://localhost:4848"} },
+      "limits": {
+        "maxPromptTokens": 100000,
+        "maxCompletionTokens": 8192
+      }
     },
     "claude-upstream": {
       "type": "chat",


### PR DESCRIPTION
Adds an Anthropic-compatible models listing endpoint so Anthropic-ecosystem plugins/clients can discover available models before calling `/anthropic/v1/messages`.

### Applicable issues

- fixes #1876

### Description of changes

- Added `GET /anthropic/v1/models` and `GET /anthropic/v1/models/{model_name}`, scoped to models that declare the `anthropicMessages` interface (the ones actually reachable via the existing `/anthropic/v1/messages` endpoint) and filtered by role access, mirroring the existing `ModelController` pattern.
- Response shaped like Anthropic's [Models List API](https://platform.claude.com/docs/en/api/models/list): `id`, `type`, `display_name`, `created_at`, `max_input_tokens`/`max_tokens` (mapped from DIAL's `TokenLimits.maxPromptTokens`/`maxCompletionTokens`), wrapped in `data`/`has_more`/`first_id`/`last_id`.
- Cursor pagination via `after_id`/`before_id`/`limit` query params, with `400` responses for an out-of-range/unparseable `limit`, both cursors given at once, or an unknown cursor id.
- Documented the optional `anthropic-beta` request header (accepted and ignored, same as `anthropic-version` is documented but not read today).
- `capabilities` is intentionally omitted — DIAL doesn't track most of Anthropic's per-model capability sub-fields (batch/citations/code_execution/context_management/etc.), so asserting `false` for them would be misleading.
- Regenerated `docs/open_api_core.yaml` to include the new endpoints.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.