### PR TITLE
fix: responses background jobs ignore the interfaces config #1881

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/service/BackgroundJobService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/service/BackgroundJobService.java
@@ -4,6 +4,7 @@ import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
+import com.epam.aidial.core.config.Translator;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.credentials.data.credentials.BucketInfo;
 import com.epam.aidial.core.credentials.encryption.CredentialEncryptionService;
@@ -20,6 +21,7 @@ import com.epam.aidial.core.server.token.TokenStatsTracker;
 import com.epam.aidial.core.server.token.TokenUsage;
 import com.epam.aidial.core.server.token.UsagePerModel;
 import com.epam.aidial.core.server.upstream.UpstreamRouteProvider;
+import com.epam.aidial.core.server.util.DeploymentEndpointUtil;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.epam.aidial.core.server.util.ResponseIdUtil;
 import com.epam.aidial.core.server.vertx.AsyncTaskExecutor;
@@ -194,17 +196,23 @@ public class BackgroundJobService {
         if (deployment == null) {
             return Future.failedFuture("Deployment {} not found");
         }
-        if (deployment.getResponsesEndpoint() == null) {
+        Map<String, Translator> translators = config.getTranslators();
+        String responsesBaseUri = DeploymentEndpointUtil.resolveResponsesBaseUri(deployment, translators);
+        if (responsesBaseUri == null) {
             return Future.failedFuture("Deployment " + deployment.getName() + " does not have a responses endpoint");
         }
         Upstream upstream;
         try {
-            upstream = upstreamRouteProvider.get(deployment, null, mapping.getUpstreamKey()).next();
+            // resolved the way the original request was routed, so that a deployment declaring no upstreams of
+            // its own builds the same synthetic upstream the mapping's key was issued against
+            upstream = upstreamRouteProvider.get(deployment, null,
+                    dep -> DeploymentEndpointUtil.resolveServingEndpoint(dep, InterfaceType.OPENAI_RESPONSES, translators),
+                    mapping.getUpstreamKey()).next();
         } catch (Exception e) {
             return Future.failedFuture("Failed to get upstream for deployment " + deployment.getName()
                     + " and upstream key " + mapping.getUpstreamKey() + ": " + e.getMessage());
         }
-        String targetUrl = deployment.getResponsesEndpoint() + "/" + mapping.getUpstreamResponseId();
+        String targetUrl = responsesBaseUri + "/" + mapping.getUpstreamResponseId();
         return client.send(targetUrl, HttpMethod.GET, upstream)
                 .compose(response -> {
                     int statusCode = response.statusCode();

--- a/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
+++ b/server/src/main/java/com/epam/aidial/core/server/upstream/UpstreamRouteProvider.java
@@ -59,10 +59,6 @@ public class UpstreamRouteProvider {
         return get(deployment, breakpointContext, Deployment::getEndpoint, null);
     }
 
-    public UpstreamRoute get(Deployment deployment, CacheBreakpointContext breakpointContext, String upstreamId) {
-        return get(deployment, breakpointContext, Deployment::getEndpoint, upstreamId);
-    }
-
     public UpstreamRoute get(Deployment deployment, CacheBreakpointContext breakpointContext,
                              Function<Deployment, String> endpointSupplier) {
         return get(deployment, breakpointContext, endpointSupplier, null);

--- a/server/src/test/java/com/epam/aidial/core/server/service/BackgroundJobServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/service/BackgroundJobServiceTest.java
@@ -2,6 +2,9 @@ package com.epam.aidial.core.server.service;
 
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.DeploymentInterface;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
 import com.epam.aidial.core.credentials.encryption.CredentialEncryptionService;
 import com.epam.aidial.core.server.ProxyContext;
@@ -39,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.Redisson;
@@ -50,7 +54,9 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -460,7 +466,7 @@ class BackgroundJobServiceTest {
         when(configStore.get()).thenReturn(config);
         when(config.selectDeployment(anyString())).thenReturn(deployment);
         when(deployment.getResponsesEndpoint()).thenReturn("http://test-upstream/responses");
-        when(upstreamRouteProvider.get(any(), any(), anyString()))
+        when(upstreamRouteProvider.get(any(), any(), any(), anyString()))
                 .thenThrow(new RuntimeException("No available upstream"));
 
         poller.poll(buildMapping())
@@ -490,12 +496,66 @@ class BackgroundJobServiceTest {
         await(ctx);
     }
 
+    @Test
+    void pollResolvesResponsesEndpointFromInterfaces(VertxTestContext ctx) throws Throwable {
+        Model model = new Model();
+        model.setName(DEPLOYMENT_NAME);
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_RESPONSES.getValue(), new DeploymentInterface("http://adapter")));
+        setupDeploymentMocks(model);
+        setupHttpMocks("{\"status\":\"completed\",\"usage\":{}}");
+
+        poller.poll(buildMapping())
+                .onSuccess(result -> ctx.verify(() -> {
+                    assertNotNull(result);
+                    assertEquals("http://adapter/openai/v1/responses/" + UPSTREAM_RESPONSE_ID, capturePolledUrl());
+                    // the upstream is looked up by the endpoint the mapping's key was issued against
+                    assertEquals("http://adapter", captureEndpointSupplier().apply(model));
+                    ctx.completeNow();
+                }))
+                .onFailure(ctx::failNow);
+        await(ctx);
+    }
+
+    @Test
+    void pollResolvesResponsesEndpointFromDeploymentBaseUrl(VertxTestContext ctx) throws Throwable {
+        Model model = new Model();
+        model.setName(DEPLOYMENT_NAME);
+        model.setBaseUrl("http://adapter/");
+        model.setInterfaces(Map.of(InterfaceType.OPENAI_RESPONSES.getValue(), new DeploymentInterface()));
+        setupDeploymentMocks(model);
+        setupHttpMocks("{\"status\":\"completed\",\"usage\":{}}");
+
+        poller.poll(buildMapping())
+                .onSuccess(result -> ctx.verify(() -> {
+                    assertEquals("http://adapter/openai/v1/responses/" + UPSTREAM_RESPONSE_ID, capturePolledUrl());
+                    ctx.completeNow();
+                }))
+                .onFailure(ctx::failNow);
+        await(ctx);
+    }
+
+    private String capturePolledUrl() {
+        ArgumentCaptor<RequestOptions> options = ArgumentCaptor.forClass(RequestOptions.class);
+        verify(httpClient).request(options.capture());
+        return "http://" + options.getValue().getHost() + options.getValue().getURI();
+    }
+
+    private Function<Deployment, String> captureEndpointSupplier() {
+        ArgumentCaptor<Function<Deployment, String>> endpointSupplier = ArgumentCaptor.forClass(Function.class);
+        verify(upstreamRouteProvider).get(any(Deployment.class), isNull(), endpointSupplier.capture(), anyString());
+        return endpointSupplier.getValue();
+    }
+
     private void setupDeploymentMocks() {
-        Config config = mock(Config.class);
         Deployment deployment = mock(Deployment.class);
+        when(deployment.getResponsesEndpoint()).thenReturn("http://test-upstream/responses");
+        setupDeploymentMocks(deployment);
+    }
+
+    private void setupDeploymentMocks(Deployment deployment) {
+        Config config = mock(Config.class);
         when(configStore.get()).thenReturn(config);
         when(config.selectDeployment(anyString())).thenReturn(deployment);
-        when(deployment.getResponsesEndpoint()).thenReturn("http://test-upstream/responses");
 
         Upstream upstream = mock(Upstream.class);
         when(upstream.getKey()).thenReturn("api-key");
@@ -504,7 +564,7 @@ class BackgroundJobServiceTest {
 
         UpstreamRoute route = mock(UpstreamRoute.class);
         when(route.next()).thenReturn(upstream);
-        when(upstreamRouteProvider.get(any(Deployment.class), isNull(), anyString())).thenReturn(route);
+        when(upstreamRouteProvider.get(any(Deployment.class), isNull(), any(), anyString())).thenReturn(route);
     }
 
     private void setupHttpMocks(String responseJson) {

--- a/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/upstream/UpstreamRouteProviderTest.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.server.upstream;
 
 import com.epam.aidial.core.config.Application;
+import com.epam.aidial.core.config.Deployment;
 import com.epam.aidial.core.config.InterfaceType;
 import com.epam.aidial.core.config.Model;
 import com.epam.aidial.core.config.Upstream;
@@ -151,7 +152,7 @@ public class UpstreamRouteProviderTest {
         model.setUpstreams(List.of(upstream1, upstream2));
 
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
-        UpstreamRoute route = provider.get(model, null, "beta");
+        UpstreamRoute route = provider.get(model, null, Deployment::getEndpoint, "beta");
         Upstream result = route.next();
 
         assertEquals(upstream2, result);
@@ -168,7 +169,7 @@ public class UpstreamRouteProviderTest {
         model.setUpstreams(List.of(upstream1));
 
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
-        HttpException ex = assertThrows(HttpException.class, () -> provider.get(model, null, "missing"));
+        HttpException ex = assertThrows(HttpException.class, () -> provider.get(model, null, Deployment::getEndpoint, "missing"));
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
         assertEquals("Unknown upstream id missing", ex.getMessage());
     }
@@ -190,8 +191,8 @@ public class UpstreamRouteProviderTest {
 
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
 
-        assertEquals(interfaced, provider.get(model, null, "fireworks").next());
-        assertEquals(legacy, provider.get(model, null, "alpha").next());
+        assertEquals(interfaced, provider.get(model, null, Deployment::getEndpoint, "fireworks").next());
+        assertEquals(legacy, provider.get(model, null, Deployment::getEndpoint, "alpha").next());
     }
 
     @Test
@@ -205,7 +206,7 @@ public class UpstreamRouteProviderTest {
         model.setUpstreams(List.of(upstream1, upstream2));
 
         UpstreamRouteProvider provider = new UpstreamRouteProvider(vertx, taskExecutor, () -> generator, upstreamCacheService);
-        UpstreamRoute route = provider.get(model, null, "   ");
+        UpstreamRoute route = provider.get(model, null, Deployment::getEndpoint, "   ");
         assertNotNull(route.next());
     }
 


### PR DESCRIPTION
Background-mode polling for the Responses API resolved its target by reading the deployment's legacy `responsesEndpoint` field directly, so a deployment declaring the API through `interfaces.openaiResponses` was never polled to completion. `BackgroundJobService` now resolves the endpoint the same way every other Responses path does.

### Applicable issues

- fixes #1881

### Description of changes

- `BackgroundJobService.poll` resolves the target url with `DeploymentEndpointUtil.resolveResponsesBaseUri(deployment, translators)` in place of the two direct `getResponsesEndpoint()` reads, so `interfaces.openaiResponses` (its own `base_url`, or the deployment-level `baseUrl`) is honoured and the legacy field stays a fallback.
- The upstream lookup now passes the same `OPENAI_RESPONSES` endpoint supplier the original request was routed with. For a deployment declaring no `upstreams`, `UpstreamRouteProvider` synthesizes an upstream whose id is the supplied endpoint, and the mapping's `upstreamKey` was issued against the Responses serving endpoint — while the poller asked for `Deployment::getEndpoint`. The two ids never matched, so polling failed with `Unknown upstream id`, or an NPE where `endpoint` was absent, for every upstream-less deployment — legacy `responsesEndpoint` configs included.
- Removed `UpstreamRouteProvider.get(Deployment, CacheBreakpointContext, String)`, whose last production caller was the code above; the five test call sites now pass `Deployment::getEndpoint` explicitly.
- Added `BackgroundJobServiceTest` coverage for a deployment configured through `interfaces` only — once with an interface-level `base_url`, once with the deployment-level `baseUrl` — asserting both the polled url and the endpoint supplier handed to the route provider.

### Checklist

- [x] Title of the pull request
  follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (BackgroundJobServiceTest 21/21, UpstreamRouteProviderTest 9/9, Responses and ResponseItem controller suites, checkstyle clean; four unrelated integration tests flaked in the full run and pass on rerun)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
