### PR TITLE
fix: skill recreate after delete fails with 412 #1904

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -970,7 +970,7 @@ public class ComplexResourceService {
 
     private String readAggregateEtag(ResourceDescriptor marker) {
         FolderResourceMarker document = readMarker(marker, false);
-        return document == null ? null : document.getEtag();
+        return isActive(document) ? document.getEtag() : null;
     }
 
     private FolderResourceMarker readMarker(ResourceDescriptor marker, boolean lock) {

--- a/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
@@ -195,6 +195,16 @@ public class SkillResourceApiTest extends ResourceBaseTest {
     }
 
     @Test
+    void testRecreateAfterDeleteWithIfNoneMatch() {
+        Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+
+        verify(uploadSkill("/recreate-me", files), 200);
+        verify(deleteSkill("/recreate-me"), 200);
+        // path is free again -> create-only PUT must succeed, not 412
+        verify(uploadSkill("/recreate-me", files, "if-none-match", "*"), 200);
+    }
+
+    @Test
     void testInvisibleToV1FilesApi() {
         Map<String, byte[]> files = Map.of("SKILL.md", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
         verify(uploadSkill("/hidden", files), 200);


### PR DESCRIPTION
After deleting a skill and immediately re-creating one at the same path with `If-None-Match: *`, the create-only PUT was incorrectly rejected with `412 Resource already exists`, even though the skill no longer appeared in any listing.

### Applicable issues

- fixes #1904

### Description of changes

- `ComplexResourceService.delete(...)` only tombstones the marker resource (`state = "deleting"`) and defers actual removal to the sweep service's grace period. Every other read path in `ComplexResourceService` (`getMarker`, `classify`, `listChildren`, ...) treats a `deleting` marker as absent via the `isActive(...)` helper, but the etag lookup used for `If-Match`/`If-None-Match` precondition validation (`readAggregateEtag`) did not, so it still returned a non-null etag for a deleted-but-not-yet-swept resource, tripping the `If-None-Match: *` check.
- Fixed `readAggregateEtag` to return `null` for an inactive (tombstoned) marker, consistent with the rest of the class.
- Added a regression test (`SkillResourceApiTest#testRecreateAfterDeleteWithIfNoneMatch`) covering create → delete → recreate with `If-None-Match: *`.

The secondary inconsistency noted in the issue (412 body being raw plain text instead of the JSON error envelope) is existing, consistent behavior across all `/v1` and `/v2` resource endpoints, not specific to this bug, so it was left out of scope for this fix.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.