### PR TITLE
fix: resolve declared dependencies at every hop of a chain, not just the root

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/function/ResolveResourceDependenciesFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/ResolveResourceDependenciesFn.java
@@ -39,13 +39,15 @@ import javax.annotation.Nullable;
  * already holds gets richer. A record is a request, not a grant: nothing here widens anything
  * the user cannot already reach.
  *
- * <p><b>Root-call only.</b> Resolution runs when the context still carries the originating user
- * (no per-request key) — that is the only state in which the user's reach is directly
- * evaluable; under a per-request key the same checks would silently evaluate a deployment's own
- * key instead. Hops that arrive with a per-request key present — an interceptor's final call
- * back to the app, or a chained app-to-app call — are skipped: their declarations do not
- * resolve and their grants do not propagate in v1 (documented limitation; chained composition
- * needs originating-user evaluation under key contexts, which is phase-2 machinery).
+ * <p><b>Every hop, one rule.</b> Resolution runs identically on the root user call and on any
+ * chained or interceptor hop. Identity is not the obstacle it was once thought to be:
+ * {@code ApiKeyData.initFromContext} propagates {@code extractedClaims} and {@code originalKey}
+ * at every depth, so {@code ProxyContext.userId} is always the originating human — which is why
+ * placeholder targets resolve correctly through {@code BucketBuilder.buildInitiatorBucket} at
+ * any depth. Only the reach check needed care: the general permission chain's own-bucket rule
+ * deliberately flips to the per-request key holder's sandbox, so reach is evaluated through
+ * {@code AccessService.lookupOriginatingUserPermissions} — own bucket as the human, shared,
+ * public — and never through rules that read the calling key's own grants (D-24).
  */
 public class ResolveResourceDependenciesFn extends BaseRequestFunction<RequestObject> {
 
@@ -62,11 +64,6 @@ public class ResolveResourceDependenciesFn extends BaseRequestFunction<RequestOb
         }
         List<ResourceDependency> declaration = application.getResourceDependencies();
         if (declaration == null || declaration.isEmpty()) {
-            return false;
-        }
-        if (context.getApiKeyData().getPerRequestKey() != null) {
-            // Not the root user call — see the class javadoc. Skip, never throw: a declaring app
-            // behind an interceptor or in a chain must stay callable, just without grants.
             return false;
         }
         resolve(application, declaration);
@@ -101,7 +98,7 @@ public class ResolveResourceDependenciesFn extends BaseRequestFunction<RequestOb
             // One batched walk of the permission chain for all resolved targets.
             Set<ResourceDescriptor> targets = resolvedTargets.stream().map(Resolved::target).collect(Collectors.toSet());
             Map<ResourceDescriptor, Set<ResourceAccessType>> userAccessByTarget =
-                    proxy.getAccessService().lookupPermissions(targets, context);
+                    proxy.getAccessService().lookupOriginatingUserPermissions(targets, context);
             for (Resolved resolved : resolvedTargets) {
                 Set<ResourceAccessType> userAccess = userAccessByTarget.getOrDefault(resolved.target(), Set.of());
                 if (userAccess.containsAll(resolved.access())) {

--- a/server/src/main/java/com/epam/aidial/core/server/log/ResourceDependencyAuditLog.java
+++ b/server/src/main/java/com/epam/aidial/core/server/log/ResourceDependencyAuditLog.java
@@ -47,9 +47,9 @@ public final class ResourceDependencyAuditLog {
             return;
         }
         AUDIT.info("event=resource_dependency_grant outcome=SUCCESS actor={} user_id={} application_id={} "
-                        + "targets={} access_types={} trace_id={}",
+                        + "source_deployment={} targets={} access_types={} trace_id={}",
                 actorEvidence(context), AuditLogSanitizer.sanitizeToken(context.getUserId()), AuditLogSanitizer.sanitizeToken(applicationId),
-                targetsOf(granted), accessTypesOf(granted), context.getTraceId());
+                sourceDeployment(context), targetsOf(granted), accessTypesOf(granted), context.getTraceId());
     }
 
     /**
@@ -62,16 +62,17 @@ public final class ResourceDependencyAuditLog {
             return;
         }
         AUDIT.info("event=resource_dependency_denial outcome=DENIED actor={} user_id={} application_id={} "
-                        + "targets={} trace_id={}",
+                        + "source_deployment={} targets={} trace_id={}",
                 actorEvidence(context), AuditLogSanitizer.sanitizeToken(context.getUserId()), AuditLogSanitizer.sanitizeToken(applicationId),
-                targetsOf(unresolved), context.getTraceId());
+                sourceDeployment(context), targetsOf(unresolved), context.getTraceId());
     }
 
     /** One event when a required dependency failed to resolve and the call is rejected. */
     public static void runtimeFail(ProxyContext context, String applicationId, List<String> requiredFailures) {
         AUDIT.info("event=resource_dependency_runtime_fail outcome=RUNTIME_FAIL actor={} user_id={} "
-                        + "application_id={} targets={} trace_id={} reason=\"required dependencies unresolvable\"",
+                        + "application_id={} source_deployment={} targets={} trace_id={} reason=\"required dependencies unresolvable\"",
                 actorEvidence(context), AuditLogSanitizer.sanitizeToken(context.getUserId()), AuditLogSanitizer.sanitizeToken(applicationId),
+                sourceDeployment(context),
                 requiredFailures.stream().map(AuditLogSanitizer::sanitizeToken)
                         .collect(Collectors.joining(",")),
                 context.getTraceId());
@@ -100,6 +101,12 @@ public final class ResourceDependencyAuditLog {
             case ResourceNotFoundException ignored -> "NOT_FOUND";
             default -> "ERROR";
         };
+    }
+
+    /** The deployment that made this call — the immediate caller. "root" on the user's own call. */
+    private static String sourceDeployment(ProxyContext context) {
+        String deployment = context.getSourceDeployment();
+        return deployment == null ? "root" : AuditLogSanitizer.sanitizeToken(deployment);
     }
 
     // Non-secret evidence of the calling actor: the DIAL key's project and/or the workload JWT's azp.

--- a/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
+++ b/server/src/main/java/com/epam/aidial/core/server/security/AccessService.java
@@ -70,6 +70,20 @@ public class AccessService {
             AccessService::getAppSelfAccess,
             this::getOwnResourcesAccessForChainedSchemaRichApplication);
 
+    /**
+     * Reach as the <b>originating human</b>, independent of how deep in a call chain the request
+     * is. Three rules, and deliberately only three (D-24): the human's own bucket via
+     * {@link BucketBuilder#buildInitiatorBucket} (never the PRK holder's sandbox), what has been
+     * shared with the human, and what is public to the human's roles. Every rule that reads the
+     * <i>current per-request key holder's</i> state is excluded — otherwise a calling app could
+     * launder grants it already holds into satisfying the next app's independent reach check.
+     * Used by resource-dependency resolution only; the general chain is {@link #permissionRules}.
+     */
+    private final List<PermissionRule> originatingUserPermissionRules = List.of(
+            (resources, context) -> ownBucketAccess(resources, BucketBuilder.buildInitiatorBucket(context)),
+            this::getSharedAccess,
+            this::getPublicAccess);
+
     public AccessService(EncryptionService encryptionService,
                          ShareService shareService,
                          RuleService ruleService,
@@ -156,9 +170,15 @@ public class AccessService {
 
     private Map<ResourceDescriptor, Set<ResourceAccessType>> lookupPermissions(
             Set<ResourceDescriptor> resources, ProxyContext context, Set<ResourceAccessType> toLookup) {
+        return lookupPermissions(resources, context, toLookup, permissionRules);
+    }
+
+    private Map<ResourceDescriptor, Set<ResourceAccessType>> lookupPermissions(
+            Set<ResourceDescriptor> resources, ProxyContext context, Set<ResourceAccessType> toLookup,
+            List<PermissionRule> rules) {
         Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
         Set<ResourceDescriptor> remainingResources = new HashSet<>(resources);
-        for (PermissionRule permissionRule : permissionRules) {
+        for (PermissionRule permissionRule : rules) {
             Map<ResourceDescriptor, Set<ResourceAccessType>> rulePermissions =
                     permissionRule.apply(remainingResources, context);
 
@@ -180,6 +200,19 @@ public class AccessService {
         }
 
         return result;
+    }
+
+    /**
+     * Permissions the <b>originating user</b> holds on {@code resources}, evaluated identically at
+     * the root call and at any depth in a chain. Not a variant of {@link #lookupPermissions}: it
+     * answers a narrower question — "what can the human behind this request reach on their own
+     * standing" — over a purpose-built rule set (see {@link #originatingUserPermissionRules}).
+     * Resource-dependency resolution is the only caller; do not widen it into a general-purpose
+     * permission API without revisiting D-24's exclusions.
+     */
+    public Map<ResourceDescriptor, Set<ResourceAccessType>> lookupOriginatingUserPermissions(
+            Set<ResourceDescriptor> resources, ProxyContext context) {
+        return lookupPermissions(resources, context, ResourceAccessType.ALL, originatingUserPermissionRules);
     }
 
     @VisibleForTesting
@@ -300,10 +333,20 @@ public class AccessService {
 
     private static Map<ResourceDescriptor, Set<ResourceAccessType>> getOwnResourcesAccess(
             Set<ResourceDescriptor> resources, ProxyContext context) {
-        String location = BucketBuilder.buildUserBucket(context);
+        return ownBucketAccess(resources, BucketBuilder.buildUserBucket(context));
+    }
+
+    /**
+     * Resources living in {@code bucketLocation}, with full rights. The caller picks whose bucket
+     * that is: {@link BucketBuilder#buildUserBucket} — the PRK holder's own sandbox under a
+     * per-request key — for the general chain, {@link BucketBuilder#buildInitiatorBucket} — always
+     * the originating human — for {@link #lookupOriginatingUserPermissions}.
+     */
+    private static Map<ResourceDescriptor, Set<ResourceAccessType>> ownBucketAccess(
+            Set<ResourceDescriptor> resources, String bucketLocation) {
         Map<ResourceDescriptor, Set<ResourceAccessType>> result = new HashMap<>();
         for (ResourceDescriptor resource : resources) {
-            if (resource.getBucketLocation().equals(location)) {
+            if (resource.getBucketLocation().equals(bucketLocation)) {
                 result.put(resource, ResourceAccessType.ALL);
             }
         }

--- a/server/src/test/java/com/epam/aidial/core/server/ResourceDependencyApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ResourceDependencyApiTest.java
@@ -3,7 +3,6 @@ package com.epam.aidial.core.server;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.epam.aidial.core.server.data.ApiKeyData;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
@@ -168,25 +167,29 @@ public class ResourceDependencyApiTest extends ResourceBaseTest {
     }
 
     @Test
-    void testChainedCallIntoDeclaringAppStaysCallableWithoutGrants() {
-        // Root-call-only resolution (design §7.1's chained composition is phase-2 machinery): a
-        // chained hop presenting a per-request key must stay callable — never the hard failure the
-        // first revision threw — and must not bake grants it cannot evaluate the originating
-        // user's reach for.
-        verify(putDeclaringApp("""
-                {"kind": "dial.resourceLink", "link_id": "lnk", "target": {"path": "prompts/{current-user}/dep-smoke/"}, "access": ["write"], "required": true}
-                """), 200);
+    void testInterceptorProtectedAppStillResolvesOnTheRootCall() {
+        // A plain-root-call correctness bug, not a chained-composition scenario: the interceptor's
+        // own call back into DeploymentPostController.handleDeployment(initialDeployment) re-enters
+        // with the interceptor's per-request key already in context, hitting the very guard PR4b
+        // removes — so before this PR an interceptor-protected declaring app silently never
+        // resolved its dependencies, even on a plain user root call.
+        verify(send(HttpMethod.PUT, "/v1/applications/public/dep-e2e-app", null, """
+                {
+                  "endpoint": "http://localhost:4849/chat/completions",
+                  "display_name": "Dependency E2E App",
+                  "resource_dependencies": [
+                    {"kind": "dial.resourceLink", "link_id": "lnk", "target": {"path": "prompts/{current-user}/dep-smoke/"}, "access": ["write"], "required": true}
+                  ],
+                  "interceptors": ["interceptor1"]
+                }
+                """, "authorization", "admin"), 200);
         verify(grantConsent(), 200);
         String bucket = userBucket();
 
-        // The key an orchestrator would hold when delegating to the declaring app.
-        ApiKeyData appKey = createAppKey("user", java.util.Map.of());
-        appKey.setExecutionPath(List.of("orchestrator"));
-        apiKeyStore.assignPerRequestApiKey(appKey);
-
         AtomicReference<Integer> targetStatus = new AtomicReference<>();
-        try (TestWebServer server = new TestWebServer(4849)) {
-            server.map(HttpMethod.POST, "/chat/completions", request -> {
+        try (TestWebServer appServer = new TestWebServer(4849);
+                TestWebServer interceptorServer = new TestWebServer(4088)) {
+            appServer.map(HttpMethod.POST, "/chat/completions", request -> {
                 targetStatus.set(send(HttpMethod.PUT,
                         "/v1/prompts/%s/dep-smoke/prompt-by-app".formatted(bucket), null, PROMPT_BODY,
                         "api-key", request.getHeader("Api-Key")).status());
@@ -194,16 +197,29 @@ public class ResourceDependencyApiTest extends ResourceBaseTest {
                         "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[]}",
                         "Content-Type", "application/json");
             });
+            // The interceptor server: forwards to the original deployment with the per-request key
+            // it was handed — this second, inbound call is where handleDeployment re-enters with a
+            // per-request key already present.
+            interceptorServer.map(HttpMethod.POST, "/api/v1/interceptor/handle", request -> {
+                String perRequestKey = request.getHeader("Api-Key");
+                Response completion = send(HttpMethod.POST,
+                        "/openai/deployments/applications/public/dep-e2e-app/chat/completions", null, """
+                        {"messages":[{"role":"user","content":"how are you?"}]}
+                        """, "api-key", perRequestKey, "Content-Type", "application/json");
+                return TestWebServer.createResponse(completion.status(), completion.body(),
+                        "Content-Type", "application/json");
+            });
+
             Response completion = send(HttpMethod.POST,
                     "/openai/deployments/applications/public/dep-e2e-app/chat/completions", null, """
                     {"messages":[{"role":"user","content":"how are you?"}]}
-                    """, "api-key", appKey.getPerRequestKey(), "Content-Type", "application/json");
+                    """, "authorization", "user", "Content-Type", "application/json");
             assertEquals(200, completion.status(), () -> "Body: " + completion.body());
         }
 
-        // Callable, but the dependency did not resolve on this hop: no grant, target off-limits.
-        assertEquals(403, targetStatus.get(),
-                "a chained hop must not receive grants — the originating user's reach is not evaluable there");
+        // Before this PR: 403 (the guard skipped resolution on this re-entry). After: resolved.
+        assertEquals(200, targetStatus.get(),
+                "an interceptor-protected declaring app must resolve its dependencies on a plain root call");
     }
 
     @Test
@@ -240,6 +256,9 @@ public class ResourceDependencyApiTest extends ResourceBaseTest {
             assertTrue(denial.contains("targets=prompts/{current-user}/dep-smoke/"), denial);
             assertTrue(denial.contains("user_id=user"), denial);
             assertTrue(denial.contains("trace_id=") && !denial.contains("trace_id=,") && !denial.contains("trace_id=null"), denial);
+            // A plain user root call: no calling deployment, so source_deployment is the "root"
+            // sentinel — pinned here since it's the path least likely to be exercised elsewhere.
+            assertTrue(denial.contains("source_deployment=root"), denial);
 
             String runtimeFail = events.stream()
                     .filter(e -> e.contains("event=resource_dependency_runtime_fail")).findFirst().orElse(null);

--- a/server/src/test/java/com/epam/aidial/core/server/ResourceDependencyResolutionApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ResourceDependencyResolutionApiTest.java
@@ -1,9 +1,16 @@
 package com.epam.aidial.core.server;
 
+import com.epam.aidial.core.config.ResourceAccessType;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.data.permission.PerRequestSharedData;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -68,5 +75,109 @@ public class ResourceDependencyResolutionApiTest extends ResourceBaseTest {
         assertEquals(200, inScopeStatus.get(), "the consented dependency target must be writable by the app's key");
         // …and only there — the user's files root stays off-limits to the app's key.
         assertEquals(403, outOfScopeStatus.get(), "anything outside the declared target must stay off-limits");
+    }
+
+    @Test
+    void testChainedHopResolvesItsOwnDeclarationAgainstTheOriginatingUser() {
+        // The rewritten successor of the removed root-call-only test (design §7.1, D-24):
+        // createAppKey puts the user's ExtractedClaims on the chained key, so ProxyContext.userId
+        // is still "user", buildInitiatorBucket is still Users/user/, and
+        // lookupOriginatingUserPermissions's own-bucket rule grants ALL — whereas the general
+        // chain would have asked whether Keys/testapp/ (the orchestrator's own sandbox) owns the
+        // prompt folder, and answered no.
+        Response response = send(HttpMethod.GET, "/v1/bucket", null, "", "authorization", "user");
+        String userBucket = new JsonObject(response.body()).getString("bucket");
+        String appUrl = "applications/public/dep-chained-app";
+
+        verify(send(HttpMethod.PUT, "/v1/applications/public/dep-chained-app", null, """
+                {
+                  "endpoint": "http://localhost:4847/chat/completions",
+                  "display_name": "Dependency Chained App",
+                  "resource_dependencies": [
+                    {"kind": "dial.resourceLink", "link_id": "lnk",
+                     "target": {"path": "prompts/{current-user}/dep-smoke/"}, "access": ["write"], "required": true}
+                  ]
+                }
+                """, "authorization", "admin", "If-None-Match", "*"), 200);
+        verify(send(HttpMethod.POST, "/v1/consent/" + appUrl + "/admin-consent", null, "",
+                "authorization", "admin"), 200);
+
+        // The key an orchestrator would hold when delegating to the declaring app — a chained hop.
+        ApiKeyData orchestratorKey = createAppKey("user", Map.of());
+        orchestratorKey.setExecutionPath(List.of("orchestrator"));
+        apiKeyStore.assignPerRequestApiKey(orchestratorKey);
+
+        AtomicReference<Integer> targetStatus = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4847)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                targetStatus.set(send(HttpMethod.PUT,
+                        "/v1/prompts/%s/dep-smoke/prompt-by-app".formatted(userBucket), null,
+                        "{\"id\":\"prompt-by-app\",\"folderId\":\"dep-smoke/\",\"name\":\"prompt-by-app\",\"content\":\"app content\"}",
+                        "api-key", request.getHeader("Api-Key")).status());
+                return TestWebServer.createResponse(200,
+                        "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[]}",
+                        "Content-Type", "application/json");
+            });
+            Response completion = send(HttpMethod.POST, "/openai/deployments/%s/chat/completions".formatted(appUrl), null, """
+                    {"messages":[{"role":"user","content":"how are you?"}]}
+                    """, "api-key", orchestratorKey.getPerRequestKey(), "Content-Type", "application/json");
+            assertEquals(200, completion.status(), () -> "Body: " + completion.body());
+        }
+
+        // Before this PR: 200 and 403 (the guard skipped resolution on this hop). After: 200 and 200.
+        assertEquals(200, targetStatus.get(),
+                "a chained hop must resolve its own declaration against the originating user");
+    }
+
+    @Test
+    void testChainedHopIsSandboxedFromTheCallersOwnGrants() {
+        // The single most important assertion in this PR, end to end (D-24): a grant already
+        // baked into the CALLING app's own per-request key must not satisfy the CALLED app's
+        // independent reach check — otherwise app1 could launder its own grants into app2.
+        String adminBucket = new JsonObject(
+                send(HttpMethod.GET, "/v1/bucket", null, "", "authorization", "admin").body()).getString("bucket");
+        String targetPath = "files/" + adminBucket + "/secret.txt";
+        String appUrl = "applications/public/dep-laundering-app";
+
+        verify(send(HttpMethod.PUT, "/v1/applications/public/dep-laundering-app", null, """
+                {
+                  "endpoint": "http://localhost:4846/chat/completions",
+                  "display_name": "Dependency Laundering App",
+                  "resource_dependencies": [
+                    {"kind": "dial.resourceLink", "link_id": "lnk",
+                     "target": {"path": "%s"}, "access": ["write"], "required": false}
+                  ]
+                }
+                """.formatted(targetPath), "authorization", "admin", "If-None-Match", "*"), 200);
+        verify(send(HttpMethod.POST, "/v1/consent/" + appUrl + "/admin-consent", null, "",
+                "authorization", "admin"), 200);
+
+        // The orchestrator holds a grant on this exact target already — the plain "user" role has
+        // no reach to the admin's bucket on their own standing.
+        ApiKeyData orchestratorKey = createAppKey("user", Map.of());
+        orchestratorKey.setExecutionPath(List.of("orchestrator"));
+        orchestratorKey.getPerRequestSharedResources().put(targetPath,
+                new PerRequestSharedData(new HashSet<>(Set.of(ResourceAccessType.WRITE))));
+        apiKeyStore.assignPerRequestApiKey(orchestratorKey);
+
+        AtomicReference<Integer> targetStatus = new AtomicReference<>();
+        try (TestWebServer server = new TestWebServer(4846)) {
+            server.map(HttpMethod.POST, "/chat/completions", request -> {
+                targetStatus.set(send(HttpMethod.PUT, "/v1/" + targetPath, null,
+                        "{\"content\":\"nope\"}", "api-key", request.getHeader("Api-Key")).status());
+                return TestWebServer.createResponse(200,
+                        "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[]}",
+                        "Content-Type", "application/json");
+            });
+            Response completion = send(HttpMethod.POST, "/openai/deployments/%s/chat/completions".formatted(appUrl), null, """
+                    {"messages":[{"role":"user","content":"how are you?"}]}
+                    """, "api-key", orchestratorKey.getPerRequestKey(), "Content-Type", "application/json");
+            assertEquals(200, completion.status(), () -> "Body: " + completion.body());
+        }
+
+        // Without D-24's exclusions this test's write would pass at 200 — the orchestrator's own
+        // grant laundered straight through into the declaring app's key.
+        assertEquals(403, targetStatus.get(),
+                "a grant already held by the calling app must not satisfy the called app's reach check");
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/function/ResolveResourceDependenciesFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/ResolveResourceDependenciesFnTest.java
@@ -119,20 +119,44 @@ public class ResolveResourceDependenciesFnTest {
     }
 
     @Test
-    void apply_skipsWhenNotTheRootUserCall() {
-        // Load-bearing timing: under a per-request key the reach checks would evaluate a
-        // deployment's own key instead of the originating user — so hops that arrive with one
-        // (an interceptor's final call back, a chained app-to-app call) are skipped, never run
-        // and never thrown: a declaring app behind an interceptor must stay callable.
+    void apply_resolvesOnChainedHop() {
+        // The guard this replaces was not an identity limitation: extractedClaims and originalKey
+        // propagate at every depth, so the originating user's reach is evaluable here. Reach is
+        // asked of lookupOriginatingUserPermissions, whose own-bucket rule uses
+        // buildInitiatorBucket — never the calling key's Keys/<app>/ sandbox.
         when(context.getDeployment()).thenReturn(application);
         application.setResourceDependencies(List.of(dependency("skills/{current-user}/", false)));
-        ApiKeyData assigned = new ApiKeyData();
-        assigned.setPerRequestKey("prk");
-        when(context.getApiKeyData()).thenReturn(assigned);
+        ApiKeyData chained = new ApiKeyData();
+        chained.setPerRequestKey("prk");
+        chained.setSourceDeployment("app1");
+        when(context.getApiKeyData()).thenReturn(chained);
+        when(context.getSourceDeployment()).thenReturn("app1");
+        when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context)))
+                .thenReturn(Map.of(userSkillsFolder(), Set.of(ResourceAccessType.READ, ResourceAccessType.WRITE)));
 
         assertFalse(fn.apply(request));
-        verify(consentService, never()).isAdminConsented(anyString(), any());
-        assertTrue(proxyApiKeyData.getPerRequestSharedResources().isEmpty());
+
+        assertEquals(Set.of(ResourceAccessType.READ, ResourceAccessType.WRITE),
+                proxyApiKeyData.getPerRequestSharedResources().get(userSkillsFolder().getUrl()).permissions());
+    }
+
+    @Test
+    void apply_failsChainedHopWhenRequiredDependencyDoesNotResolve() {
+        // The new failure mode this PR introduces: a required dependency that does not resolve on
+        // a chained hop now hard-fails that call, the same as it always has at the root.
+        when(context.getDeployment()).thenReturn(application);
+        application.setResourceDependencies(List.of(dependency("skills/{current-user}/", true)));
+        ApiKeyData chained = new ApiKeyData();
+        chained.setPerRequestKey("prk");
+        chained.setSourceDeployment("app1");
+        when(context.getApiKeyData()).thenReturn(chained);
+        when(context.getSourceDeployment()).thenReturn("app1");
+        when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context))).thenReturn(Map.of());
+
+        HttpException error = assertThrows(HttpException.class, () -> fn.apply(request));
+        assertEquals(HttpStatus.FORBIDDEN, error.getStatus());
     }
 
     @Test
@@ -140,7 +164,7 @@ public class ResolveResourceDependenciesFnTest {
         when(context.getDeployment()).thenReturn(application);
         application.setResourceDependencies(List.of(dependency("skills/{current-user}/", false)));
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
-        when(accessService.lookupPermissions(any(), eq(context)))
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context)))
                 .thenReturn(Map.of(userSkillsFolder(), Set.of(ResourceAccessType.READ, ResourceAccessType.WRITE)));
 
         assertFalse(fn.apply(request));
@@ -166,7 +190,7 @@ public class ResolveResourceDependenciesFnTest {
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
         ResourceDescriptor target = com.epam.aidial.core.server.util.ResourceDescriptorFactory
                 .fromAnyUrl("files/public/p/", encryptionService);
-        when(accessService.lookupPermissions(any(), eq(context)))
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context)))
                 .thenReturn(Map.of(target, Set.of(ResourceAccessType.READ, ResourceAccessType.WRITE)));
 
         assertFalse(fn.apply(request));
@@ -189,7 +213,10 @@ public class ResolveResourceDependenciesFnTest {
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
 
         assertFalse(fn.apply(request));
+        // Pins that the resolver no longer reaches the general chain at all, alongside the
+        // narrower reach check it now uses instead.
         verify(accessService, never()).lookupPermissions(any(), any());
+        verify(accessService, never()).lookupOriginatingUserPermissions(any(), any());
         assertTrue(proxyApiKeyData.getPerRequestSharedResources().isEmpty());
     }
 
@@ -200,7 +227,7 @@ public class ResolveResourceDependenciesFnTest {
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
         ResourceDescriptor target = com.epam.aidial.core.server.util.ResourceDescriptorFactory
                 .fromAnyUrl("files/public/policies/", encryptionService);
-        when(accessService.lookupPermissions(any(), eq(context)))
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context)))
                 .thenReturn(Map.of(target, Set.of(ResourceAccessType.READ, ResourceAccessType.WRITE)));
 
         assertFalse(fn.apply(request));
@@ -215,7 +242,7 @@ public class ResolveResourceDependenciesFnTest {
         when(context.getDeployment()).thenReturn(application);
         application.setResourceDependencies(List.of(dependency("files/public/policies/", false)));
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
-        when(accessService.lookupPermissions(any(), eq(context))).thenReturn(Map.of());
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context))).thenReturn(Map.of());
 
         assertFalse(fn.apply(request));
         assertTrue(proxyApiKeyData.getPerRequestReceivers().isEmpty());
@@ -228,7 +255,7 @@ public class ResolveResourceDependenciesFnTest {
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(false);
 
         assertFalse(fn.apply(request));
-        verify(accessService, never()).lookupPermissions(any(), any());
+        verify(accessService, never()).lookupOriginatingUserPermissions(any(), any());
         assertTrue(proxyApiKeyData.getPerRequestReceivers().isEmpty());
     }
 
@@ -237,7 +264,7 @@ public class ResolveResourceDependenciesFnTest {
         when(context.getDeployment()).thenReturn(application);
         application.setResourceDependencies(List.of(dependency("files/public/policies/", true)));
         when(consentService.isAdminConsented(eq("app"), any())).thenReturn(true);
-        when(accessService.lookupPermissions(any(), eq(context))).thenReturn(Map.of());
+        when(accessService.lookupOriginatingUserPermissions(any(), eq(context))).thenReturn(Map.of());
 
         HttpException error = assertThrows(HttpException.class, () -> fn.apply(request));
         assertEquals(HttpStatus.FORBIDDEN, error.getStatus());
@@ -273,7 +300,7 @@ public class ResolveResourceDependenciesFnTest {
 
         assertFalse(fn.apply(request));
         assertTrue(proxyApiKeyData.getPerRequestReceivers().isEmpty());
-        verify(accessService, never()).lookupPermissions(any(), any());
+        verify(accessService, never()).lookupOriginatingUserPermissions(any(), any());
     }
 
     private ResourceDescriptor userSkillsFolder() {

--- a/server/src/test/java/com/epam/aidial/core/server/security/AccessServiceTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/security/AccessServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -675,5 +676,77 @@ public class AccessServiceTest {
         Map<ResourceDescriptor, Set<ResourceAccessType>> result = accessService.getGlobalReaderAccess(Set.of(resource), context);
 
         assertTrue(result.isEmpty());
+    }
+
+    // ---- lookupOriginatingUserPermissions (PR4b, D-24) ----
+
+    @Test
+    public void testLookupOriginatingUserPermissions_ResolvesOwnBucketAtAnyChainDepth() {
+        // The regression this PR exists for: a resource in the human's own bucket must grant ALL.
+        // None of the three rules in this list read ApiKeyData/per-request-key state at all — that
+        // is precisely why the answer does not change with chain depth.
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", "Users/user-sub/", false);
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(context.getUserId()).thenReturn("user-sub");
+        AccessService accessService = accessService(applicationSchemaService);
+
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result =
+                accessService.lookupOriginatingUserPermissions(Set.of(resource), context);
+
+        assertEquals(ResourceAccessType.ALL, result.get(resource));
+    }
+
+    @Test
+    public void testLookupOriginatingUserPermissions_ExcludesTheCallingAppsOwnSandbox() {
+        // Pins that the general chain's own-bucket rule (Keys/<app>/, via buildUserBucket) is not
+        // in this list — only buildInitiatorBucket (always the human) is.
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", "Keys/app1/", false);
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(context.getUserId()).thenReturn("user-sub");
+        AccessService accessService = accessService(applicationSchemaService);
+
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result =
+                accessService.lookupOriginatingUserPermissions(Set.of(resource), context);
+
+        assertTrue(result.get(resource).isEmpty());
+    }
+
+    @Test
+    public void testLookupOriginatingUserPermissions_ExcludesTheCallingKeysOwnGrants() {
+        // The single most important assertion in this PR (D-24): a grant already baked into the
+        // CALLING app's own per-request key must not satisfy the CALLED app's independent reach
+        // check — otherwise app1 could launder its own grants down the chain into app2. The stub
+        // below documents that the grant exists; none of the three rules ever read it.
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "secret.json", List.of(), "bucket", "Users/other-user/", false);
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setPerRequestKey("prk");
+        apiKeyData.setSourceDeployment("app1");
+        apiKeyData.getPerRequestSharedResources().put(resource.getUrl(),
+                new com.epam.aidial.core.server.data.permission.PerRequestSharedData(new java.util.HashSet<>(Set.of(ResourceAccessType.READ, ResourceAccessType.WRITE))));
+        lenient().when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.getUserId()).thenReturn("user-sub");
+        AccessService accessService = accessService(applicationSchemaService);
+
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result =
+                accessService.lookupOriginatingUserPermissions(Set.of(resource), context);
+
+        assertTrue(result.get(resource).isEmpty());
+    }
+
+    @Test
+    public void testLookupPermissions_UnaffectedByTheNewRuleList() {
+        // Zero-behaviour-change claim (A1): the general chain still grants own-bucket access via
+        // buildUserBucket, unaffected by the new originatingUserPermissionRules list existing.
+        ResourceDescriptor resource = new ResourceDescriptor(ResourceTypes.FILE, "file.json", List.of(), "bucket", "Users/user-sub/", false);
+        ApplicationSchemaService applicationSchemaService = mock(ApplicationSchemaService.class);
+        when(context.getApiKeyData()).thenReturn(new ApiKeyData());
+        when(context.getUserId()).thenReturn("user-sub");
+        AccessService accessService = accessService(applicationSchemaService);
+
+        Map<ResourceDescriptor, Set<ResourceAccessType>> result =
+                accessService.lookupPermissions(Set.of(resource), context);
+
+        assertEquals(ResourceAccessType.ALL, result.get(resource));
     }
 }


### PR DESCRIPTION
### Applicable issues

- fixes #1938
- Parent epic: #1930

### Description of changes

`ResolveResourceDependenciesFn.apply()` skipped resolution whenever a per-request key was already present — true at every hop past the root, and true on a plain root call behind an interceptor (the post-interceptor `handleDeployment` re-entry already carries the interceptor's key). Identity was never the obstacle: `ApiKeyData.initFromContext` propagates `extractedClaims`/`originalKey` at every depth, so `ProxyContext.userId` is always the originating human — which is why placeholder-path resolution already worked at any depth. Only the reach check needed care: the general permission chain's own-bucket rule deliberately flips to the per-request key holder's own `Keys/<app>/` sandbox — the wrong function to ask "does the human own this".

`AccessService` gains a second, purpose-built rule list — `lookupOriginatingUserPermissions`, evaluated over own-bucket-via-`buildInitiatorBucket` + `getSharedAccess` + `getPublicAccess` only. Rules that read the current per-request-key holder's own state (`getAutoSharedAccess`, `getPerRequestPermissions`, `getAppResourceAccess`, `getAppSelfAccess`) are deliberately excluded: including them would let a calling app launder grants it already holds into satisfying the next app's independent reach check, compounding privilege down a chain instead of every hop being checked against the human alone. `lookupPermissions`'s existing signature and behavior are unchanged — zero-behavior-change for all 10 existing call sites.

Resolution now runs uniformly for root and chained calls with no depth-conditional branch.

`source_deployment` is added to the three `ResourceDependencyAuditLog` events (grant/denial/runtimeFail): once resolution runs at every hop, user_id/trace_id/actor evidence are identical at every hop, so nothing else in the audit trail distinguished "app2 got the grant" from "app1's call caused app2 to get the grant".

### Behavior changes flagged for review

- **A `required` dependency that does not resolve on a chained or interceptor hop now hard-fails that call with 403.** Before this PR such a hop silently skipped resolution and stayed callable regardless. This is the correct semantics (an app never half-works silently) and the same rule the root call has always enforced — but it is a **new, previously-absent failure mode for existing chained deployments**, reachable by any app that declares `required: true` and is invoked non-first in a chain by a user whose reach or consent does not cover the target. Operators who need the old behavior set `required: false`, which degrades exactly as before.
- **Scope narrowing — ask the team to confirm:** root-call reach is now evaluated over three rules instead of eleven. For a normal user the answer is identical (own bucket, shared, public). It differs for a caller who could previously satisfy a dependency target **only** through `getAdminAccess`, `getGlobalReaderAccess` or `getReviewAccess`: an admin or global reader invoking a declaring app no longer has operator-role standing counted toward that app's dependency reach. Deliberate (a dependency target is the human's own/shared/public resource, not an operator-role-gated one) — if anyone wants admin standing to count, that is a design conversation, not a code tweak.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
