### PR TITLE
feat: auto-share config-declared skill resources #1865

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/data/ApiKeyData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ApiKeyData.java
@@ -51,6 +51,8 @@ public class ApiKeyData {
     private Map<String, AutoSharedData> attachedResourceCredentials = new HashMap<>();
     // list of prompts included into application properties
     private Map<String, AutoSharedData> attachedPrompts = new HashMap<>();
+    // list of skills included into application properties
+    private Map<String, AutoSharedData> attachedSkills = new HashMap<>();
     // deployment name of the source(application/model/interceptor) associated with the current request
     private String sourceDeployment;
     // Execution path of the root request

--- a/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/AutoShareDeploymentFn.java
@@ -53,6 +53,7 @@ public class AutoShareDeploymentFn extends BaseRequestFunction<RequestObject> {
             if (deployment instanceof Application app && app.hasApplicationTypeSchemaId()) {
                 shareApplicationFiles(app);
                 shareApplicationPrompts(app);
+                shareApplicationSkills(app);
                 shareApplicationDeployments(app);
             }
             return false;

--- a/server/src/main/java/com/epam/aidial/core/server/function/BaseRequestFunction.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/BaseRequestFunction.java
@@ -76,6 +76,23 @@ public abstract class BaseRequestFunction<T> extends BaseFunction<T, Boolean> {
         }
     }
 
+    void shareApplicationSkills(Application application) {
+        List<ResourceDescriptor> skills = proxy.getApplicationSchemaService().getSkills(application);
+        ApiKeyData apiKeyData = context.getProxyApiKeyData();
+        AccessService accessService = proxy.getAccessService();
+        for (ResourceDescriptor resource : skills) {
+            if (resource.isPublic()) {
+                continue;
+            }
+            String resourceUrl = resource.getUrl();
+            if (accessService.hasReadAccess(resource, context)) {
+                apiKeyData.getAttachedSkills().put(resourceUrl, new AutoSharedData(ResourceAccessType.READ_ONLY));
+            } else {
+                throw new HttpException(HttpStatus.FORBIDDEN, "Access denied to the skill %s".formatted(resourceUrl));
+            }
+        }
+    }
+
     void shareApplicationFiles(Application application) {
         List<ResourceDescriptor> files = proxy.getApplicationSchemaService().getFiles(application);
         ApiKeyData apiKeyData = context.getProxyApiKeyData();

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFn.java
@@ -29,6 +29,7 @@ public class CollectRequestApplicationFilesFn extends BaseRequestFunction<Reques
             }
             shareApplicationFiles(application);
             shareApplicationPrompts(application);
+            shareApplicationSkills(application);
             return false;
         } catch (HttpException ex) {
             throw ex;

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -238,6 +238,11 @@ public class AccessService {
                 result.put(resource, autoSharedData.accessTypes());
                 continue;
             }
+            autoSharedData = apiKeyData.getAttachedSkills().get(resourceUrl);
+            if (autoSharedData != null) {
+                result.put(resource, autoSharedData.accessTypes());
+                continue;
+            }
             autoSharedData = apiKeyData.getAttachedDeployments().get(resourceUrl);
             if (autoSharedData != null) {
                 result.put(resource, autoSharedData.accessTypes());

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
@@ -387,6 +387,11 @@ public class ApplicationSchemaService {
                 ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
     }
 
+    public List<ResourceDescriptor> getSkills(Application application) {
+        return getApplicationResources(application, Set.of(ResourceTypes.SKILL),
+                ListCollector.ResourceCollectorType.ALL_RESOURCES, false);
+    }
+
     public List<ResourceDescriptor> getDeployments(Application application) {
         return getApplicationResources(application, Set.of(ResourceTypes.APPLICATION, ResourceTypes.TOOL_SET),
                 ListCollector.ResourceCollectorType.ALL_RESOURCES, false);

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectRequestApplicationFilesFnTest.java
@@ -221,6 +221,49 @@ public class CollectRequestApplicationFilesFnTest {
     }
 
     @Test
+    void apply_appendsSkillsToApiKeyData_whenApplicationHasCustomSchemaId() {
+        String skillUrl = "skills/bucket/my-skill";
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        Map<String, Object> customProps = new HashMap<>();
+        customProps.put("skill", Map.of("name", "my-skill", "dial_id", skillUrl));
+        application.setApplicationProperties(customProps);
+        when(accessService.hasReadAccess(any(), any())).thenReturn(true);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+        when(proxy.getApplicationSchemaService()).thenReturn(applicationSchemaService);
+        when(proxy.getAccessService()).thenReturn(accessService);
+        ResourceDescriptor skill = mock(ResourceDescriptor.class);
+        when(skill.getUrl()).thenReturn(skillUrl);
+        when(applicationSchemaService.getSkills(eq(application))).thenReturn(List.of(skill));
+
+        boolean result = fn.apply(request);
+
+        assertFalse(result);
+        assertNotNull(apiKeyData.getAttachedSkills().get(skillUrl));
+        assertEquals(1, apiKeyData.getAttachedSkills().size());
+    }
+
+    @Test
+    void apply_throws_whenAccessServiceHasNoReadAccessToSkill() {
+        String skillUrl = "skills/bucket/my-skill";
+        when(context.getDeployment()).thenReturn(application);
+        application.setApplicationTypeSchemaId(URI.create("customSchemaId"));
+        Map<String, Object> customProps = new HashMap<>();
+        customProps.put("skill", Map.of("name", "my-skill", "dial_id", skillUrl));
+        application.setApplicationProperties(customProps);
+        when(proxy.getApplicationSchemaService()).thenReturn(applicationSchemaService);
+        when(proxy.getAccessService()).thenReturn(accessService);
+        ResourceDescriptor skill = mock(ResourceDescriptor.class);
+        when(applicationSchemaService.getSkills(eq(application))).thenReturn(List.of(skill));
+        when(accessService.hasReadAccess(any(), any())).thenReturn(false);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+
+        Assertions.assertThrows(HttpException.class, () -> fn.apply(request));
+    }
+
+    @Test
     void apply_throws_whenAccessServiceHasNoReadAccess() {
         when(context.getProxyApiKeyData()).thenReturn(new ApiKeyData());
         String serverFile = "files/public/valid-file-path/valid-sub-path/valid%20file%20name2.ext";

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -832,6 +832,31 @@ public class ApplicationSchemaServiceTest {
     }
 
     @Test
+    public void getSkills_returnsListOfSkills_whenSchemaHasDialResourceSkills() {
+        customProperties.put("toolset", Map.of("name", "my-skill", "dial_id", "skills/bucket/my-skill"));
+        when(configStore.get()).thenReturn(config);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+        application.setApplicationProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        when(resourceService.hasResource(any())).thenReturn(true);
+        when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
+
+        List<ResourceDescriptor> result = service.getSkills(application);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("my-skill", result.getFirst().getName());
+    }
+
+    @Test
+    public void getSkills_returnsEmptyList_whenSchemaIsNull() {
+        application.setApplicationTypeSchemaId(null);
+
+        List<ResourceDescriptor> result = service.getSkills(application);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
     public void testGetToolsets_ToolsetExistsNotDialResourceFormat() {
         customProperties.put("toolset", Map.of("name", "my-toolset", "dial_id", "mytoolset"));
         when(configStore.get()).thenReturn(config);


### PR DESCRIPTION
Extends the existing auto-share mechanism for config-declared `files` and `prompts` resources to also cover `skills` resources, so an application can read a skill declared in its config from the builder's bucket regardless of who calls it.

### Applicable issues

- fixes #1865

### Description of changes

- Added `ApplicationSchemaService.getSkills` to collect config-declared `skills/...` resource dependencies, mirroring `getPrompts`.
- Added `attachedSkills` map to `ApiKeyData` for auto-shared skill resources.
- Added `BaseRequestFunction.shareApplicationSkills`, granting read access to the per-request key (or throwing 403), mirroring `shareApplicationPrompts`.
- Wired the new sharing call into `AutoShareDeploymentFn` and `CollectRequestApplicationFilesFn`.
- Added `attachedSkills` lookup to `AccessService.getAutoSharedAccess`'s permission chain.
- Added unit tests covering the new behavior in `ApplicationSchemaServiceTest` and `CollectRequestApplicationFilesFnTest`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.