### PR TITLE
fix: skill file listing reports subfolders as nodeType ITEM #1912

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/resource/ComplexResourceService.java
@@ -651,7 +651,12 @@ public class ComplexResourceService {
         for (MetadataBase item : raw.getItems()) {
             boolean folder = item.getNodeType() == NodeType.FOLDER;
             String relativePath = versionFolder.getRelativePath(item.getDescriptor());
-            ResourceItemMetadata file = new ResourceItemMetadata(displayFileDescriptor(resource, relativePath, folder));
+            ResourceDescriptor descriptor = displayFileDescriptor(resource, relativePath, folder);
+            if (folder) {
+                items.add(new ResourceFolderMetadata(descriptor));
+                continue;
+            }
+            ResourceItemMetadata file = new ResourceItemMetadata(descriptor);
             if (item instanceof ResourceItemMetadata source) {
                 file.setEtag(source.getEtag());
                 file.setCreatedAt(source.getCreatedAt());

--- a/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/SkillResourceApiTest.java
@@ -441,9 +441,15 @@ public class SkillResourceApiTest extends ResourceBaseTest {
         verify(uploadSkill("/files-skill", files), 200);
 
         // non-recursive: immediate entries of the version, under a clean .../files/ url (version prefix hidden)
-        Set<String> immediate = childUrls(listSkillFiles("/files-skill"));
+        Response listing = listSkillFiles("/files-skill");
+        Set<String> immediate = childUrls(listing);
         assertTrue(immediate.contains("skills/" + bucket + "/files-skill/files/SKILL.md"), immediate.toString());
         assertTrue(immediate.contains("skills/" + bucket + "/files-skill/files/scripts/"), immediate.toString());
+
+        // nodeType must distinguish files from subfolders, just like the v1 metadata API
+        Map<String, String> nodeTypes = childNodeTypes(listing);
+        assertEquals("ITEM", nodeTypes.get("SKILL.md"));
+        assertEquals("FOLDER", nodeTypes.get("scripts"));
 
         // recursive: all files flattened
         Set<String> all = childUrls(send(HttpMethod.GET,


### PR DESCRIPTION
The non-recursive skill file listing endpoint (`GET /v2/metadata/skills/{bucket}/{path}/files/`) reported directory entries with `"nodeType": "ITEM"` instead of `"FOLDER"`, unlike the `/v1/metadata/files/{bucket}/{path}` endpoint. Clients relying on `nodeType` to tell files from directories were misled.

### Applicable issues

- fixes #1912

### Description of changes

- `ComplexResourceService.listFiles()` now constructs a `ResourceFolderMetadata` (nodeType `FOLDER`) for directory entries instead of always wrapping every entry in `ResourceItemMetadata` (nodeType `ITEM`), mirroring the existing branch used by `ResourceService.storageToResourceMetadata`.
- Extended `testMetadataFilesListing` in `SkillResourceApiTest` to assert `nodeType` is `ITEM` for a file and `FOLDER` for a subfolder in the non-recursive listing.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.