### PR TITLE
fix: skill item metadata response contains incorrect nodeType #1888

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceMetadataController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ComplexResourceMetadataController.java
@@ -112,7 +112,7 @@ public class ComplexResourceMetadataController extends AccessControlBaseControll
 
         proxy.getTaskExecutor().submit(() -> filesMode
                         ? complexResourceService.listFiles(resource, subPath, token, limit, recursive)
-                        : complexResourceService.listChildren(resource, token, limit, recursive))
+                        : complexResourceService.getMetadata(resource, token, limit, recursive))
                 .onSuccess(result -> {
                     if (result == null) {
                         context.respond(HttpStatus.NOT_FOUND);

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -546,6 +546,28 @@ public class ComplexResourceService {
     }
 
     /**
+     * Resolves metadata for the v2 metadata route's target path. If the path is itself an active DIAL
+     * resource (a skill), returns its metadata as a single {@code ITEM}; otherwise treats it as a grouping
+     * level and lists its children via {@link #listChildren}.
+     */
+    public MetadataBase getMetadata(ResourceDescriptor resource, String token, int limit, boolean recursive) {
+        FolderResourceMarker marker = getMarker(resource);
+        if (marker != null) {
+            return itemMetadata(resource, marker);
+        }
+        return listChildren(resource, token, limit, recursive);
+    }
+
+    private static ResourceItemMetadata itemMetadata(ResourceDescriptor resource, FolderResourceMarker marker) {
+        ResourceItemMetadata metadata = new ResourceItemMetadata(resource);
+        metadata.setCreatedAt(marker.getCreatedAt());
+        metadata.setUpdatedAt(marker.getUpdatedAt());
+        metadata.setEtag(marker.getEtag());
+        metadata.setAuthor(marker.getAuthor());
+        return metadata;
+    }
+
+    /**
      * Lists DIAL resources and grouping folders at a grouping level. A node is classified by the presence
      * of its marker file ({@code .dial-resource} → {@code ITEM}, {@code .dial-folder} → {@code FOLDER}).
      * A {@code .dial-resource} marker is additionally read to exclude a tombstoned ({@code deleting})

--- a/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
@@ -374,6 +374,24 @@ public class SkillResourceApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testMetadataOfSkillItselfIsItem() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+        verify(uploadSkill("/cat/skill-a", files), 200);
+        verify(createFolder("/cat/sub/"), 200);
+
+        // requesting the skill's own path (not its parent) must report the skill itself as an ITEM,
+        // not an (empty) FOLDER
+        Response skillMetadata = listMetadata("cat/skill-a");
+        verify(skillMetadata, 200);
+        assertEquals("ITEM", nodeType(skillMetadata));
+
+        // a grouping folder's own path must still report itself as a FOLDER
+        Response folderMetadata = listMetadata("cat/sub");
+        verify(folderMetadata, 200);
+        assertEquals("FOLDER", nodeType(folderMetadata));
+    }
+
+    @Test
     void testMetadataListingRecursive() {
         Map<String, byte[]> files = new LinkedHashMap<>();
         files.put("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
@@ -637,6 +655,11 @@ public class SkillResourceApiTest extends ResourceBaseTest {
 
     private Response deleteFolder(String folderPath, String... headers) {
         return send(HttpMethod.DELETE, "/v2/skills/" + bucket + folderPath, null, "", headers);
+    }
+
+    @SneakyThrows
+    private static String nodeType(Response metadata) {
+        return ProxyUtil.MAPPER.readTree(metadata.body()).get("nodeType").asText();
     }
 
     @SneakyThrows


### PR DESCRIPTION
Fixes the `/v2/metadata/skills/{bucket}/{path}` endpoint reporting `nodeType: FOLDER` for a specific skill item instead of `ITEM`.

### Applicable issues

- fixes #1888

### Description of changes

- Added `ComplexResourceService.getMetadata()`, which checks whether the requested path is itself an active DIAL resource (via the existing `getMarker()`) and, if so, returns single-item `ITEM` metadata for it instead of falling through to the children-listing logic used for grouping folders.
- Updated `ComplexResourceMetadataController` to call the new `getMetadata()` method instead of unconditionally calling `listChildren()`.
- Added a regression test (`testMetadataOfSkillItselfIsItem`) verifying a skill's own metadata reports `ITEM` while a grouping folder's own metadata still reports `FOLDER`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.