### PR TITLE
fix: chat completion returns 403 when application config references a DIAL skill resource

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/AiDial.java
+++ b/server/src/main/java/com/epam/aidial/core/server/AiDial.java
@@ -259,7 +259,18 @@ public class AiDial {
             mergedConfigStore.init(fileConfigStore);
             ConfigStore configStore = mergedConfigStore;
             ApplicationOperatorService operatorService = new ApplicationOperatorService(client, settings("applications"));
-            ApplicationSchemaService applicationSchemaService = new ApplicationSchemaService(resourceService, configStore, encryptionService, httpProxySelector);
+
+            // Hoisted ahead of ApplicationSchemaService construction: SKILL resource existence
+            // checks in ApplicationSchemaService.getApplicationResources need ComplexResourceService
+            // (skills are complex/versioned resources, not single-blob resources). storage and
+            // lockService are already available above, so hoisting this construction earlier is safe.
+            ComplexResourceService.Settings complexResourceSettings = Json.decodeValue(
+                    settings("complexResource").toBuffer(), ComplexResourceService.Settings.class);
+            ComplexResourceService complexResourceService = new ComplexResourceService(
+                    resourceService, lockService, storage, complexResourceSettings);
+
+            ApplicationSchemaService applicationSchemaService = new ApplicationSchemaService(
+                    resourceService, configStore, complexResourceService, encryptionService, httpProxySelector);
             CatalogSchemaService catalogSchemaService = new CatalogSchemaService(resourceService, configStore, encryptionService);
 
             ResourceAuthSettingsService resourceAuthSettingsService = getResourceAuthSettingsService(
@@ -306,11 +317,6 @@ public class AiDial {
 
             UpstreamCacheService upstreamCacheService = new UpstreamCacheService(redis, lockService, clock, storage.getPrefix());
             UpstreamRouteProvider upstreamRouteProvider = new UpstreamRouteProvider(vertx, taskExecutor, Random::new, upstreamCacheService);
-
-            ComplexResourceService.Settings complexResourceSettings = Json.decodeValue(
-                    settings("complexResource").toBuffer(), ComplexResourceService.Settings.class);
-            ComplexResourceService complexResourceService = new ComplexResourceService(
-                    resourceService, lockService, storage, complexResourceSettings);
 
             ResourceOperationService resourceOperationService = new ResourceOperationService(applicationService,
                     toolSetService, resourceService, invitationService, shareService, lockService, complexResourceService);

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
@@ -7,6 +7,7 @@ import com.epam.aidial.core.metaschemas.CopyAppBucketOptions;
 import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
 import com.epam.aidial.core.server.config.ConfigStore;
 import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.service.resource.ComplexResourceService;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaProcessingException;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResourceDescriptorFactory;
@@ -112,6 +113,7 @@ public class ApplicationSchemaService {
 
     private final ResourceService resourceService;
     private final ConfigStore configStore;
+    private final ComplexResourceService complexResourceService;
 
     private final EncryptionService encryptionService;
 
@@ -140,9 +142,11 @@ public class ApplicationSchemaService {
     private final ConcurrentHashMap<URI, CachedSchema> schemaCache = new ConcurrentHashMap<>();
 
     public ApplicationSchemaService(ResourceService resourceService, ConfigStore configStore,
+                                    ComplexResourceService complexResourceService,
                                     EncryptionService encryptionService, @Nullable ProxySelector proxySelector) {
         this.resourceService = resourceService;
         this.configStore = configStore;
+        this.complexResourceService = complexResourceService;
         this.encryptionService = encryptionService;
         HttpClient.Builder builder = HttpClient.newBuilder();
         builder.connectTimeout(Duration.of(5, ChronoUnit.SECONDS));
@@ -154,9 +158,11 @@ public class ApplicationSchemaService {
 
     @VisibleForTesting
     ApplicationSchemaService(ResourceService resourceService, ConfigStore configStore,
+                             ComplexResourceService complexResourceService,
                              EncryptionService encryptionService, HttpClient httpClient) {
         this.resourceService = resourceService;
         this.configStore = configStore;
+        this.complexResourceService = complexResourceService;
         this.encryptionService = encryptionService;
         this.httpClient = httpClient;
     }
@@ -453,7 +459,7 @@ public class ApplicationSchemaService {
                     ResourceDescriptor descriptor = ResourceDescriptorFactory.fromAnyUrl(item, encryptionService);
                     ResourceType type = descriptor.getType();
                     if (resourceTypes.contains(type)) {
-                        if (!descriptor.isFolder() && !resourceService.hasResource(descriptor)) {
+                        if (!descriptor.isFolder() && !hasResource(descriptor)) {
                             throw new ApplicationTypeResourceException("Resource listed as dependent to the application is not found", item);
                         }
                         result.add(descriptor);
@@ -468,6 +474,12 @@ public class ApplicationSchemaService {
         } catch (Exception e) {
             throw new ApplicationTypeSchemaProcessingException("Failed to obtain list of resources attached to the custom app", e);
         }
+    }
+
+    private boolean hasResource(ResourceDescriptor resource) {
+        return resource.getType() == ResourceTypes.SKILL
+                ? complexResourceService.getMarker(resource) != null
+                : resourceService.hasResource(resource);
     }
 
     @Nullable

--- a/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/ApplicationSchemaService.java
@@ -478,7 +478,7 @@ public class ApplicationSchemaService {
 
     private boolean hasResource(ResourceDescriptor resource) {
         return resource.getType() == ResourceTypes.SKILL
-                ? complexResourceService.getMarker(resource) != null
+                ? complexResourceService.hasResource(resource)
                 : resourceService.hasResource(resource);
     }
 

--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -487,6 +487,15 @@ public class ComplexResourceService {
     }
 
     /**
+     * Checks whether the given complex resource (e.g. a {@code SKILL}) exists, i.e. has an
+     * active {@code .dial-resource} marker. Complex resources have no blob at their bare URL
+     * key, so this must be used instead of a plain blob/Redis existence check.
+     */
+    public boolean hasResource(ResourceDescriptor resource) {
+        return getMarker(resource) != null;
+    }
+
+    /**
      * Resolves the {@code .dial-resource} marker for a whole-resource GET. Returns {@code null} if the path
      * is absent or in the {@code deleting} state (→ 404), or throws {@code 400} if the path is a DIAL folder
      * (clients must use the metadata listing for folders).

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -4,7 +4,6 @@ import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.server.config.ConfigStore;
-import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
 import com.epam.aidial.core.server.security.EncryptionService;
 import com.epam.aidial.core.server.service.resource.ComplexResourceService;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaProcessingException;
@@ -842,7 +841,7 @@ public class ApplicationSchemaServiceTest {
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
         application.setApplicationProperties(customProperties);
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
-        when(complexResourceService.getMarker(any())).thenReturn(mock(FolderResourceMarker.class));
+        when(complexResourceService.hasResource(any())).thenReturn(true);
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
 
         List<ResourceDescriptor> result = service.getSkills(application);
@@ -867,7 +866,7 @@ public class ApplicationSchemaServiceTest {
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
         application.setApplicationProperties(customProperties);
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
-        when(complexResourceService.getMarker(any())).thenReturn(null);
+        when(complexResourceService.hasResource(any())).thenReturn(false);
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
 
         Assertions.assertThrows(ApplicationTypeResourceException.class, () -> service.getSkills(application));

--- a/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/ApplicationSchemaServiceTest.java
@@ -4,7 +4,9 @@ import com.epam.aidial.core.config.Application;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Route;
 import com.epam.aidial.core.server.config.ConfigStore;
+import com.epam.aidial.core.server.data.folder.FolderResourceMarker;
 import com.epam.aidial.core.server.security.EncryptionService;
+import com.epam.aidial.core.server.service.resource.ComplexResourceService;
 import com.epam.aidial.core.server.util.ApplicationTypeSchemaProcessingException;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.validation.ApplicationTypeResourceException;
@@ -47,6 +49,8 @@ public class ApplicationSchemaServiceTest {
     private ResourceService resourceService;
     @Mock
     private EncryptionService encryptionService;
+    @Mock
+    private ComplexResourceService complexResourceService;
 
     @Mock
     private HttpClient httpClient;
@@ -152,7 +156,7 @@ public class ApplicationSchemaServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new ApplicationSchemaService(resourceService, configStore, encryptionService, httpClient);
+        service = new ApplicationSchemaService(resourceService, configStore, complexResourceService, encryptionService, httpClient);
         customProperties.putAll(clientProperties);
         customProperties.putAll(serverProperties);
         application = new Application();
@@ -838,7 +842,7 @@ public class ApplicationSchemaServiceTest {
         when(config.getCustomApplicationSchema(any())).thenReturn(schema);
         application.setApplicationProperties(customProperties);
         application.setApplicationTypeSchemaId(URI.create("schemaId"));
-        when(resourceService.hasResource(any())).thenReturn(true);
+        when(complexResourceService.getMarker(any())).thenReturn(mock(FolderResourceMarker.class));
         when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
 
         List<ResourceDescriptor> result = service.getSkills(application);
@@ -854,6 +858,19 @@ public class ApplicationSchemaServiceTest {
         List<ResourceDescriptor> result = service.getSkills(application);
 
         Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getSkills_throwsException_whenResourceNotFound() {
+        customProperties.put("toolset", Map.of("name", "my-skill", "dial_id", "skills/bucket/my-skill"));
+        when(configStore.get()).thenReturn(config);
+        when(config.getCustomApplicationSchema(any())).thenReturn(schema);
+        application.setApplicationProperties(customProperties);
+        application.setApplicationTypeSchemaId(URI.create("schemaId"));
+        when(complexResourceService.getMarker(any())).thenReturn(null);
+        when(encryptionService.decrypt(anyString())).thenReturn("/Users/123/");
+
+        Assertions.assertThrows(ApplicationTypeResourceException.class, () -> service.getSkills(application));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Custom "typed" applications can declare a `dial:resource` schema property pointing at a skill resource (`skills/<bucket>/<path>`). Every chat completion to such an app failed with `403 Forbidden` ("Resource listed as dependent to the application is not found"), even though the skill genuinely existed.
- Root cause: `ApplicationSchemaService.getApplicationResources` checked existence via `ResourceService#hasResource`, a plain single-blob check. Skills are complex/versioned folder resources with no blob at their bare URL key, so the check always returned `false`.
- Fix: dispatch to a marker-based existence check for `SKILL` resources, exposed as `ComplexResourceService#hasResource` (reusing the existing `getMarker` logic), and used by `ApplicationSchemaService`'s dependency-resolution check — mirroring the pattern already used in `ResourceOperationService`.

Fixes #1905

## Test plan
- [x] `./gradlew :server:compileJava :server:compileTestJava`
- [x] `./gradlew :server:checkstyleMain :server:checkstyleTest`
- [x] `./gradlew :server:test` (full suite, incl. new/updated `ApplicationSchemaServiceTest` skill tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)