### PR TITLE
feat: add GET /v1/deployments/{deployment_id} endpoint

### DIFF
--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -4637,6 +4637,50 @@ paths:
       - lang: cURL
         label: CURL
         source: "curl https://chat.<company>.com/deployments?interface_type={interface_type} \\\n  -H \"Api-Key: DIAL_API_KEY\"          \n"
+  /v1/deployments/{deployment_name}:
+    get:
+      tags:
+      - Deployment listing
+      summary: "/v1/deployments/{deployment_name}"
+      operationId: getDeploymentInfo
+      parameters:
+      - name: deployment_name
+        in: path
+        description: The name of the deployment.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeploymentData"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: The server had an error while processing your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
   /v1/deployments/{deployment_name}/configuration:
     get:
       summary: "/v1/deployments/{deployment_name}/configuration"

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ControllerSelector.java
@@ -607,6 +607,14 @@ public class ControllerSelector {
         for (HttpMethod method : Proxy.ALLOWED_HTTP_METHODS) {
             ROUTES.add(new ControllerRoute(method, RouteTemplate.DEPLOYMENT_ROUTES.getPattern(), applicationRouteTemplate));
         }
+
+        // Registered last: its {id} spans slashes, so it also matches /v1/deployments/{id}/limits,
+        // /configuration, /mcp and /route/... - every one of those must be matched first (first match wins).
+        get(RouteTemplate.DEPLOYMENT_INFO, (proxy, context, pathMatcher) -> {
+            DeploymentController controller = new DeploymentController(proxy, context);
+            String deploymentId = UrlUtil.decodePath(pathMatcher.group("id"));
+            return () -> controller.getDeploymentInfo(deploymentId);
+        });
     }
 
     public ControllerTemplate select(HttpServerRequest request) {

--- a/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/DeploymentController.java
@@ -24,9 +24,11 @@ import com.epam.aidial.core.server.data.ToolSetData;
 import com.epam.aidial.core.server.service.ApplicationSchemaService;
 import com.epam.aidial.core.server.service.ApplicationService;
 import com.epam.aidial.core.server.service.DeploymentService;
+import com.epam.aidial.core.server.service.PermissionDeniedException;
 import com.epam.aidial.core.server.service.ToolSetService;
 import com.epam.aidial.core.server.util.DeploymentEndpointUtil;
 import com.epam.aidial.core.storage.data.ResourceItemMetadata;
+import com.epam.aidial.core.storage.exception.ResourceNotFoundException;
 import com.epam.aidial.core.storage.http.HttpStatus;
 import com.epam.aidial.core.storage.resource.ResourceTypes;
 import io.vertx.core.CompositeFuture;
@@ -168,6 +170,54 @@ public class DeploymentController {
     }
 
 
+    @ApiOperation(
+            method = "GET",
+            path = "/v1/deployments/{deployment_name}",
+            operationId = "getDeploymentInfo",
+            tags = {"Deployment listing"},
+            parameters = {
+                    @ApiParameter(name = "deployment_name", in = ParameterIn.PATH, required = true,
+                            description = OpenApiDescriptions.DEPLOYMENT_NAME)
+            },
+            responses = {
+                    @ApiResponse(code = 200, description = "Success", body = @ApiSchema(implementation = DeploymentData.class)),
+                    @ApiResponse(code = 400),
+                    @ApiResponse(code = 403),
+                    @ApiResponse(code = 404),
+                    @ApiResponse(code = 500)
+            }
+    )
+    public Future<?> getDeploymentInfo(String deploymentId) {
+        proxy.getTaskExecutor()
+                .submit(() -> toDeploymentData(deploymentService.findDeployment(context, deploymentId)))
+                .onSuccess(deployment -> context.respond(HttpStatus.OK, deployment))
+                .onFailure(error -> respondError(deploymentId, error));
+
+        return Future.succeededFuture();
+    }
+
+    private DeploymentData toDeploymentData(Deployment deployment) {
+        return switch (deployment) {
+            case Model model -> to(model);
+            case Application application -> to(resolveLocalApplication(application));
+            case ToolSet toolSet -> to(toolSet);
+            // interceptors are deployments as well, but the deployment listing never exposes them
+            default -> throw new ResourceNotFoundException("Deployment is not found: " + deployment.getName());
+        };
+    }
+
+    private void respondError(String deploymentId, Throwable error) {
+        switch (error) {
+            case IllegalArgumentException ignored -> context.respond(HttpStatus.BAD_REQUEST, error.getMessage());
+            case PermissionDeniedException ignored -> context.respond(HttpStatus.FORBIDDEN, error.getMessage());
+            case ResourceNotFoundException ignored -> context.respond(HttpStatus.NOT_FOUND, error.getMessage());
+            case null, default -> {
+                log.error("Error occurred on getting deployment {}", deploymentId, error);
+                context.respond(error, "Internal error");
+            }
+        }
+    }
+
     private String[] getDeploymentInterfaces() {
         String interfacesParam = context.getRequest().getParam("interface_type", "all");
         return interfacesParam.split(",");
@@ -302,19 +352,23 @@ public class DeploymentController {
         Config config = context.getConfig();
         for (Model model : config.getModels().values()) {
             if (model.hasAccess(context.getUserRoles()) && match(filters, model)) {
-                DeploymentData deployment = createModel(model);
-                List<String> interfaces = new ArrayList<>();
-                if (model.getType() == ModelType.CHAT) {
-                    interfaces.add(CHAT_IFACE);
-                } else {
-                    interfaces.add(EMBEDDING_IFACE);
-                }
-                interfaces.addAll(supportedInterfaces(model));
-                deployment.setInterfaces(interfaces);
-                deployments.add(deployment);
+                deployments.add(to(model));
             }
         }
         return Future.succeededFuture(deployments);
+    }
+
+    private static DeploymentData to(Model model) {
+        DeploymentData deployment = createModel(model);
+        List<String> interfaces = new ArrayList<>();
+        if (model.getType() == ModelType.CHAT) {
+            interfaces.add(CHAT_IFACE);
+        } else {
+            interfaces.add(EMBEDDING_IFACE);
+        }
+        interfaces.addAll(supportedInterfaces(model));
+        deployment.setInterfaces(interfaces);
+        return deployment;
     }
 
     private static ApplicationData to(Application app) {

--- a/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/RouteTemplate.java
@@ -364,7 +364,16 @@ public enum RouteTemplate {
             "/v1/ops/resource/per-request-permissions/{operation}"),
 
     CLIENT_CHANNEL("^/v1/ops/client-channel/(subscribe|report|unsubscribe|interact)",
-            "/v1/ops/client-channel/{operation}");
+            "/v1/ops/client-channel/{operation}"),
+
+    // Declared last: {id} spans slashes (resource-backed deployments are addressed by their url), so this
+    // template also matches every /v1/deployments/{id}/... path. Path normalization returns the first
+    // matching template, hence the more specific ones must stay ahead of it - as must their routes in
+    // ControllerSelector.
+    DEPLOYMENT_INFO(
+            "^/+v1/deployments/(?<id>.+?)$",
+            "/v1/deployments/{id}"
+    );
 
     private final Pattern pattern;
     private final String template;

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -87,6 +87,58 @@ public class DeploymentApiTest extends ResourceBaseTest {
         assertTrue(collectInterfaces(body).containsKey("schema-app"));
     }
 
+    @DialConfigLocation("dial-config/deployment-interfaces-listing.json")
+    @Test
+    public void testGetDeployment() throws JsonProcessingException {
+        // a model, an application and a toolset are returned in the very same shape the listing uses
+        JsonNode model = readDeployment(send(HttpMethod.GET, "/v1/deployments/gpt-4"));
+        assertEquals("model", model.get("object").asText());
+        assertEquals(Set.of("chat", "openaiChatCompletions"), interfacesOf(model));
+
+        JsonNode application = readDeployment(send(HttpMethod.GET, "/v1/deployments/schema-app"));
+        assertEquals("application", application.get("object").asText());
+        assertEquals(Set.of("chat", "mcp", "custom_ui", "openaiChatCompletions"), interfacesOf(application));
+
+        JsonNode toolSet = readDeployment(send(HttpMethod.GET, "/v1/deployments/git"));
+        assertEquals("toolset", toolSet.get("object").asText());
+        assertEquals(Set.of("mcp"), interfacesOf(toolSet));
+
+        verify(send(HttpMethod.GET, "/v1/deployments/unknown-deployment"), 404);
+    }
+
+    @DialConfigLocation("dial-config/deployment-interfaces-listing.json")
+    @Test
+    public void testGetCustomApplicationDeployment() throws JsonProcessingException {
+        Response response = send(HttpMethod.PUT, "/v1/applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my%20app", null, """
+                {
+                "display_name": "My App",
+                "display_version": "1.0",
+                "icon_url": "http://apprunner/icon.svg",
+                "description": "My app Description",
+                "applicationTypeSchemaId": "https://mydial.somewhere.com/custom_application_schemas/specific_toolset_type",
+                "applicationProperties": {
+                  "property1": "foo",
+                  "property2": "bar"
+                  }
+                }
+                """);
+        verify(response, 200);
+
+        String deploymentId = "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my%20app";
+        JsonNode application = readDeployment(send(HttpMethod.GET, "/v1/deployments/" + deploymentId));
+        assertEquals("application", application.get("object").asText());
+        assertEquals(deploymentId, application.get("id").asText());
+        assertEquals(Set.of("chat", "mcp", "custom_ui", "openaiChatCompletions"), interfacesOf(application));
+    }
+
+    @Test
+    public void testGetForbiddenDeployment() {
+        // gpt-4 is restricted to the power-user role, proxyKey1 has the default one
+        verify(send(HttpMethod.GET, "/v1/deployments/gpt-4"), 403);
+        // an interceptor is a deployment, but it is not a part of the deployment listing
+        verify(send(HttpMethod.GET, "/v1/deployments/interceptor1"), 404);
+    }
+
     @DialConfigLocation("dial-config/deployment-interfaces-features.json")
     @Test
     public void testChatCompletionFeatureFollowsInterfaces() throws JsonProcessingException {
@@ -122,6 +174,19 @@ public class DeploymentApiTest extends ResourceBaseTest {
             result.put(deployment.get("id").asText(), deployment.get("features"));
         }
         return result;
+    }
+
+    private static JsonNode readDeployment(Response response) throws JsonProcessingException {
+        verify(response, 200);
+        return ProxyUtil.MAPPER.readTree(response.body());
+    }
+
+    private static Set<String> interfacesOf(JsonNode deployment) {
+        Set<String> interfaces = new HashSet<>();
+        for (JsonNode iface : deployment.get("interfaces")) {
+            interfaces.add(iface.asText());
+        }
+        return interfaces;
     }
 
     private static Map<String, Set<String>> collectInterfaces(JsonNode body) {

--- a/server/src/test/java/com/epam/aidial/core/server/controller/ControllerSelectorTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/controller/ControllerSelectorTest.java
@@ -526,6 +526,56 @@ public class ControllerSelectorTest {
     }
 
     @Test
+    public void testSelectGetDeploymentInfoController() {
+        when(request.path()).thenReturn("/v1/deployments/name");
+        when(request.method()).thenReturn(HttpMethod.GET);
+        Controller controller = ControllerSelector.select(request).build(proxy, context);
+        assertNotNull(controller);
+        SerializedLambda lambda = getSerializedLambda(controller);
+        assertNotNull(lambda);
+        Object arg1 = lambda.getCapturedArg(0);
+        Object arg2 = lambda.getCapturedArg(1);
+        assertInstanceOf(DeploymentController.class, arg1);
+        assertEquals("name", arg2);
+    }
+
+    @Test
+    public void testSelectGetDeploymentInfoControllerWithCustomApplication() {
+        when(request.path()).thenReturn("/v1/deployments/applications/bucket/my-application");
+        when(request.method()).thenReturn(HttpMethod.GET);
+        Controller controller = ControllerSelector.select(request).build(proxy, context);
+        assertNotNull(controller);
+        SerializedLambda lambda = getSerializedLambda(controller);
+        assertNotNull(lambda);
+        Object arg1 = lambda.getCapturedArg(0);
+        Object arg2 = lambda.getCapturedArg(1);
+        assertInstanceOf(DeploymentController.class, arg1);
+        assertEquals("applications/bucket/my-application", arg2);
+    }
+
+    // The {id} of the deployment info route spans slashes, so it matches the sub-resource paths as well
+    // and must stay the last registered route.
+    @Test
+    public void testDeploymentInfoRouteDoesNotShadowSubResources() {
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        when(request.path()).thenReturn("/v1/deployments/name/limits");
+        assertEquals("/v1/deployments/{id}/limits", ControllerSelector.select(request).pathTemplate());
+
+        when(request.path()).thenReturn("/v1/deployments/name/configuration");
+        assertEquals("/v1/deployments/{id}/configuration", ControllerSelector.select(request).pathTemplate());
+
+        when(request.path()).thenReturn("/v1/deployments/name/mcp");
+        assertEquals("/v1/deployments/{id}/mcp", ControllerSelector.select(request).pathTemplate());
+
+        when(request.path()).thenReturn("/v1/deployments/name/route/v1/search");
+        assertEquals("/v1/deployments/{id}/route{routePath}", ControllerSelector.select(request).pathTemplate());
+
+        when(request.path()).thenReturn("/v1/deployments/name");
+        assertEquals("/v1/deployments/{id}", ControllerSelector.select(request).pathTemplate());
+    }
+
+    @Test
     public void testSelectGetLimitsController() {
         when(request.path()).thenReturn("/v1/deployments/name/limits");
         when(request.method()).thenReturn(HttpMethod.GET);


### PR DESCRIPTION
### Description of changes

- Add `GET /v1/deployments/{deployment_id}`: the single-item counterpart of `GET /v1/deployments`. It returns the deployment in the very same `DeploymentData` shape the listing uses for an entry (`interfaces` array included), so a fetched item is identical to its listing entry:
  - **model** — `createModel` + `chat`/`embedding` + the declared interface types;
  - **application** — schema-rich resolution (`mcp`, `viewer_url` taken from the application type schema) before mapping;
  - **toolset** — `interfaces: ["mcp"]`, `auth_settings` stripped exactly like in the listing (per-user sign-in status stays on `GET /openai/toolsets/{id}`).
- The id is resolved through `DeploymentService.findDeployment` on the task executor, so both config names (`gpt-4`) and resource-backed ids (`applications/{bucket}/{name}`) work.
- Statuses: `403` for a role- or ACL-denied deployment, `404` for an unknown one (interceptors included — they are deployments, but the listing never exposes them), `400` for an id that parses as a non-deployment resource url, `500` otherwise.
- Route ordering: `{id}` has to span slashes, so `^/+v1/deployments/(?<id>.+?)$` also matches `/v1/deployments/{id}/limits`, `/configuration`, `/mcp` and `/route/...`. Both lookups are first-match-wins, hence the route is registered **last** in `ControllerSelector` and `RouteTemplate.DEPLOYMENT_INFO` is declared **last** in the enum (telemetry path normalization), each with a comment explaining why. `ControllerSelectorTest#testDeploymentInfoRouteDoesNotShadowSubResources` pins the selected path template for all five paths.
- The model to `DeploymentData` mapping moved out of `getModels` into `to(Model)`, next to the existing `to(Application)` / `to(ToolSet)`, and is shared by the listing and the new endpoint.
- `docs/open_api_core.yaml` regenerated with `./gradlew :openapi-generator:replaceSpec` — the diff is exactly the one new path.

One behaviour note: a GET on `/v1/deployments/<anything>` that used to fall through to `GlobalRouteController` (config-defined `routes`) now reaches this controller and answers `404`/`403`. The `/v1/deployments` namespace is DIAL's own, so this only affects a custom route deliberately parked under it.

### Checklist

- [x] Title of the pull request                                                                                                                                                                                
  follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All tests pass (DeploymentApiTest 5/5, ControllerSelectorTest 41/41, ApplicationRouteApiTest, CustomApplicationApiTest, LimitApiTest, PathNormalizerSpanProcessorTest, `:openapi-generator:test`, checkstyle clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
