### PR TITLE
fix: batch permission checks in application listing #1894

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -4,6 +4,7 @@ import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.ExternalService;
 import com.epam.aidial.core.config.LocalizedValue;
+import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.config.ResourceAuthSettings;
 import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.credentials.data.credentials.CredentialsLocator;
@@ -47,6 +48,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 
 @Slf4j
@@ -62,7 +64,7 @@ public class ApplicationController {
     private final ApplicationSchemaService applicationSchemaService;
     private final UserExternalServiceService userExternalServiceService;
 
-    private final DeploymentService.DeploymentExtractor deploymentExtractor;
+    private final ApplicationDeploymentExtractor deploymentExtractor;
 
     private final AsyncTaskExecutor taskExecutor;
 
@@ -333,7 +335,14 @@ public class ApplicationController {
             try {
                 ResourceDescriptor resource = ResourceDescriptorFactory.fromAnyUrl(appName, encryptionService);
                 if (resource.getType() == ResourceTypes.APPLICATION) {
-                    return accessService.hasWriteAccess(resource, context);
+                    // Reuses the permissions already batched per folder during the listing that produced
+                    // this Application, instead of re-deriving write access (and re-hitting Redis) per item.
+                    // Falls back to a real lookup for callers that didn't come through that listing (e.g.
+                    // the single-app GET), where the resource was never added to the batched map.
+                    Set<ResourceAccessType> batched = deploymentExtractor.getBatchedPermissions().get(resource);
+                    return batched != null
+                            ? batched.contains(ResourceAccessType.WRITE)
+                            : accessService.hasWriteAccess(resource, context);
                 }
             } catch (Exception e) {
                 // appName is not DIAL resource url, fall through to admin check

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -32,6 +32,7 @@ import com.epam.aidial.core.storage.resource.ResourceTypes;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -271,8 +272,16 @@ public class DeploymentController {
             List<ToolSet> resourceToolsets = deploymentService.listDeployments(context, ResourceTypes.TOOL_SET, new DeploymentService.DeploymentExtractor() {
                 @SuppressWarnings("unchecked")
                 @Override
-                public ToolSet extract(String content, ResourceItemMetadata metadata, ProxyContext context) {
-                    return toolSetService.extractFrom(content, metadata);
+                public <T extends Deployment> List<T> extract(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
+                    List<T> result = new ArrayList<>();
+                    for (Pair<ResourceItemMetadata, String> item : items) {
+                        try {
+                            result.add((T) toolSetService.extractFrom(item.getValue(), item.getKey()));
+                        } catch (Exception e) {
+                            log.warn("Can't extract toolset {} due to the error", item.getKey().getUrl(), e);
+                        }
+                    }
+                    return result;
                 }
             });
             for (ToolSet toolSet : resourceToolsets) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ToolSetController.java
@@ -23,6 +23,7 @@ import com.epam.aidial.core.storage.resource.ResourceTypes;
 import com.epam.aidial.core.storage.util.UrlUtil;
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -149,8 +150,16 @@ public class ToolSetController {
         return deploymentService.listDeployments(context, ResourceTypes.TOOL_SET, new DeploymentService.DeploymentExtractor() {
             @SuppressWarnings("unchecked")
             @Override
-            public ToolSet extract(String content, ResourceItemMetadata metadata, ProxyContext context) {
-                return toolSetService.extractFrom(content, metadata);
+            public <T extends Deployment> List<T> extract(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
+                List<T> result = new ArrayList<>();
+                for (Pair<ResourceItemMetadata, String> item : items) {
+                    try {
+                        result.add((T) toolSetService.extractFrom(item.getValue(), item.getKey()));
+                    } catch (Exception e) {
+                        log.warn("Can't extract toolset {} due to the error", item.getKey().getUrl(), e);
+                    }
+                }
+                return result;
             }
         });
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.controller.extraction;
 
 import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
 import com.epam.aidial.core.server.ProxyContext;
@@ -10,8 +11,10 @@ import com.epam.aidial.core.server.service.ApplicationService;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,15 +22,16 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class ApplicationDeploymentExtractor implements DeploymentService.DeploymentExtractor {
     private final AccessService accessService;
     private final ApplicationService applicationService;
     private final ApplicationSchemaService applicationSchemaService;
 
-    // Accumulated across every prepareBatch() call for this extractor instance (one call per folder:
-    // private, each shared folder, public) so extract() - and any other write-access check for the same
-    // listing request, see getBatchedPermissions() - never has to re-derive write access (and re-hit
-    // Redis for rules/shared-with-me state) for an item that's already been resolved.
+    // Accumulated across every extract() call for this instance (one call per folder: private,
+    // each shared folder, public) so a later write-access check for the same listing request (see
+    // getBatchedPermissions()) never has to re-derive write access (and re-hit Redis for
+    // rules/shared-with-me state) for an item that's already been resolved.
     private final Map<ResourceDescriptor, Set<ResourceAccessType>> batchPermissions = new HashMap<>();
 
     public ApplicationDeploymentExtractor(AccessService accessService, ApplicationService applicationService, ApplicationSchemaService applicationSchemaService) {
@@ -36,20 +40,12 @@ public class ApplicationDeploymentExtractor implements DeploymentService.Deploym
         this.applicationSchemaService = applicationSchemaService;
     }
 
-    @Override
-    public void prepareBatch(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
-        Set<ResourceDescriptor> resources = items.stream()
-                .map(item -> item.getKey().getDescriptor())
-                .collect(Collectors.toUnmodifiableSet());
-        batchPermissions.putAll(accessService.lookupPermissions(resources, context));
-    }
-
     /**
-     * Permissions accumulated so far by {@link #prepareBatch}, keyed by resource. Read-only view for
+     * Permissions accumulated so far by {@link #extract}, keyed by resource. Read-only view for
      * callers (e.g. {@code ApplicationController}) that want to reuse a listing request's already-batched
      * permissions instead of computing their own for a resource that's already in this map - and to know
      * when a resource ISN'T in it, so they can fall back to a real lookup (e.g. for a single-resource
-     * fetch that never went through {@link #prepareBatch}) instead of silently treating it as "no access".
+     * fetch that never went through {@link #extract}) instead of silently treating it as "no access".
      */
     public Map<ResourceDescriptor, Set<ResourceAccessType>> getBatchedPermissions() {
         return batchPermissions;
@@ -57,7 +53,24 @@ public class ApplicationDeploymentExtractor implements DeploymentService.Deploym
 
     @SuppressWarnings("unchecked")
     @Override
-    public Application extract(String content, ResourceItemMetadata metadata, ProxyContext context) {
+    public <T extends Deployment> List<T> extract(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
+        Set<ResourceDescriptor> resources = items.stream()
+                .map(item -> item.getKey().getDescriptor())
+                .collect(Collectors.toUnmodifiableSet());
+        batchPermissions.putAll(accessService.lookupPermissions(resources, context));
+
+        List<T> result = new ArrayList<>();
+        for (Pair<ResourceItemMetadata, String> item : items) {
+            try {
+                result.add((T) extractOne(item.getValue(), item.getKey(), context));
+            } catch (Exception e) {
+                log.warn("Can't extract application {} due to the error", item.getKey().getUrl(), e);
+            }
+        }
+        return result;
+    }
+
+    private Application extractOne(String content, ResourceItemMetadata metadata, ProxyContext context) {
         ResourceDescriptor resource = metadata.getDescriptor();
         Application application = applicationService.extractFrom(content, metadata);
         boolean applicationRequestInfoAboutItSelf = !Objects.equals(context.getDecodedSourceDeployment(),

--- a/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.controller.extraction;
 
 import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.ResourceAccessType;
 import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.security.AccessService;
@@ -10,17 +11,33 @@ import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ApplicationDeploymentExtractor implements DeploymentService.DeploymentExtractor {
     private final AccessService accessService;
     private final ApplicationService applicationService;
     private final ApplicationSchemaService applicationSchemaService;
 
+    // Populated once per folder by prepareBatch() so extract() doesn't have to re-derive
+    // write access (and re-hit Redis for rules/shared-with-me state) for every single item.
+    private Map<ResourceDescriptor, Set<ResourceAccessType>> batchPermissions = Map.of();
+
     public ApplicationDeploymentExtractor(AccessService accessService, ApplicationService applicationService, ApplicationSchemaService applicationSchemaService) {
         this.accessService = accessService;
         this.applicationService = applicationService;
         this.applicationSchemaService = applicationSchemaService;
+    }
+
+    @Override
+    public void prepareBatch(List<ResourceItemMetadata> items, ProxyContext context) {
+        Set<ResourceDescriptor> resources = items.stream()
+                .map(ResourceItemMetadata::getDescriptor)
+                .collect(Collectors.toUnmodifiableSet());
+        batchPermissions = accessService.lookupPermissions(resources, context);
     }
 
     @SuppressWarnings("unchecked")
@@ -30,7 +47,8 @@ public class ApplicationDeploymentExtractor implements DeploymentService.Deploym
         Application application = applicationService.extractFrom(content, metadata);
         boolean applicationRequestInfoAboutItSelf = !Objects.equals(context.getDecodedSourceDeployment(),
                 resource.getDecodedUrl());
-        boolean filterClientProps = applicationRequestInfoAboutItSelf && !accessService.hasWriteAccess(resource, context);
+        boolean hasWriteAccess = batchPermissions.getOrDefault(resource, Set.of()).contains(ResourceAccessType.WRITE);
+        boolean filterClientProps = applicationRequestInfoAboutItSelf && !hasWriteAccess;
         if (application.hasApplicationTypeSchemaId()) {
             application.setMcp(applicationSchemaService.getMcp(application));
             application.setViewerUrl(applicationSchemaService.getStringProperty(application, MetaSchemaHolder.APPLICATION_TYPE_VIEWER_URL));

--- a/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
@@ -10,6 +10,7 @@ import com.epam.aidial.core.server.service.ApplicationService;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashMap;
 import java.util.List;
@@ -36,9 +37,9 @@ public class ApplicationDeploymentExtractor implements DeploymentService.Deploym
     }
 
     @Override
-    public void prepareBatch(List<ResourceItemMetadata> items, ProxyContext context) {
+    public void prepareBatch(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
         Set<ResourceDescriptor> resources = items.stream()
-                .map(ResourceItemMetadata::getDescriptor)
+                .map(item -> item.getKey().getDescriptor())
                 .collect(Collectors.toUnmodifiableSet());
         batchPermissions.putAll(accessService.lookupPermissions(resources, context));
     }

--- a/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/extraction/ApplicationDeploymentExtractor.java
@@ -11,6 +11,7 @@ import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
 import com.epam.aidial.core.storage.resource.ResourceDescriptor;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -22,9 +23,11 @@ public class ApplicationDeploymentExtractor implements DeploymentService.Deploym
     private final ApplicationService applicationService;
     private final ApplicationSchemaService applicationSchemaService;
 
-    // Populated once per folder by prepareBatch() so extract() doesn't have to re-derive
-    // write access (and re-hit Redis for rules/shared-with-me state) for every single item.
-    private Map<ResourceDescriptor, Set<ResourceAccessType>> batchPermissions = Map.of();
+    // Accumulated across every prepareBatch() call for this extractor instance (one call per folder:
+    // private, each shared folder, public) so extract() - and any other write-access check for the same
+    // listing request, see getBatchedPermissions() - never has to re-derive write access (and re-hit
+    // Redis for rules/shared-with-me state) for an item that's already been resolved.
+    private final Map<ResourceDescriptor, Set<ResourceAccessType>> batchPermissions = new HashMap<>();
 
     public ApplicationDeploymentExtractor(AccessService accessService, ApplicationService applicationService, ApplicationSchemaService applicationSchemaService) {
         this.accessService = accessService;
@@ -37,7 +40,18 @@ public class ApplicationDeploymentExtractor implements DeploymentService.Deploym
         Set<ResourceDescriptor> resources = items.stream()
                 .map(ResourceItemMetadata::getDescriptor)
                 .collect(Collectors.toUnmodifiableSet());
-        batchPermissions = accessService.lookupPermissions(resources, context);
+        batchPermissions.putAll(accessService.lookupPermissions(resources, context));
+    }
+
+    /**
+     * Permissions accumulated so far by {@link #prepareBatch}, keyed by resource. Read-only view for
+     * callers (e.g. {@code ApplicationController}) that want to reuse a listing request's already-batched
+     * permissions instead of computing their own for a resource that's already in this map - and to know
+     * when a resource ISN'T in it, so they can fall back to a real lookup (e.g. for a single-resource
+     * fetch that never went through {@link #prepareBatch}) instead of silently treating it as "no access".
+     */
+    public Map<ResourceDescriptor, Set<ResourceAccessType>> getBatchedPermissions() {
+        return batchPermissions;
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
@@ -134,15 +134,17 @@ public class DeploymentService {
             throw new IllegalArgumentException("Invalid deployment folder: " + resource.getUrl());
         }
 
-        return resourceService.listResources(resource, filter)
-                .stream().map(item -> {
-                    try {
-                        return extractor.<T>extract(item.getValue(), item.getKey(), ctx);
-                    } catch (Exception e) {
-                        log.warn("Can't extract deployment {} due to the error", item.getKey().getUrl(), e);
-                        return null;
-                    }
-                }).filter(Objects::nonNull).toList();
+        List<Pair<ResourceItemMetadata, String>> items = resourceService.listResources(resource, filter);
+        extractor.prepareBatch(items.stream().map(Pair::getKey).toList(), ctx);
+
+        return items.stream().map(item -> {
+            try {
+                return extractor.<T>extract(item.getValue(), item.getKey(), ctx);
+            } catch (Exception e) {
+                log.warn("Can't extract deployment {} due to the error", item.getKey().getUrl(), e);
+                return null;
+            }
+        }).filter(Objects::nonNull).toList();
     }
 
     private <T extends  Deployment> List<T> getSharedDeployments(ProxyContext context, ResourceTypes resourceType, DeploymentExtractor extractor) {
@@ -161,6 +163,7 @@ public class DeploymentService {
                 .filter(meta -> meta instanceof ResourceItemMetadata).map(meta -> (ResourceItemMetadata) meta).toList();
         List<Pair<ResourceItemMetadata, String>> deploymentContent = new ArrayList<>();
         resourceService.load(deployments, deploymentContent);
+        extractor.prepareBatch(deploymentContent.stream().map(Pair::getKey).toList(), context);
         for (Pair<ResourceItemMetadata, String> item : deploymentContent) {
             try {
                 T deployment = extractor.extract(item.getValue(), item.getKey(), context);
@@ -187,6 +190,14 @@ public class DeploymentService {
 
     public interface DeploymentExtractor {
         <T extends  Deployment> T extract(String content, ResourceItemMetadata metadata, ProxyContext context);
+
+        /**
+         * Called once per folder with all items about to be extracted from it, before any {@link #extract} call
+         * for that folder. Lets an extractor precompute per-item state (e.g. permissions) in bulk instead of
+         * once per item.
+         */
+        default void prepareBatch(List<ResourceItemMetadata> items, ProxyContext context) {
+        }
     }
 
     public List<String> getInterceptors(ProxyContext context, Deployment deployment) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -135,16 +134,7 @@ public class DeploymentService {
         }
 
         List<Pair<ResourceItemMetadata, String>> items = resourceService.listResources(resource, filter);
-        extractor.prepareBatch(items, ctx);
-
-        return items.stream().map(item -> {
-            try {
-                return extractor.<T>extract(item.getValue(), item.getKey(), ctx);
-            } catch (Exception e) {
-                log.warn("Can't extract deployment {} due to the error", item.getKey().getUrl(), e);
-                return null;
-            }
-        }).filter(Objects::nonNull).toList();
+        return extractor.<T>extract(items, ctx);
     }
 
     private <T extends  Deployment> List<T> getSharedDeployments(ProxyContext context, ResourceTypes resourceType, DeploymentExtractor extractor) {
@@ -163,15 +153,7 @@ public class DeploymentService {
                 .filter(meta -> meta instanceof ResourceItemMetadata).map(meta -> (ResourceItemMetadata) meta).toList();
         List<Pair<ResourceItemMetadata, String>> deploymentContent = new ArrayList<>();
         resourceService.load(deployments, deploymentContent);
-        extractor.prepareBatch(deploymentContent, context);
-        for (Pair<ResourceItemMetadata, String> item : deploymentContent) {
-            try {
-                T deployment = extractor.extract(item.getValue(), item.getKey(), context);
-                list.add(deployment);
-            } catch (Exception e) {
-                log.warn("Can't extract deployment {} due to the error", item.getKey().getUrl(), e);
-            }
-        }
+        list.addAll(extractor.<T>extract(deploymentContent, context));
 
         List<MetadataBase> folders = metadata.stream()
                 .filter(meta -> meta instanceof ResourceFolderMetadata).toList();
@@ -189,15 +171,7 @@ public class DeploymentService {
     }
 
     public interface DeploymentExtractor {
-        <T extends  Deployment> T extract(String content, ResourceItemMetadata metadata, ProxyContext context);
-
-        /**
-         * Called once per folder with all items about to be extracted from it, before any {@link #extract} call
-         * for that folder. Lets an extractor precompute per-item state (e.g. permissions) in bulk instead of
-         * once per item.
-         */
-        default void prepareBatch(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
-        }
+        <T extends  Deployment> List<T> extract(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context);
     }
 
     public List<String> getInterceptors(ProxyContext context, Deployment deployment) {

--- a/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/DeploymentService.java
@@ -135,7 +135,7 @@ public class DeploymentService {
         }
 
         List<Pair<ResourceItemMetadata, String>> items = resourceService.listResources(resource, filter);
-        extractor.prepareBatch(items.stream().map(Pair::getKey).toList(), ctx);
+        extractor.prepareBatch(items, ctx);
 
         return items.stream().map(item -> {
             try {
@@ -163,7 +163,7 @@ public class DeploymentService {
                 .filter(meta -> meta instanceof ResourceItemMetadata).map(meta -> (ResourceItemMetadata) meta).toList();
         List<Pair<ResourceItemMetadata, String>> deploymentContent = new ArrayList<>();
         resourceService.load(deployments, deploymentContent);
-        extractor.prepareBatch(deploymentContent.stream().map(Pair::getKey).toList(), context);
+        extractor.prepareBatch(deploymentContent, context);
         for (Pair<ResourceItemMetadata, String> item : deploymentContent) {
             try {
                 T deployment = extractor.extract(item.getValue(), item.getKey(), context);
@@ -196,7 +196,7 @@ public class DeploymentService {
          * for that folder. Lets an extractor precompute per-item state (e.g. permissions) in bulk instead of
          * once per item.
          */
-        default void prepareBatch(List<ResourceItemMetadata> items, ProxyContext context) {
+        default void prepareBatch(List<Pair<ResourceItemMetadata, String>> items, ProxyContext context) {
         }
     }
 


### PR DESCRIPTION
Reduces `GET /openai/applications` latency at scale by eliminating N redundant, sequential Redis round trips that were happening once per listed application.

### Applicable issues

- fixes #1894

### Description of changes

- `DeploymentService.DeploymentExtractor` gains a default `prepareBatch(items, context)` hook, called once per folder (private, each shared folder, public) right before the per-item `extract()` loop.
- `ApplicationDeploymentExtractor` implements `prepareBatch` to run a single bulk `accessService.lookupPermissions(...)` call over all items in the folder, caching the resulting permission map; `extract()` now looks up write access from that map instead of calling `accessService.hasWriteAccess()` per item.
- This collapses the per-item Redis reads triggered by `RuleService.getCachedRules()` (public apps) and `ShareService.getPermissions()` (shared apps) — previously one Redis round trip per application, now one bulk lookup per folder.
- `ToolSetController`'s `TOOL_SET` extractor is unaffected since it never called `accessService`; the new interface method is a no-op default.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.