### PR TITLE
fix: key stops working after PUT that omits the key field #1927

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/controller/ConfigResourceController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ConfigResourceController.java
@@ -1561,7 +1561,6 @@ public class ConfigResourceController implements Controller {
 
                 String blobBody;
                 Key keyEntity = null;
-                String keySecret = null;
                 String oldSecret = null;
                 Object entity = null;
                 Map<String, String> putEventMetadata = null;
@@ -1624,9 +1623,6 @@ public class ConfigResourceController implements Controller {
                     if (spec.isKey()) {
                         keyEntity = (Key) entity;
                         validateKeyForApiWrite(keyEntity, "PUT");
-                        // Capture before encryptFields mutates Key.key to ciphertext in place;
-                        // ApiKeyStore is indexed by plaintext secret (see ApiKeyStore.getApiKeyData).
-                        keySecret = keyEntity.getKey();
                     }
                     if (spec.hasEncryptedFields()) {
                         secretFieldProcessor.encryptFields(entity, descriptor);
@@ -1637,12 +1633,6 @@ public class ConfigResourceController implements Controller {
                 // blob layer doesn't re-validate against a stale snapshot.
                 ResourceItemMetadata meta = resourceService.putResource(
                         descriptor, blobBody, EtagHeader.ANY, author, false, putEventMetadata);
-                if (keySecret != null) {
-                    apiKeyStore.addOrUpdateKey(keySecret, apiKeyData(keyEntity));
-                    if (oldSecret != null && !oldSecret.isBlank() && !oldSecret.equals(keySecret)) {
-                        apiKeyStore.removeKey(oldSecret);
-                    }
-                }
                 // Decrypt-in-place after blob put. PUT-upsert can produce a mixed
                 // plaintext/ciphertext entity (preserve-on-omit on the update arm); decryptValue
                 // is idempotent on plaintext and restores ciphertext fields to plaintext,
@@ -1650,6 +1640,16 @@ public class ConfigResourceController implements Controller {
                 // Config (read-after-write parity).
                 if (entity != null && spec.hasEncryptedFields()) {
                     secretFieldProcessor.decryptFields(entity, descriptor);
+                }
+                if (keyEntity != null) {
+                    // Capture after the decrypt above: on preserve-on-omit the merged Key.key
+                    // holds the prior ciphertext until then, and ApiKeyStore is indexed by
+                    // plaintext (see ApiKeyStore.addOrUpdateKey).
+                    String keySecret = keyEntity.getKey();
+                    apiKeyStore.addOrUpdateKey(keySecret, apiKeyData(keyEntity));
+                    if (oldSecret != null && !oldSecret.isBlank() && !oldSecret.equals(keySecret)) {
+                        apiKeyStore.removeKey(oldSecret);
+                    }
                 }
                 ResourceTypes writeType = typeOf(descriptor);
                 String mapKey = putEventMetadata != null

--- a/server/src/test/java/com/epam/aidial/core/server/ConfigEntityWriteApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ConfigEntityWriteApiTest.java
@@ -485,13 +485,19 @@ public class ConfigEntityWriteApiTest extends ResourceBaseTest {
                 """;
         verify(send(HttpMethod.PUT, "/v1/keys/platform/test-key-preserve", null,
                 body, "authorization", "admin", "If-None-Match", "*"), 200);
+        verify(send(HttpMethod.GET, "/v1/bucket", null, "",
+                "Api-key", "secret-preserve"), 200);
 
         // PUT body omits "key": a 200 response proves preserve-on-omit pulled the encrypted secret
         // from the existing blob — otherwise the post-merge blank-key check would 400. The secret
-        // value itself is not asserted because U.4 retired the plaintext-reveal path.
+        // value itself is not asserted because U.4 retired the plaintext-reveal path; the bearer
+        // roundtrip below proves the preserved secret still authenticates under its plaintext
+        // form (ApiKeyStore is indexed by plaintext, not by the preserved ciphertext).
         Response put = send(HttpMethod.PUT, "/v1/keys/platform/test-key-preserve", null,
                 KEY_BODY_PROJECT_B_NO_KEY, "authorization", "admin");
         verify(put, 200);
+        verify(send(HttpMethod.GET, "/v1/bucket", null, "",
+                "Api-key", "secret-preserve"), 200);
     }
 
     @Test


### PR DESCRIPTION
A key PUT whose body omits `key` (the documented preserve-on-omit update) returned 200 but revoked the very bearer it was supposed to preserve: `handlePut` captured `keySecret` before any decryption, so `ApiKeyStore` was re-indexed under the preserved `ENC[...]` ciphertext and the rotation cleanup removed the still-working plaintext secret.

The fix moves the `keySecret` capture and the `addOrUpdateKey`/`removeKey` block to after the existing decrypt-in-place, so the capture is plaintext in every arm (create, rotation, omit).

### Applicable issues

- fixes #1927

### Description of changes

- `ConfigResourceController.handlePut`: capture `keySecret` from the decrypted `Key` entity (after the post-put `decryptFields`) instead of before `encryptFields`, gating the store update on `keyEntity != null`. On preserve-on-omit this keeps the correct plaintext index in `ApiKeyStore` and short-circuits the old-secret removal; rotation cleanup is unchanged. The ordering now matches the DELETE path and the `MergedConfigStore` replica fast path, which both capture the secret after decryption.
- `ConfigEntityWriteApiTest.testKeyPut200PreserveKeyOnOmit`: assert the old bearer still authenticates (`GET /v1/bucket` with `Api-key: <old plaintext>`) after the omitted-key PUT — verified to fail on the pre-fix code and pass with the fix.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)