### PR TITLE
chore: optimize RuleService#getCachedRules, align RULES TTL #1896

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ without putting the raw address in the log.
 | resources.resourceTypesExpiration.PROMPT |      |  5 mins  | Define expiration time for prompts                                                                 |
 | resources.resourceTypesExpiration.APPLICATION |      | 30 days  | Define expiration time for applications                                                            |
 | resources.resourceTypesExpiration.TOOL_SET |      | 30 days  | Define expiration time for toolsets                                                                |
+| resources.resourceTypesExpiration.RULES |      | 30 days  | Define expiration time for public rules                                                            |
 
 </details>
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/RuleService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/RuleService.java
@@ -125,15 +125,13 @@ public class RuleService {
     }
 
     private Map<String, List<Rule>> getCachedRules() {
-        ResourceItemMetadata meta = resources.getResourceMetadata(PUBLIC_RULES);
-        long key = (meta == null) ? Long.MIN_VALUE : meta.getUpdatedAt();
+        Pair<ResourceItemMetadata, String> resource = resources.getResourceWithMetadata(PUBLIC_RULES, EtagHeader.ANY);
+        long key = (resource == null) ? Long.MIN_VALUE : resource.getKey().getUpdatedAt();
         Pair<Long, Map<String, List<Rule>>> current = cachedRules.get();
 
         if (current == null || current.getKey() != key) {
-            Pair<ResourceItemMetadata, String> resource = resources.getResourceWithMetadata(PUBLIC_RULES, EtagHeader.ANY);
-            Pair<Long, Map<String, List<Rule>>> next = (resource == null)
-                    ? Pair.of(Long.MIN_VALUE, decodeRules(null))
-                    : Pair.of(resource.getKey().getUpdatedAt(), decodeRules(resource.getValue()));
+            Map<String, List<Rule>> decoded = decodeRules(resource == null ? null : resource.getValue());
+            Pair<Long, Map<String, List<Rule>>> next = Pair.of(key, decoded);
 
             cachedRules.compareAndSet(current, next);
             current = next;

--- a/storage/src/main/java/com/epam/aidial/core/storage/resource/ResourceTypes.java
+++ b/storage/src/main/java/com/epam/aidial/core/storage/resource/ResourceTypes.java
@@ -12,7 +12,7 @@ public enum ResourceTypes implements ResourceType {
     SHARED_BY_ME("shared_by_me", true, TimeUnit.MINUTES.toMillis(5)),
     INVITATION("invitations", true, TimeUnit.MINUTES.toMillis(5)),
     PUBLICATION("publications", true, TimeUnit.MINUTES.toMillis(5)),
-    RULES("rules", true, TimeUnit.MINUTES.toMillis(5)),
+    RULES("rules", true, TimeUnit.DAYS.toMillis(30)),
     API_KEY_DATA("api_key_data", true, TimeUnit.MINUTES.toMillis(5)),
     NOTIFICATION("notifications", true, TimeUnit.MINUTES.toMillis(5)),
     APPLICATION("applications", true, TimeUnit.DAYS.toMillis(30)),


### PR DESCRIPTION
Optimizes `RuleService#getCachedRules()` to make a single Redis round trip instead of two, and raises the `RULES` resource TTL to match `APPLICATION` so it stays resident in Redis.

### Applicable issues

- fixes #1896

### Description of changes

- `RuleService#getCachedRules()` previously called `getResourceMetadata` to check staleness and then, only if changed, `getResourceWithMetadata` to fetch the body — two sequential Redis calls on every invocation. Now it calls `getResourceWithMetadata` directly and unconditionally, and uses the returned `updatedAt` against a local `AtomicReference` cache to decide whether to re-decode the JSON body, avoiding the extra metadata pre-check while still skipping unnecessary re-parsing.
- Raised `ResourceTypes.RULES`'s Redis TTL from 5 minutes to 30 days, matching `APPLICATION` and several other small, infrequently-changing resource types. Public rules are small, so there's no storage-cost reason to evict them quickly — keeping them resident in Redis avoids the more expensive blob-storage fallback that a short TTL forces under normal traffic.
- Documented the new `resources.resourceTypesExpiration.RULES` default in `README.md`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.