### PR TITLE
fix: handle case when role limits are not set at all #1880

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/config/ConfigPostProcessor.java
@@ -390,8 +390,11 @@ public final class ConfigPostProcessor {
             Role role = entry.getValue();
             role.setName(name);
             log.debug("Start loading role `{}`", role.getName());
-            for (Map.Entry<String, Limit> limitEntry : role.getLimits().entrySet()) {
-                log.debug("Loading {} for deployment `{}`", limitEntry.getValue(), limitEntry.getKey());
+            Map<String, Limit> roleLimits = role.getLimits();
+            if (roleLimits != null && !roleLimits.isEmpty()) {
+                for (Map.Entry<String, Limit> limitEntry : roleLimits.entrySet()) {
+                    log.debug("Loading {} for deployment `{}`", limitEntry.getValue(), limitEntry.getKey());
+                }
             }
             log.debug("End loading role `{}`", role.getName());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/limiter/RateLimiter.java
+++ b/server/src/main/java/com/epam/aidial/core/server/limiter/RateLimiter.java
@@ -579,7 +579,8 @@ public class RateLimiter {
 
     private static Limit getLimit(Map<String, Role> roles, String userRole, String name, Limit defaultLimit) {
         return Optional.ofNullable(roles.get(userRole))
-                .map(role -> role.getLimits().get(name))
+                .map(Role::getLimits)
+                .map(limits -> limits.get(name))
                 .orElse(defaultLimit);
     }
 


### PR DESCRIPTION
Fixes a NullPointerException that occurs when a role is configured without any rate limits.

### Applicable issues

- fixes #1880

### Description of changes

- `ConfigPostProcessor.processRoles`: guard against `role.getLimits()` returning `null` before iterating over it during config load/reload.
- `RateLimiter.getLimit`: chain `Role::getLimits` through `Optional.map` instead of dereferencing it directly, so a role without limits falls back to the default limit instead of throwing NPE.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.