### PR TITLE
fix: GCP KMS encryption fails with NoSuchFieldError #1899

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,11 @@ allprojects {
         resolutionStrategy {
             force 'com.google.code.gson:gson:2.11.0'
             force 'net.minidev:json-smart:2.5.2'
-            force 'io.grpc:grpc-netty-shaded:1.75.0'
-            force 'io.grpc:grpc-core:1.75.0'
-            force 'io.grpc:grpc-api:1.75.0'
-            force 'io.grpc:grpc-context:1.75.0'
-            force 'io.grpc:grpc-util:1.75.0'
+            eachDependency { details ->
+                if (details.requested.group == 'io.grpc') {
+                    details.useVersion('1.75.0')
+                }
+            }
             // Keep the whole netty graph on one patched version; netty-tcnative-* is intentionally
             // absent, it has its own 2.0.x version line.
             force "io.netty:netty-buffer:${netty_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ allprojects {
             force 'com.google.code.gson:gson:2.11.0'
             force 'net.minidev:json-smart:2.5.2'
             force 'io.grpc:grpc-netty-shaded:1.75.0'
+            force 'io.grpc:grpc-core:1.75.0'
+            force 'io.grpc:grpc-api:1.75.0'
+            force 'io.grpc:grpc-context:1.75.0'
+            force 'io.grpc:grpc-util:1.75.0'
             // Keep the whole netty graph on one patched version; netty-tcnative-* is intentionally
             // absent, it has its own 2.0.x version line.
             force "io.netty:netty-buffer:${netty_version}"

--- a/credentials/src/main/java/com/epam/aidial/core/credentials/keymanagement/KeyManagementServiceFactory.java
+++ b/credentials/src/main/java/com/epam/aidial/core/credentials/keymanagement/KeyManagementServiceFactory.java
@@ -6,6 +6,7 @@ import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
 import com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm;
 import com.epam.aidial.core.credentials.data.configuration.KmsSettings;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.kms.v1.KeyManagementServiceSettings;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -65,7 +66,8 @@ public class KeyManagementServiceFactory {
     private static KeyManagementService createGcpKeyManagementService(KmsSettings kmsSettings) {
         String keyId = Objects.requireNonNull(kmsSettings.getKeyId(), "keyId cannot be null.");
 
-        KeyManagementServiceClient kmsClient = KeyManagementServiceClient.create();
+        KeyManagementServiceSettings settings = KeyManagementServiceSettings.newHttpJsonBuilder().build();
+        KeyManagementServiceClient kmsClient = KeyManagementServiceClient.create(settings);
         return new GcpKeyManagementService(kmsClient, keyId);
     }
 


### PR DESCRIPTION
Fixes a GCP KMS encryption failure (surfaced as `EncryptionException`/`UNKNOWN` gRPC status wrapping a `NoSuchFieldError`) caused by a version skew between `grpc-netty-shaded` and the plain `grpc-core`/`grpc-api` artifacts on the runtime classpath.

### Applicable issues

- fixes #1899

### Description of changes

- `build.gradle`: added `force` pins for `io.grpc:grpc-core`, `grpc-api`, `grpc-context`, and `grpc-util` at `1.75.0`, matching the existing `grpc-netty-shaded:1.75.0` force. Previously only `grpc-netty-shaded` was pinned, while `grpc-core`/`grpc-api`/`grpc-context` resolved transitively to `1.71.0` via `google-cloud-kms`'s dependency chain — `grpc-netty-shaded`'s Netty transport references the unshaded `io.grpc.internal.GrpcAttributes` class directly, and the version mismatch caused a `NoSuchFieldError` on `GrpcAttributes.ATTR_AUTHORITY_VERIFIER` during TLS handshake completion.
- `KeyManagementServiceFactory.java`: `createGcpKeyManagementService` now builds the KMS client with `KeyManagementServiceSettings.newHttpJsonBuilder()` instead of the gRPC-transport default `KeyManagementServiceClient.create()`, mirroring the existing pattern already used for `IamCredentialsClient` in `GcpCredentialsResolver`. This avoids the gRPC/Netty transport path entirely as an additional safeguard.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.