### PR TITLE
feat: support defaults on interfaces level

### DIFF
--- a/config/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/config/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -63,11 +63,15 @@ public abstract class Deployment extends RoleBasedEntity {
     @JsonAlias({"maxInputAttachments", "max_input_attachments"})
     private Integer maxInputAttachments;
     /**
-     * Default parameters are applied if a request doesn't contain them in OpenAI chat/completions API call.
+     * Default parameters applied to an OpenAI chat/completions or embeddings request that does not carry
+     * them. Used only where the interface entry declares no {@code defaults} of its own, see
+     * {@link #resolveDefaults}.
      */
     private Map<String, Object> defaults = Map.of();
     /**
-     * Default parameters are applied if a request doesn't contain them in OpenAI Responses API call.
+     * Default parameters applied to an OpenAI Responses API request that does not carry them. Used only
+     * where {@code interfaces.openaiResponses} declares no {@code defaults} of its own, see
+     * {@link #resolveDefaults}.
      */
     private Map<String, Object> responsesDefaults = Map.of();
     /**
@@ -152,5 +156,29 @@ public abstract class Deployment extends RoleBasedEntity {
         merged.putAll(defaultHeaders);
         merged.putAll(interfaceHeaders);
         return merged;
+    }
+
+    /**
+     * The default body parameters in force for the interface type: {@code interfaces.<type>.defaults} when
+     * the entry declares any, and the deployment-level defaults serving that interface otherwise. One set
+     * or the other, never both — an interface declaring its own replaces the deployment-level set rather
+     * than adding to it.
+     *
+     * <p>Which deployment-level field serves an interface is fixed per type, and Anthropic has none:
+     * {@link #defaults} and {@link #responsesDefaults} hold OpenAI parameters, so a deployment defaults an
+     * Anthropic parameter on the interface entry or nowhere.
+     */
+    public Map<String, Object> resolveDefaults(InterfaceType type) {
+        DeploymentInterface declared = interfaces == null ? null : interfaces.get(type.getValue());
+        Map<String, Object> interfaceDefaults = declared == null ? Map.of() : declared.getDefaults();
+        if (!interfaceDefaults.isEmpty()) {
+            return interfaceDefaults;
+        }
+        return switch (type) {
+            // an embeddings request is an OpenAI one, and predates the split into typed interfaces
+            case OPENAI_CHAT_COMPLETIONS, OPENAI_EMBEDDINGS -> defaults;
+            case OPENAI_RESPONSES -> responsesDefaults;
+            case ANTHROPIC_MESSAGES -> Map.of();
+        };
     }
 }

--- a/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
+++ b/config/src/main/java/com/epam/aidial/core/config/DeploymentInterface.java
@@ -46,6 +46,14 @@ public class DeploymentInterface {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> defaultHeaders = Map.of();
 
+    /**
+     * Body parameters added to a request for this interface that carries none under that key. Declaring
+     * any replaces the deployment-level defaults for this interface rather than adding to them.
+     * Resolved by {@link Deployment#resolveDefaults}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, Object> defaults = Map.of();
+
     public DeploymentInterface(String baseUrl) {
         this.baseUrl = baseUrl;
     }

--- a/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
+++ b/config/src/test/java/com/epam/aidial/core/config/DeploymentTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -7,6 +8,7 @@ import java.util.Map;
 
 import static com.epam.aidial.core.config.InterfaceType.ANTHROPIC_MESSAGES;
 import static com.epam.aidial.core.config.InterfaceType.OPENAI_CHAT_COMPLETIONS;
+import static com.epam.aidial.core.config.InterfaceType.OPENAI_EMBEDDINGS;
 import static com.epam.aidial.core.config.InterfaceType.OPENAI_RESPONSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -144,6 +146,93 @@ public class DeploymentTest {
 
         assertEquals(source.getInterfaces(), copy.getInterfaces());
         assertEquals("http://adapter", copy.getInterfaces().get(OPENAI_RESPONSES.getValue()).getBaseUrl());
+    }
+
+    @Test
+    void defaultsServeTheOpenAiInterfacesTheyBelongTo() {
+        Model model = new Model();
+        model.setDefaults(Map.of("temperature", 1));
+        model.setResponsesDefaults(Map.of("store", false));
+
+        // chat completions and embeddings share the field that predates the split into typed interfaces
+        assertEquals(Map.of("temperature", 1), model.resolveDefaults(OPENAI_CHAT_COMPLETIONS));
+        assertEquals(Map.of("temperature", 1), model.resolveDefaults(OPENAI_EMBEDDINGS));
+        assertEquals(Map.of("store", false), model.resolveDefaults(OPENAI_RESPONSES));
+        // neither holds Anthropic parameters, so neither reaches the Anthropic interface
+        assertEquals(Map.of(), model.resolveDefaults(ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void interfaceDefaultsReplaceTheDeploymentLevelRatherThanAddingToIt() {
+        DeploymentInterface chatCompletions = new DeploymentInterface("http://openai");
+        chatCompletions.setDefaults(Map.of("temperature", 0.5));
+        Model model = new Model();
+        model.setDefaults(Map.of("temperature", 1, "custom_fields", Map.of("configuration", "foo.baz")));
+        model.setInterfaces(Map.of(OPENAI_CHAT_COMPLETIONS.getValue(), chatCompletions));
+
+        // the entry declares defaults, so they are the whole set: custom_fields is not laid under them
+        assertEquals(Map.of("temperature", 0.5), model.resolveDefaults(OPENAI_CHAT_COMPLETIONS));
+        // and it speaks for its own interface alone, so embeddings still take the deployment level
+        assertEquals(
+                Map.of("temperature", 1, "custom_fields", Map.of("configuration", "foo.baz")),
+                model.resolveDefaults(OPENAI_EMBEDDINGS));
+    }
+
+    @Test
+    void anthropicDefaultsComeFromTheInterfaceEntryAlone() {
+        DeploymentInterface anthropic = new DeploymentInterface("http://anthropic");
+        anthropic.setDefaults(Map.of("temperature", 0.5));
+        Model model = new Model();
+        model.setDefaults(Map.of("temperature", 1));
+        model.setResponsesDefaults(Map.of("store", false));
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), anthropic));
+
+        // nothing of the deployment level is laid under it
+        assertEquals(Map.of("temperature", 0.5), model.resolveDefaults(ANTHROPIC_MESSAGES));
+    }
+
+    @Test
+    void defaultsFallBackToDeploymentLevelForAnInterfaceDeclaringNone() {
+        Model model = new Model();
+        model.setDefaults(Map.of("temperature", 1));
+        model.setInterfaces(Map.of(OPENAI_CHAT_COMPLETIONS.getValue(), new DeploymentInterface("http://openai")));
+
+        // declared without defaults of its own, and not declared at all, resolve alike
+        assertEquals(Map.of("temperature", 1), model.resolveDefaults(OPENAI_CHAT_COMPLETIONS));
+        assertEquals(Map.of("temperature", 1), model.resolveDefaults(OPENAI_EMBEDDINGS));
+    }
+
+    @Test
+    void roundTripInterfaceDefaults() throws Exception {
+        String json = """
+                {
+                    "endpoint": "http://host/chat/completions",
+                    "defaults": {"temperature": 1},
+                    "interfaces": {
+                        "anthropicMessages": {
+                            "base_url": "http://anthropic",
+                            "defaults": {"temperature": 0.5, "max_tokens": 1024}
+                        }
+                    }
+                }
+                """;
+
+        Model restored = MAPPER.readValue(MAPPER.writeValueAsString(MAPPER.readValue(json, Model.class)), Model.class);
+
+        assertEquals(Map.of("temperature", 0.5, "max_tokens", 1024), restored.resolveDefaults(ANTHROPIC_MESSAGES));
+        assertEquals(Map.of("temperature", 1), restored.resolveDefaults(OPENAI_CHAT_COMPLETIONS));
+    }
+
+    @Test
+    void interfaceDefaultsAreOmittedWhenEmpty() throws Exception {
+        Model model = new Model();
+        model.setInterfaces(Map.of(ANTHROPIC_MESSAGES.getValue(), new DeploymentInterface("http://anthropic")));
+
+        JsonNode declared = MAPPER.readTree(MAPPER.writeValueAsString(model))
+                .path("interfaces").path(ANTHROPIC_MESSAGES.getValue());
+
+        // the deployment-level defaults serialize either way, so the check has to be scoped to the entry
+        assertFalse(declared.has("defaults"), declared.toString());
     }
 
     @Test

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -48,7 +48,7 @@ An object containing parameters for each [application](#applications).
 * `dependencies`: A list of dependent deployments (applications, AI models) which the application may use. Refer to [Managing Authorization in Complex Application Ecosystems](https://docs.dialx.ai/tutorials/developers/apps-development/auth-matrix) to learn more about dependencies.
 * `viewerUrl`: A string with URL of the application's [custom viewer UI](https://github.com/epam/ai-dial-chat/tree/development/docs). A custom UI, if enabled, will override the standard DIAL Chat UI.
 * `editorUrl`: A string with URL of the application's custom builder UI. Application builder allows DIAL Chat end-users to create instances of apps using a [UI wizards](https://docs.dialx.ai/tutorials/user-guide#application-builder).
-* `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.         
+* `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call. Used only where the interface entry declares no `defaults` of its own. Refer to [applications.<application_name>.interfaces](#applicationsapplication_nameinterfaces).
 * `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them. Refer to [applications.<application_name>.defaultHeaders](#applicationsapplication_namedefaultheaders).
 * `interceptors`: A list of local interceptors to be triggered for the given application. Refer to [Interceptors](./interceptors.md) to learn more.
 * `mcp`: MCP configuration. Refer to [MCP](#applicationsapplication_namemcp) to learn more.
@@ -157,6 +157,7 @@ Each value is an object with the following fields:
 
 * `base_url`: The root URL that the matching ingress path is appended to. Optional — the application-level `baseUrl` serves an entry that omits it.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the application-level `defaultHeaders`. Refer to [applications.<application_name>.defaultHeaders](#applicationsapplication_namedefaultheaders).
+* `defaults`: Body parameters applied to requests for this interface only. Unlike `defaultHeaders`, the two levels are **not** merged: an entry declaring `defaults` states the whole set and **replaces** the application-level `defaults`, so a key it does not name is not defaulted at all. The application-level `defaults` applies only where the entry declares none. Whatever the source, a default is only a fallback — a parameter the request body already carries is never replaced.
 
 **Example**
 

--- a/docs/dynamic-settings/interceptors.md
+++ b/docs/dynamic-settings/interceptors.md
@@ -46,7 +46,7 @@ An object containing parameters for each [interceptor](#interceptors).
 * `updatedAt`: The date of the last interceptor update.
 * `features`: Features supported by the interceptors.
 *  `configurationEndpoint`: The URL that exposes the configuration of the interceptor.
-*  `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.
+*  `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call. Used only where the interface entry declares no `defaults` of its own. Refer to [interceptors.<interceptor_name>.interfaces](#interceptorsinterceptor_nameinterfaces).
 *  `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them, on the hop that calls this interceptor. Refer to [interceptors.<interceptor_name>.defaultHeaders](#interceptorsinterceptor_namedefaultheaders).
 
 ### interceptors.<interceptor_name>.interfaces
@@ -65,6 +65,7 @@ Each value is an object with the following fields:
 
 * `base_url`: The interceptor service root that the matching ingress path is appended to. Optional — the interceptor-level `baseUrl` serves an entry that omits it.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the interceptor-level `defaultHeaders`. Refer to [interceptors.<interceptor_name>.defaultHeaders](#interceptorsinterceptor_namedefaultheaders).
+* `defaults`: Body parameters applied to requests for this interface only. Unlike `defaultHeaders`, the two levels are **not** merged: an entry declaring `defaults` states the whole set and **replaces** the interceptor-level `defaults`, so a key it does not name is not defaulted at all. The interceptor-level `defaults` applies only where the entry declares none. Whatever the source, a default is only a fallback — a parameter the request body already carries is never replaced.
 
 **Example**
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -41,7 +41,7 @@ An object containing parameters for each [model](#models).
 * `author`: The model's developer.
 * `createdAt`: The date of the model creation.
 * `updatedAt`: The date of the last model update.
-* `defaults`: Default parameters are applied if a request doesn't contain them in OpenAI `chat/completions` API call.
+* `defaults`: Default parameters are applied if a request doesn't contain them in an OpenAI `chat/completions` or `embeddings` API call. Used only where the interface entry declares no `defaults` of its own. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `responsesEndpoint`: Endpoint of the model adapter that supports the OpenAI Responses API. Currently only OpenAI adapters support this. When set, DIAL Core proxies the following Responses API operations to this endpoint:
   * `POST /openai/v1/responses` — create a response (streaming and non-streaming, including background mode).
   * `GET /openai/v1/responses/{id}` — retrieve a response by its DIAL-assigned ID; supports streaming via SSE.
@@ -49,7 +49,7 @@ An object containing parameters for each [model](#models).
   * `POST /openai/v1/responses/{id}/cancel` — cancel an in-progress background response.
 
   DIAL Core rewrites upstream response IDs to stable `resp_dial_*` identifiers and uses sticky routing to ensure follow-up requests are forwarded to the same upstream instance that handled the original request. `previous_response_id`, conversations, prompts, and files are not supported.
-* `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API.
+* `responsesDefaults`: Default parameters applied if a request doesn't contain them in an OpenAI Responses API call. Works the same way as `defaults` for the chat completions API, and is used only where `interfaces.openaiResponses` declares no `defaults` of its own.
 * `defaultHeaders`: HTTP headers DIAL Core adds to a request that doesn't already carry them, for every interface the model serves. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
 * `baseUrl`: The root URL shared by every `interfaces` entry that declares no `base_url` of its own. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
 * `interfaces`: An alternative to the flat `endpoint`/`responsesEndpoint` fields for declaring routing targets, keyed by interface type. Both shapes are first-class — pick whichever you prefer per model. Refer to [models.<model_name>.interfaces](#modelsmodel_nameinterfaces).
@@ -182,6 +182,7 @@ Each value is an object with the following fields:
 * `mode`: `passthrough` (default) or `translator`. It declares whether the request is forwarded in the shape it arrived in, or handed to a service that translates it into an API the model does speak. A `translator` interface **does not touch the caller's [role limits](roles.md#rolesrole_namelimits)** — neither checks nor charges them. The translator calls DIAL Core back to have the completion served, and that second call is the real request: it carries the tokens, the cost and the `requestHour`/`requestDay` slot, so a client call is counted once rather than twice. An exhausted quota is therefore enforced on the callback rather than on the translated call itself. Refer to [Limits and a translated request](translators.md#limits-and-a-translated-request).
 * `translator`: The translator serving this interface, required by `mode: translator` and rejected without it. Either the name of a [translators](translators.md) entry, or a definition written inline as `{"out": ..., "baseUrl": ...}`. An interface is served either by a base URL or by a translator, never by both — a model declaring both is rejected on config load.
 * `defaultHeaders`: Headers applied to requests for this interface only, laid over the model-level `defaultHeaders`. Refer to [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders).
+* `defaults`: Body parameters applied to requests for this interface only, replacing whichever model-level defaults would otherwise serve it. They are injected the same way the model-level ones are — a key the request already carries is never replaced. Refer to [Defaults per interface](#defaults-per-interface).
 
 **Example**
 
@@ -223,6 +224,50 @@ An object of HTTP header names and values DIAL Core adds to a request that does 
 A default header behaves exactly as if the client had sent it: DIAL Core reads it as part of the incoming request — so `X-DIAL-CACHE-POLICY` set this way drives upstream cache pinning, not just what the adapter receives — and forwards it under the same rules as a client header. That cuts both ways: a name DIAL Core strips on the way to the model — a hop-by-hop header, `Api-Key`/`x-api-key`, `traceparent`/`tracestate`, or `Authorization` unless `forwardAuthToken` is set — is stripped when it comes from `defaultHeaders` too, even though DIAL Core itself still sees it on the incoming request.
 
 The model-level `defaultHeaders` apply to every interface the model serves. `interfaces.<type>.defaultHeaders` is laid over them for that interface only: a name it repeats is overridden, a new name is added, and every other model-level header still applies.
+
+### Defaults per interface
+
+Unlike `defaultHeaders`, the model-level defaults are **not** shared by every interface — each holds parameters of one API, so each serves only the interfaces speaking that API:
+
+| Interface | Model-level source (fallback) | Interface-level, when declared |
+|---|---|---|
+| `openaiChatCompletions` | `defaults` | `interfaces.openaiChatCompletions.defaults` |
+| `openaiEmbeddings` | `defaults` | `interfaces.openaiEmbeddings.defaults` |
+| `openaiResponses` | `responsesDefaults` | `interfaces.openaiResponses.defaults` |
+| `anthropicMessages` | *none* | `interfaces.anthropicMessages.defaults` |
+
+`defaults` and `responsesDefaults` hold OpenAI parameters, so **neither reaches an Anthropic request**: a model defaults an Anthropic parameter on `interfaces.anthropicMessages.defaults` or nowhere.
+
+Unlike `defaultHeaders`, the two levels are **not** merged. An interface entry declaring `defaults` states the whole set for that interface, and the model-level source is not laid under it — a key it does not name is simply not defaulted. The model-level source applies only where the entry declares no `defaults` at all.
+
+Each entry speaks for its own interface alone: `interfaces.openaiChatCompletions.defaults` does not reach an `embeddings` request, which takes the model-level `defaults` unless `interfaces.openaiEmbeddings.defaults` declares its own.
+
+Whatever the source, a default is only ever a **fallback**: a parameter the request body already carries is taken from the request, and one it omits is filled in from the defaults. That is unchanged from how the model-level `defaults` has always behaved.
+
+```json
+"openai-gpt-5.4-mini": {
+    "type": "chat",
+    "baseUrl": "http://dial-openai-adapter",
+    "defaults": {
+        "temperature": 1,
+        "custom_fields": { "configuration": "foo.baz" }
+    },
+    "interfaces": {
+        "openaiChatCompletions": { "mode": "passthrough" },
+        "openaiResponses": { "mode": "passthrough" },
+        "anthropicMessages": {
+            "mode": "passthrough",
+            "defaults": { "temperature": 0.5 }
+        }
+    }
+}
+```
+
+Effective defaults for that model:
+
+* `POST /openai/deployments/{name}/chat/completions` and `POST /openai/deployments/{name}/embeddings` — `{"temperature": 1, "custom_fields": {"configuration": "foo.baz"}}`, from the model level, since neither entry declares `defaults`.
+* `POST /openai/v1/responses` — nothing: `responsesDefaults` is absent and the entry declares no `defaults` of its own. The model-level `defaults` does not serve this interface.
+* `POST /anthropic/v1/messages` — `{"temperature": 0.5}` and nothing else: the entry declares `defaults`, so that is the whole set.
 
 They are applied once per request, when it enters the model: with `interceptors` configured that is the hop to the first interceptor, from where they travel down the chain. An interceptor's own `defaultHeaders` are applied on the hop that calls it and take precedence over the model's.
 

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -15143,6 +15143,8 @@ components:
           $ref: "#/components/schemas/InterfaceMode"
         translator:
           $ref: "#/components/schemas/TranslatorRef"
+        defaults:
+          $ref: "#/components/schemas/MapStringObject"
     EmbeddingResponse:
       required:
       - data

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
@@ -23,9 +23,15 @@ import java.util.List;
 
 public class ChatCompletionInterceptorController extends BaseInterceptorController {
 
-    public ChatCompletionInterceptorController(Proxy proxy, ProxyContext context, int interceptorIndex) {
+    /**
+     * @param requestedInterface the interface the client called, {@link InterfaceType#OPENAI_EMBEDDINGS} for an
+     *                           embeddings request. The interceptor itself is always addressed on its chat
+     *                           completions interface, which is the only one it may declare.
+     */
+    public ChatCompletionInterceptorController(Proxy proxy, ProxyContext context, int interceptorIndex,
+                                               InterfaceType requestedInterface) {
         super(proxy, context, interceptorIndex, List.of(
-                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS, requestedInterface),
                 new EnhanceDeploymentRequestFn(proxy, context),
                 new CollectRequestStandardAttachmentsFn(proxy, context),
                 new AutoShareDeploymentFn(proxy, context)));

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
@@ -25,8 +25,8 @@ public class ChatCompletionInterceptorController extends BaseInterceptorControll
 
     /**
      * @param requestedInterface the interface the client called, {@link InterfaceType#OPENAI_EMBEDDINGS} for an
-     *                           embeddings request. The interceptor itself is always addressed on its chat
-     *                           completions interface, which is the only one it may declare.
+     *                           embeddings request. It reaches the interceptor over the interceptor's chat
+     *                           completions interface, which is the only one {@link #buildUri} addresses it on.
      */
     public ChatCompletionInterceptorController(Proxy proxy, ProxyContext context, int interceptorIndex,
                                                InterfaceType requestedInterface) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorController.java
@@ -25,13 +25,13 @@ public class ChatCompletionInterceptorController extends BaseInterceptorControll
 
     /**
      * @param requestedInterface the interface the client called, {@link InterfaceType#OPENAI_EMBEDDINGS} for an
-     *                           embeddings request. It reaches the interceptor over the interceptor's chat
-     *                           completions interface, which is the only one {@link #buildUri} addresses it on.
+     *                           embeddings request. Both the interceptor and the deployment it fronts resolve
+     *                           their settings under it, however {@link #buildUri} routes this hop.
      */
     public ChatCompletionInterceptorController(Proxy proxy, ProxyContext context, int interceptorIndex,
                                                InterfaceType requestedInterface) {
         super(proxy, context, interceptorIndex, List.of(
-                new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS, requestedInterface),
+                new ApplyDefaultDeploymentSettingsFn(proxy, context, requestedInterface),
                 new EnhanceDeploymentRequestFn(proxy, context),
                 new CollectRequestStandardAttachmentsFn(proxy, context),
                 new AutoShareDeploymentFn(proxy, context)));

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentPostController.java
@@ -240,7 +240,7 @@ public class DeploymentPostController extends BaseDeploymentPostController {
     private Future<?> handleInterceptor(int interceptorIndex) {
         List<String> interceptors = context.getInterceptors();
         if (interceptorIndex < interceptors.size()) {
-            return new ChatCompletionInterceptorController(proxy, context, interceptorIndex).handle();
+            return new ChatCompletionInterceptorController(proxy, context, interceptorIndex, requestedInterface()).handle();
         } else { // all interceptors are completed we should call the initial deployment
             return handleDeployment(context.getApiKeyData().getInitialDeployment());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
@@ -17,25 +17,15 @@ import java.util.Map;
 public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<RequestObject> {
 
     /**
-     * The interface the deployment this hop calls is addressed on. On the hop that calls an interceptor
-     * that is the interceptor's own interface, which is not necessarily the one the client called.
+     * The interface the client called. Every deployment this hop applies settings for resolves them under
+     * it - the interceptor it calls as much as the deployment the chain fronts - whatever interface the
+     * hop is routed on.
      */
-    private final InterfaceType servingInterface;
-    /**
-     * The interface the client called. The deployment the interceptor chain fronts resolves its settings
-     * under this one however the hops in front of it are addressed.
-     */
-    private final InterfaceType requestedInterface;
+    private final InterfaceType interfaceType;
 
     public ApplyDefaultDeploymentSettingsFn(Proxy proxy, ProxyContext context, InterfaceType interfaceType) {
-        this(proxy, context, interfaceType, interfaceType);
-    }
-
-    public ApplyDefaultDeploymentSettingsFn(Proxy proxy, ProxyContext context,
-                                            InterfaceType servingInterface, InterfaceType requestedInterface) {
         super(proxy, context);
-        this.servingInterface = servingInterface;
-        this.requestedInterface = requestedInterface;
+        this.interfaceType = interfaceType;
     }
 
     @Override
@@ -49,7 +39,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
         request.clearInterceptorSettings();
         Deployment deployment = context.getDeployment();
         if (deployment instanceof Interceptor) {
-            applyDefaults(request, deployment, servingInterface);
+            applyDefaults(request, deployment);
         }
     }
 
@@ -60,7 +50,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
                 String deploymentId = context.getInitialDeployment();
                 deployment = proxy.getDeploymentService().findDeployment(context, deploymentId);
             }
-            applyDefaults(request, deployment, requestedInterface);
+            applyDefaults(request, deployment);
         }
     }
 
@@ -69,9 +59,9 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
      * already carries. At the first interceptor that means the interceptor's own settings, applied first,
      * take precedence over the ones of the deployment it fronts.
      */
-    private void applyDefaults(RequestObject request, Deployment deployment, InterfaceType interfaceType) {
+    private void applyDefaults(RequestObject request, Deployment deployment) {
         request.applyDefaults(deployment.resolveDefaults(interfaceType));
-        applyDefaultHeaders(deployment, interfaceType);
+        applyDefaultHeaders(deployment);
     }
 
     /**
@@ -80,7 +70,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
      * the client had sent them: the core's own header reads see them, and they reach the deployment
      * through the same copy - and the same exclusions - as client headers.
      */
-    private void applyDefaultHeaders(Deployment deployment, InterfaceType interfaceType) {
+    private void applyDefaultHeaders(Deployment deployment) {
         Map<String, String> defaultHeaders = deployment.resolveDefaultHeaders(interfaceType);
         if (defaultHeaders.isEmpty()) {
             return;

--- a/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFn.java
@@ -16,11 +16,26 @@ import java.util.Map;
 @Slf4j
 public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<RequestObject> {
 
-    private final InterfaceType interfaceType;
+    /**
+     * The interface the deployment this hop calls is addressed on. On the hop that calls an interceptor
+     * that is the interceptor's own interface, which is not necessarily the one the client called.
+     */
+    private final InterfaceType servingInterface;
+    /**
+     * The interface the client called. The deployment the interceptor chain fronts resolves its settings
+     * under this one however the hops in front of it are addressed.
+     */
+    private final InterfaceType requestedInterface;
 
     public ApplyDefaultDeploymentSettingsFn(Proxy proxy, ProxyContext context, InterfaceType interfaceType) {
+        this(proxy, context, interfaceType, interfaceType);
+    }
+
+    public ApplyDefaultDeploymentSettingsFn(Proxy proxy, ProxyContext context,
+                                            InterfaceType servingInterface, InterfaceType requestedInterface) {
         super(proxy, context);
-        this.interfaceType = interfaceType;
+        this.servingInterface = servingInterface;
+        this.requestedInterface = requestedInterface;
     }
 
     @Override
@@ -34,7 +49,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
         request.clearInterceptorSettings();
         Deployment deployment = context.getDeployment();
         if (deployment instanceof Interceptor) {
-            applyDefaults(request, deployment);
+            applyDefaults(request, deployment, servingInterface);
         }
     }
 
@@ -45,7 +60,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
                 String deploymentId = context.getInitialDeployment();
                 deployment = proxy.getDeploymentService().findDeployment(context, deploymentId);
             }
-            applyDefaults(request, deployment);
+            applyDefaults(request, deployment, requestedInterface);
         }
     }
 
@@ -54,9 +69,9 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
      * already carries. At the first interceptor that means the interceptor's own settings, applied first,
      * take precedence over the ones of the deployment it fronts.
      */
-    private void applyDefaults(RequestObject request, Deployment deployment) {
-        request.applyDefaults(deployment);
-        applyDefaultHeaders(deployment);
+    private void applyDefaults(RequestObject request, Deployment deployment, InterfaceType interfaceType) {
+        request.applyDefaults(deployment.resolveDefaults(interfaceType));
+        applyDefaultHeaders(deployment, interfaceType);
     }
 
     /**
@@ -65,7 +80,7 @@ public class ApplyDefaultDeploymentSettingsFn extends BaseRequestFunction<Reques
      * the client had sent them: the core's own header reads see them, and they reach the deployment
      * through the same copy - and the same exclusions - as client headers.
      */
-    private void applyDefaultHeaders(Deployment deployment) {
+    private void applyDefaultHeaders(Deployment deployment, InterfaceType interfaceType) {
         Map<String, String> defaultHeaders = deployment.resolveDefaultHeaders(interfaceType);
         if (defaultHeaders.isEmpty()) {
             return;

--- a/server/src/main/java/com/epam/aidial/core/server/function/request/ChatCompletionRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/request/ChatCompletionRequest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.core.server.function.request;
 
-import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.server.data.cache.CachePrefixPath;
 import com.epam.aidial.core.server.util.ChatUtil;
 import com.epam.aidial.core.server.util.JsonUtil;
@@ -111,8 +110,8 @@ public class ChatCompletionRequest implements RequestObject {
     }
 
     @Override
-    public void applyDefaults(Deployment deployment) {
-        ChatUtil.applyDefaults(tree, deployment.getDefaults());
+    public void applyDefaults(Map<String, Object> defaults) {
+        ChatUtil.applyDefaults(tree, defaults);
     }
 
     @Override

--- a/server/src/main/java/com/epam/aidial/core/server/function/request/MessagesApiRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/request/MessagesApiRequest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.core.server.function.request;
 
-import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.server.data.cache.CachePrefixPath;
 import com.epam.aidial.core.server.util.ChatUtil;
 import com.epam.aidial.core.server.util.JsonUtil;
@@ -148,9 +147,8 @@ public class MessagesApiRequest implements RequestObject {
     }
 
     @Override
-    public void applyDefaults(Deployment deployment) {
-        // No-op: Anthropic params differ from the OpenAI chat/responses defaults, so applying
-        // Deployment defaults here would be wrong. Per-interface defaults can be added later.
+    public void applyDefaults(Map<String, Object> defaults) {
+        ChatUtil.applyDefaults(tree, defaults);
     }
 
     @Override

--- a/server/src/main/java/com/epam/aidial/core/server/function/request/RequestObject.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/request/RequestObject.java
@@ -1,9 +1,9 @@
 package com.epam.aidial.core.server.function.request;
 
-import com.epam.aidial.core.config.Deployment;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -63,11 +63,13 @@ public interface RequestObject {
     void clearInterceptorSettings();
 
     /**
-     * Applies default values from the specified deployment configuration to this request.
+     * Applies default body parameters to this request, under every key it does not already carry. Which
+     * defaults are in force is {@link com.epam.aidial.core.config.Deployment#resolveDefaults}' to decide -
+     * it depends on the interface the request arrived on, not on the shape of the request.
      *
-     * @param deployment the deployment configuration containing default values
+     * @param defaults the default values to apply
      */
-    void applyDefaults(Deployment deployment);
+    void applyDefaults(Map<String, Object> defaults);
 
     /**
      * Serializes this request to a byte array.

--- a/server/src/main/java/com/epam/aidial/core/server/function/request/ResponsesApiRequest.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/request/ResponsesApiRequest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.core.server.function.request;
 
-import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.server.data.cache.CachePrefixPath;
 import com.epam.aidial.core.server.util.ChatUtil;
 import com.epam.aidial.core.server.util.ProxyUtil;
@@ -12,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -85,8 +85,8 @@ public class ResponsesApiRequest implements RequestObject {
     }
 
     @Override
-    public void applyDefaults(Deployment deployment) {
-        ChatUtil.applyDefaults(tree, deployment.getResponsesDefaults());
+    public void applyDefaults(Map<String, Object> defaults) {
+        ChatUtil.applyDefaults(tree, defaults);
     }
 
     @Override

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorControllerTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ChatCompletionInterceptorControllerTest.java
@@ -62,7 +62,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.path()).thenReturn("/openai/deployments/original-model/chat/completions");
         when(request.query()).thenReturn(null);
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://interceptor/openai/deployments/my-interceptor/chat/completions",
@@ -80,7 +80,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.path()).thenReturn("/openai/deployments/original-model/chat/completions");
         when(request.query()).thenReturn("api-version=2024-05");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://interceptor/openai/deployments/my-interceptor/chat/completions?api-version=2024-05",
@@ -99,7 +99,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.query()).thenReturn(null);
         when(request.path()).thenReturn("/openai/deployments/original-model/chat/completions");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://adapter/openai/deployments/my-interceptor/chat/completions",
@@ -118,7 +118,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.query()).thenReturn("api-version=2024-05");
         when(request.path()).thenReturn("/openai/deployments/original-model/chat/completions");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://adapter/openai/deployments/my-interceptor/chat/completions?api-version=2024-05",
@@ -137,7 +137,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.query()).thenReturn(null);
         when(request.path()).thenReturn("/openai/deployments/model/chat/completions");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://adapter/openai/deployments/my-interceptor/chat/completions",
@@ -156,7 +156,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.query()).thenReturn("api-version=2025-01-01-preview");
         when(request.path()).thenReturn("/openai/deployments/models/platform/original-model/chat/completions");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://adapter/openai/deployments/my-interceptor/chat/completions?api-version=2025-01-01-preview",
@@ -176,7 +176,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.query()).thenReturn(null);
         when(request.path()).thenReturn("/openai/deployments/original-model/chat/completions");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals(
                 "http://adapter/openai/deployments/interceptor-override/chat/completions",
@@ -195,7 +195,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(request.query()).thenReturn(null);
         when(request.path()).thenReturn("/some/other/path");
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         assertEquals("http://adapter/some/other/path", controller.buildUri(context));
     }
@@ -223,7 +223,7 @@ public class ChatCompletionInterceptorControllerTest {
         when(context.getRequestBody()).thenCallRealMethod();
         doCallRealMethod().when(context).setRequestBody(any());
 
-        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0);
+        ChatCompletionInterceptorController controller = new ChatCompletionInterceptorController(proxy, context, 0, InterfaceType.OPENAI_CHAT_COMPLETIONS);
 
         String body = """
                 {

--- a/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
@@ -8,6 +8,7 @@ import com.epam.aidial.core.server.Proxy;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.function.request.ChatCompletionRequest;
+import com.epam.aidial.core.server.function.request.MessagesApiRequest;
 import com.epam.aidial.core.server.service.DeploymentService;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -202,6 +204,111 @@ public class ApplyDefaultDeploymentSettingsFnTest {
     }
 
     @Test
+    public void testDefaults_WhenInterfaceReplacesDeploymentLevel() throws JsonProcessingException {
+        DeploymentInterface chatCompletions = new DeploymentInterface("http://openai");
+        chatCompletions.setDefaults(Map.of("temperature", 0.5));
+        Model model = new Model();
+        model.setDefaults(Map.of("temperature", 1, "seed", 42));
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), chatCompletions));
+        stubDeployment(model);
+        ObjectNode result = emptyBody();
+
+        assertTrue(fn.apply(new ChatCompletionRequest(result)));
+
+        assertEquals(0.5, result.get("temperature").asDouble());
+        // the entry's defaults are the whole set, so a key only the model names is not applied
+        assertFalse(result.has("seed"));
+    }
+
+    @Test
+    public void testDefaults_WhenRequestAlreadyCarriesTheKey() throws JsonProcessingException {
+        DeploymentInterface chatCompletions = new DeploymentInterface("http://openai");
+        chatCompletions.setDefaults(Map.of("temperature", 0.5));
+        Model model = new Model();
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), chatCompletions));
+        stubDeployment(model);
+        ObjectNode result = (ObjectNode) ProxyUtil.MAPPER.readTree("{\"temperature\": 0.9}");
+
+        assertTrue(fn.apply(new ChatCompletionRequest(result)));
+
+        // an interface default is injected, never imposed, exactly as a deployment-level one is
+        assertEquals(0.9, result.get("temperature").asDouble());
+    }
+
+    @Test
+    public void testDefaults_WhenAnthropicInterface() throws JsonProcessingException {
+        DeploymentInterface anthropic = new DeploymentInterface("http://anthropic");
+        anthropic.setDefaults(Map.of("temperature", 0.5));
+        Model model = new Model();
+        model.setDefaults(Map.of("seed", 42));
+        model.setResponsesDefaults(Map.of("store", false));
+        model.setInterfaces(Map.of(InterfaceType.ANTHROPIC_MESSAGES.getValue(), anthropic));
+        stubDeployment(model);
+        ObjectNode result = emptyBody();
+
+        new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.ANTHROPIC_MESSAGES)
+                .apply(new MessagesApiRequest(result));
+
+        // the OpenAI parameter sets hold nothing an Anthropic request could want, so neither reaches it
+        assertEquals(0.5, result.get("temperature").asDouble());
+        assertFalse(result.has("seed"));
+        assertFalse(result.has("store"));
+    }
+
+    @Test
+    public void testDefaults_WhenEmbeddingsInterfaceDeclaresItsOwn() throws JsonProcessingException {
+        DeploymentInterface embeddings = new DeploymentInterface("http://openai");
+        embeddings.setDefaults(Map.of("dimensions", 256));
+        Model model = new Model();
+        model.setDefaults(Map.of("seed", 42));
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_EMBEDDINGS.getValue(), embeddings));
+        stubDeployment(model);
+        ObjectNode result = emptyBody();
+
+        new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_EMBEDDINGS)
+                .apply(new ChatCompletionRequest(result));
+
+        // embeddings fall back to the model-level defaults, but declaring their own replaces them
+        assertEquals(256, result.get("dimensions").asInt());
+        assertFalse(result.has("seed"));
+    }
+
+    @Test
+    public void testDefaults_AtFirstInterceptorOfAnEmbeddingsRequest() throws JsonProcessingException {
+        DeploymentInterface embeddings = new DeploymentInterface("http://openai");
+        embeddings.setDefaults(Map.of("dimensions", 256));
+        Model model = new Model();
+        model.setDefaults(Map.of("seed", 42));
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_EMBEDDINGS.getValue(), embeddings));
+        DeploymentInterface chatCompletions = new DeploymentInterface("http://interceptor");
+        chatCompletions.setDefaultHeaders(Map.of("x-dial-custom-header", "from-interceptor"));
+        Interceptor interceptor = new Interceptor();
+        interceptor.setName("interceptor1");
+        interceptor.setInterfaces(Map.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), chatCompletions));
+        ApiKeyData proxyApiKeyData = new ApiKeyData();
+        proxyApiKeyData.setInterceptors(List.of("interceptor1"));
+        proxyApiKeyData.setInterceptorIndex(0);
+        when(context.getDeployment()).thenReturn(interceptor);
+        when(context.getProxyApiKeyData()).thenReturn(proxyApiKeyData);
+        when(context.getInitialDeployment()).thenReturn("model");
+        DeploymentService deploymentService = mock(DeploymentService.class);
+        when(proxy.getDeploymentService()).thenReturn(deploymentService);
+        when(deploymentService.findDeployment(eq(context), eq("model"))).thenReturn(model);
+        MultiMap headers = stubRequestHeaders();
+        ObjectNode result = emptyBody();
+
+        new ApplyDefaultDeploymentSettingsFn(
+                proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS, InterfaceType.OPENAI_EMBEDDINGS)
+                .apply(new ChatCompletionRequest(result));
+
+        // the fronted model resolves under the interface the client called, not the one this hop addresses
+        assertEquals(256, result.get("dimensions").asInt());
+        assertFalse(result.has("seed"));
+        // while the interceptor, addressed on its own chat completions interface, still resolves under that
+        assertEquals("from-interceptor", headers.get("x-dial-custom-header"));
+    }
+
+    @Test
     public void testDefaultHeaders_WhenModelWithoutInterceptors() throws JsonProcessingException {
         Model model = new Model();
         model.setDefaultHeaders(Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar"));
@@ -319,6 +426,13 @@ public class ApplyDefaultDeploymentSettingsFnTest {
 
         // nothing to re-apply on the last hop, so the inbound request is not even touched
         verify(context, never()).getRequest();
+    }
+
+    private void stubDeployment(Model model) {
+        ApiKeyData apiKeyData = new ApiKeyData();
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getProxyApiKeyData()).thenReturn(apiKeyData);
+        when(context.getDeployment()).thenReturn(model);
     }
 
     private static ObjectNode emptyBody() throws JsonProcessingException {

--- a/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/enhancement/ApplyDefaultDeploymentSettingsFnTest.java
@@ -281,9 +281,10 @@ public class ApplyDefaultDeploymentSettingsFnTest {
         model.setDefaults(Map.of("seed", 42));
         model.setInterfaces(Map.of(InterfaceType.OPENAI_EMBEDDINGS.getValue(), embeddings));
         DeploymentInterface chatCompletions = new DeploymentInterface("http://interceptor");
-        chatCompletions.setDefaultHeaders(Map.of("x-dial-custom-header", "from-interceptor"));
+        chatCompletions.setDefaultHeaders(Map.of("x-dial-custom-header", "from-chat-completions-entry"));
         Interceptor interceptor = new Interceptor();
         interceptor.setName("interceptor1");
+        interceptor.setDefaultHeaders(Map.of("x-dial-custom-header", "from-interceptor"));
         interceptor.setInterfaces(Map.of(InterfaceType.OPENAI_CHAT_COMPLETIONS.getValue(), chatCompletions));
         ApiKeyData proxyApiKeyData = new ApiKeyData();
         proxyApiKeyData.setInterceptors(List.of("interceptor1"));
@@ -297,14 +298,13 @@ public class ApplyDefaultDeploymentSettingsFnTest {
         MultiMap headers = stubRequestHeaders();
         ObjectNode result = emptyBody();
 
-        new ApplyDefaultDeploymentSettingsFn(
-                proxy, context, InterfaceType.OPENAI_CHAT_COMPLETIONS, InterfaceType.OPENAI_EMBEDDINGS)
+        new ApplyDefaultDeploymentSettingsFn(proxy, context, InterfaceType.OPENAI_EMBEDDINGS)
                 .apply(new ChatCompletionRequest(result));
 
-        // the fronted model resolves under the interface the client called, not the one this hop addresses
+        // the fronted model resolves under the interface the client called, not the one this hop is routed on
         assertEquals(256, result.get("dimensions").asInt());
         assertFalse(result.has("seed"));
-        // while the interceptor, addressed on its own chat completions interface, still resolves under that
+        // and so does the interceptor, so its chat completions entry gives way to its deployment-level header
         assertEquals("from-interceptor", headers.get("x-dial-custom-header"));
     }
 

--- a/server/src/test/java/com/epam/aidial/core/server/function/request/ResponsesApiRequestTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/request/ResponsesApiRequestTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.core.server.function.request;
 
+import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -108,7 +109,7 @@ class ResponsesApiRequestTest {
                         "another-field", "added-value"));
 
         ResponsesApiRequest request = request(body);
-        request.applyDefaults(model);
+        request.applyDefaults(model.resolveDefaults(InterfaceType.OPENAI_RESPONSES));
         String expected = """
                 {"field":"kept-value","another-field":"added-value"}""";
 


### PR DESCRIPTION
Adds `defaults` to an `interfaces.<type>` entry, so a deployment can default body parameters per interface instead of only per API through the deployment-level `defaults`/`responsesDefaults`. An entry declaring `defaults` states the whole set for that interface and replaces the deployment-level one; the deployment-level fields stay as the fallback they have always been, which keeps every existing config behaving exactly as before.

### Description of changes

- Add `defaults` to `DeploymentInterface`, resolved by `Deployment#resolveDefaults(InterfaceType)`. The two levels are **not** merged: the deployment-level sets hold parameters of one API each, so they cannot be laid under an interface of another. The priority is interface entry first, deployment level second.
- Keep the deployment-level fields serving the interfaces they were written for: `defaults` for `openaiChatCompletions` and `openaiEmbeddings`, `responsesDefaults` for `openaiResponses`. Neither holds Anthropic parameters, so neither reaches `anthropicMessages`, which defaults from `interfaces.anthropicMessages.defaults` or nowhere.
- Take the resolved map in `RequestObject#applyDefaults` instead of the whole `Deployment`, so which defaults are in force is decided once, by interface, rather than by each request shape. `MessagesApiRequest` now applies them instead of skipping them.
- Resolve the fronted deployment's defaults and default headers under the interface the client called: an intercepted `embeddings` request no longer resolves them as chat completions, while the interceptor's own settings keep resolving under the interface it is addressed on.
- Document the field in `models.md`, `applications.md` and `interceptors.md`, and add it to the `DeploymentInterface` OpenAPI schema.

For the configuration below:

```json
"openai-gpt-5.4-mini": {
    "type": "chat",
    "baseUrl": "http://dial-openai-adapter/",
    "defaults": {
        "temperature": 1,
        "custom_fields": { "configuration": "foo.baz" }
    },
    "interfaces": {
        "openaiChatCompletions": { "mode": "passthrough" },
        "openaiResponses": { "mode": "passthrough" },
        "anthropicMessages": {
            "mode": "passthrough",
            "defaults": { "temperature": 0.5 }
        }
    }
}
```

| Request | Effective `defaults` | Source |
|---|---|---|
| `POST /openai/deployments/{name}/chat/completions`, `POST /openai/deployments/{name}/embeddings` | `{"temperature": 1, "custom_fields": {"configuration": "foo.baz"}}` | deployment-level `defaults`, since neither entry declares its own |
| `POST /openai/v1/responses` | `{}` | `responsesDefaults` is absent and the entry declares none; the deployment-level `defaults` does not serve this interface |
| `POST /anthropic/v1/messages` | `{"temperature": 0.5}` | the entry declares `defaults`, so that is the whole set |

### Checklist

- [x] Title of the pull request
  follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (2642 tests, 0 failures, 0 errors; checkstyle clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
