### PR TITLE
feat: expose per-interface configs in deployment listings

### DIFF
--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -172,6 +172,8 @@ Each value is an object with the following fields:
 }
 ```
 
+The application listings — `/v1/deployments`, `/v1/deployments/{name}` and `/openai/applications` — report the effective per-interface `features`, `defaults` and `default_headers` in an `interface_configs` object next to the `interfaces` array; see [Interface configs in the listings](models.md#interface-configs-in-the-listings).
+
 #### applications.<application_name>.defaultHeaders
 
 An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.

--- a/docs/dynamic-settings/applications.md
+++ b/docs/dynamic-settings/applications.md
@@ -172,8 +172,6 @@ Each value is an object with the following fields:
 }
 ```
 
-The application listings — `/v1/deployments`, `/v1/deployments/{name}` and `/openai/applications` — report the effective per-interface `features`, `defaults` and `default_headers` in an `interface_configs` object next to the `interfaces` array; see [Interface configs in the listings](models.md#interface-configs-in-the-listings).
-
 #### applications.<application_name>.defaultHeaders
 
 An object of HTTP header names and values DIAL Core adds to a request that does not already carry a header of that name. A header sent by the client always wins, and so does one DIAL Core sets itself (`Api-Key`, `X-DIAL-DEPLOYMENT-ID`, ...). Names are matched case-insensitively.

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -174,7 +174,7 @@ Supported interface types for models:
 
 The `interfaces` map is strict: chat completions is configured via `openaiChatCompletions` and embeddings via `openaiEmbeddings`, and one never stands in for the other — a model declaring only `openaiChatCompletions` answers `503` to `embeddings`, and a model declaring only `openaiEmbeddings` answers `503` to `chat/completions` and `completions`. The untyped legacy `endpoint` predates the split and keeps serving `embeddings` requests verbatim, so models configured before the split keep working unchanged.
 
-Only the interface types a model declares are reported in the `interfaces` array of the `/v1/deployments` listing. A legacy `endpoint` is advertised as the interface matching what the model says it is: `openaiEmbeddings` when `type` is `embedding`, `openaiChatCompletions` otherwise — so an embedding model configured this way reports `openaiEmbeddings` and `"chat_completion": false`, even though that one endpoint still serves the whole deployments POST family.
+Only the interface types a model declares are reported in the `interfaces` array of the `/v1/deployments` listing. A legacy `endpoint` is advertised as the interface matching what the model says it is: `openaiEmbeddings` when `type` is `embedding`, `openaiChatCompletions` otherwise — so an embedding model configured this way reports `openaiEmbeddings` and `"chat_completion": false`, even though that one endpoint still serves the whole deployments POST family. The same advertisement drives the listing's `interface_configs` map, which reports the `features`, `defaults` and `default_headers` in force for each advertised interface — see [Interface configs in the listings](#interface-configs-in-the-listings).
 
 Each value is an object with the following fields:
 
@@ -256,7 +256,7 @@ Chat completions and Responses inherit `["low", "medium", "high"]`; Anthropic Me
 
 The same rule applies to `openaiEmbeddings`. It needs its own interface declaration when using `interfaces` for routing. Passthrough and translator requests receive effective features in `X-DIAL-DEPLOYMENT-FEATURES`, using the existing header format (`tools`, `temperature`, `reasoning_efforts`, etc.). Request-time caching, automatic caching, per-request-key access, and consent checks also use the requested interface's features. Consent reviews include requirements declared on interfaces.
 
-Deployment and model listings continue to expose deployment-level features, since they have no requested inference interface. Core defaults are applied after merging, and resolving a request does not modify the shared configuration.
+Deployment and model listings continue to expose deployment-level features, since they have no requested inference interface; the values in force per interface appear in the listings' `interface_configs` map instead — see [Interface configs in the listings](#interface-configs-in-the-listings). Core defaults are applied after merging, and resolving a request does not modify the shared configuration.
 
 #### models.<model_name>.defaultHeaders
 
@@ -338,6 +338,44 @@ They are applied once per request, when it enters the model: with `interceptors`
 ```
 
 The effective headers are `x-dial-cache-policy: cache-priority` and `x-dial-custom-header: foo-bar` for `chat/completions`, `embeddings` and the Responses API, and `x-dial-cache-policy: cache-priority`, `x-dial-custom-header: foo-bar-2`, `x-dial-custom-header-2: some-value` for the Anthropic Messages API.
+
+### Interface configs in the listings
+
+The deployment listings — `/v1/deployments` and `/v1/deployments/{name}`, plus the OpenAI-flavoured `/openai/models`, `/openai/models/{name}`, `/openai/deployments`, `/openai/deployments/{name}` and `/openai/applications` — report an `interface_configs` object next to the `interfaces` array, with one entry per interface the deployment advertises, keyed by that interface's own name:
+
+```json
+"interface_configs": {
+    "openaiChatCompletions": {
+        "features": {
+            "system_prompt": true, "tools": true, "temperature": true,
+            "chat_completion": true, "responses_api": false,
+            "reasoning_efforts": ["low", "medium"]
+        },
+        "defaults": {"temperature": 1},
+        "default_headers": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar"}
+    },
+    "openaiResponses": {
+        "features": {
+            "system_prompt": true, "tools": true, "temperature": true,
+            "chat_completion": false, "responses_api": true,
+            "reasoning_efforts": ["low", "medium"]
+        },
+        "defaults": {"temperature": 1},
+        "default_headers": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar"}
+    },
+    "anthropicMessages": {
+        "features": {
+            "system_prompt": true, "tools": true, "temperature": true,
+            "chat_completion": false, "responses_api": false,
+            "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        "defaults": {"temperature": 0.5},
+        "default_headers": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar-2", "x-dial-custom-header-2": "some-value"}
+    }
+}
+```
+
+Each entry's `features`, `defaults` and `default_headers` are the ones in force for that interface, resolved exactly as [Features per interface](#features-per-interface), [Defaults per interface](#defaults-per-interface) and [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders) resolve them; an entry with no default headers returns `"default_headers": {}`, consistent with `defaults`. A legacy `endpoint` or `responsesEndpoint` is advertised the same way as in the `interfaces` array. Inside an entry, `chat_completion` and `responses_api` name the API that the interface itself is — `true` only on the `openaiChatCompletions` and `openaiResponses` entries respectively — whereas in the deployment-level `features` they name the APIs the deployment serves at all. The deployment-level `features`, `defaults` and `responses_defaults` fields keep their own meaning, and a deployment serving no interface omits `interface_configs` altogether.
 
 #### models.<model_name>.limits
 

--- a/docs/dynamic-settings/models.md
+++ b/docs/dynamic-settings/models.md
@@ -174,8 +174,6 @@ Supported interface types for models:
 
 The `interfaces` map is strict: chat completions is configured via `openaiChatCompletions` and embeddings via `openaiEmbeddings`, and one never stands in for the other — a model declaring only `openaiChatCompletions` answers `503` to `embeddings`, and a model declaring only `openaiEmbeddings` answers `503` to `chat/completions` and `completions`. The untyped legacy `endpoint` predates the split and keeps serving `embeddings` requests verbatim, so models configured before the split keep working unchanged.
 
-Only the interface types a model declares are reported in the `interfaces` array of the `/v1/deployments` listing. A legacy `endpoint` is advertised as the interface matching what the model says it is: `openaiEmbeddings` when `type` is `embedding`, `openaiChatCompletions` otherwise — so an embedding model configured this way reports `openaiEmbeddings` and `"chat_completion": false`, even though that one endpoint still serves the whole deployments POST family. The same advertisement drives the listing's `interface_configs` map, which reports the `features`, `defaults` and `default_headers` in force for each advertised interface — see [Interface configs in the listings](#interface-configs-in-the-listings).
-
 Each value is an object with the following fields:
 
 * `base_url`: The root URL that the matching ingress path is appended to. Optional — the model-level `baseUrl` serves an entry that omits it.
@@ -256,7 +254,7 @@ Chat completions and Responses inherit `["low", "medium", "high"]`; Anthropic Me
 
 The same rule applies to `openaiEmbeddings`. It needs its own interface declaration when using `interfaces` for routing. Passthrough and translator requests receive effective features in `X-DIAL-DEPLOYMENT-FEATURES`, using the existing header format (`tools`, `temperature`, `reasoning_efforts`, etc.). Request-time caching, automatic caching, per-request-key access, and consent checks also use the requested interface's features. Consent reviews include requirements declared on interfaces.
 
-Deployment and model listings continue to expose deployment-level features, since they have no requested inference interface; the values in force per interface appear in the listings' `interface_configs` map instead — see [Interface configs in the listings](#interface-configs-in-the-listings). Core defaults are applied after merging, and resolving a request does not modify the shared configuration.
+Core defaults are applied after merging, and resolving a request does not modify the shared configuration.
 
 #### models.<model_name>.defaultHeaders
 
@@ -338,44 +336,6 @@ They are applied once per request, when it enters the model: with `interceptors`
 ```
 
 The effective headers are `x-dial-cache-policy: cache-priority` and `x-dial-custom-header: foo-bar` for `chat/completions`, `embeddings` and the Responses API, and `x-dial-cache-policy: cache-priority`, `x-dial-custom-header: foo-bar-2`, `x-dial-custom-header-2: some-value` for the Anthropic Messages API.
-
-### Interface configs in the listings
-
-The deployment listings — `/v1/deployments` and `/v1/deployments/{name}`, plus the OpenAI-flavoured `/openai/models`, `/openai/models/{name}`, `/openai/deployments`, `/openai/deployments/{name}` and `/openai/applications` — report an `interface_configs` object next to the `interfaces` array, with one entry per interface the deployment advertises, keyed by that interface's own name:
-
-```json
-"interface_configs": {
-    "openaiChatCompletions": {
-        "features": {
-            "system_prompt": true, "tools": true, "temperature": true,
-            "chat_completion": true, "responses_api": false,
-            "reasoning_efforts": ["low", "medium"]
-        },
-        "defaults": {"temperature": 1},
-        "default_headers": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar"}
-    },
-    "openaiResponses": {
-        "features": {
-            "system_prompt": true, "tools": true, "temperature": true,
-            "chat_completion": false, "responses_api": true,
-            "reasoning_efforts": ["low", "medium"]
-        },
-        "defaults": {"temperature": 1},
-        "default_headers": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar"}
-    },
-    "anthropicMessages": {
-        "features": {
-            "system_prompt": true, "tools": true, "temperature": true,
-            "chat_completion": false, "responses_api": false,
-            "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
-        },
-        "defaults": {"temperature": 0.5},
-        "default_headers": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar-2", "x-dial-custom-header-2": "some-value"}
-    }
-}
-```
-
-Each entry's `features`, `defaults` and `default_headers` are the ones in force for that interface, resolved exactly as [Features per interface](#features-per-interface), [Defaults per interface](#defaults-per-interface) and [models.<model_name>.defaultHeaders](#modelsmodel_namedefaultheaders) resolve them; an entry with no default headers returns `"default_headers": {}`, consistent with `defaults`. A legacy `endpoint` or `responsesEndpoint` is advertised the same way as in the `interfaces` array. Inside an entry, `chat_completion` and `responses_api` name the API that the interface itself is — `true` only on the `openaiChatCompletions` and `openaiResponses` entries respectively — whereas in the deployment-level `features` they name the APIs the deployment serves at all. The deployment-level `features`, `defaults` and `responses_defaults` fields keep their own meaning, and a deployment serving no interface omits `interface_configs` altogether.
 
 #### models.<model_name>.limits
 

--- a/docs/open_api_core.yaml
+++ b/docs/open_api_core.yaml
@@ -14282,6 +14282,8 @@ components:
         catalog_schema_id:
           type: string
           format: uri
+        interface_configs:
+          $ref: "#/components/schemas/MapStringInterfaceConfigData"
     ApplicationFunction:
       type: object
       properties:
@@ -16192,6 +16194,15 @@ components:
           $ref: "#/components/schemas/MapStringString"
         baseUrl:
           type: string
+    InterfaceConfigData:
+      type: object
+      properties:
+        defaults:
+          $ref: "#/components/schemas/MapStringObject"
+        features:
+          $ref: "#/components/schemas/FeaturesData"
+        default_headers:
+          $ref: "#/components/schemas/MapStringString"
     InterfaceMode:
       type: string
       enum:
@@ -16437,6 +16448,10 @@ components:
       type: object
       additionalProperties:
         $ref: "#/components/schemas/Interceptor"
+    MapStringInterfaceConfigData:
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/InterfaceConfigData"
     MapStringKey:
       type: object
       additionalProperties:
@@ -16694,6 +16709,8 @@ components:
         catalog_schema_id:
           type: string
           format: uri
+        interface_configs:
+          $ref: "#/components/schemas/MapStringInterfaceConfigData"
     ModelType:
       type: string
       enum:
@@ -17781,6 +17798,8 @@ components:
         catalog_schema_id:
           type: string
           format: uri
+        interface_configs:
+          $ref: "#/components/schemas/MapStringInterfaceConfigData"
     ToolSetRepairControllerRepairResponse:
       type: object
       properties:

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ApplicationController.java
@@ -21,6 +21,7 @@ import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.controller.extraction.ApplicationDeploymentExtractor;
 import com.epam.aidial.core.server.data.ApplicationData;
 import com.epam.aidial.core.server.data.FeaturesData;
+import com.epam.aidial.core.server.data.InterfaceConfigData;
 import com.epam.aidial.core.server.data.ListData;
 import com.epam.aidial.core.server.data.ResourceLink;
 import com.epam.aidial.core.server.security.AccessService;
@@ -384,6 +385,7 @@ public class ApplicationController {
         data.setMaxInputAttachments(application.getMaxInputAttachments());
         data.setDefaults(application.getDefaults());
         data.setResponsesDefaults(application.getResponsesDefaults());
+        data.setInterfaceConfigs(InterfaceConfigData.createInterfaceConfigs(application));
         data.setDescriptionKeywords(application.getDescriptionKeywords());
 
         data.setApplicationTypeSchemaId(application.getApplicationTypeSchemaId());

--- a/server/src/main/java/com/epam/aidial/core/server/controller/ModelController.java
+++ b/server/src/main/java/com/epam/aidial/core/server/controller/ModelController.java
@@ -14,6 +14,7 @@ import com.epam.aidial.core.openapi.annotations.OpenApiDescriptions;
 import com.epam.aidial.core.openapi.annotations.ParameterIn;
 import com.epam.aidial.core.server.ProxyContext;
 import com.epam.aidial.core.server.data.FeaturesData;
+import com.epam.aidial.core.server.data.InterfaceConfigData;
 import com.epam.aidial.core.server.data.ListData;
 import com.epam.aidial.core.server.data.ModelData;
 import com.epam.aidial.core.server.data.PricingData;
@@ -123,6 +124,7 @@ public class ModelController {
         data.setPricing(createPricing(model.getPricing()));
         data.setDefaults(model.getDefaults());
         data.setResponsesDefaults(model.getResponsesDefaults());
+        data.setInterfaceConfigs(InterfaceConfigData.createInterfaceConfigs(model));
         if (model.getAuthor() != null) {
             data.setOwner(model.getAuthor());
         }

--- a/server/src/main/java/com/epam/aidial/core/server/data/ApplicationData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/ApplicationData.java
@@ -76,6 +76,7 @@ public class ApplicationData extends DeploymentData {
         data.setMaxInputAttachments(application.getMaxInputAttachments());
         data.setDefaults(application.getDefaults());
         data.setResponsesDefaults(application.getResponsesDefaults());
+        data.setInterfaceConfigs(InterfaceConfigData.createInterfaceConfigs(application));
         data.setDescriptionKeywords(application.getDescriptionKeywords());
 
         data.setApplicationTypeSchemaId(application.getApplicationTypeSchemaId());

--- a/server/src/main/java/com/epam/aidial/core/server/data/DeploymentData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/DeploymentData.java
@@ -57,6 +57,8 @@ public class DeploymentData {
     private List<String> descriptionKeywords;
     private int maxRetryAttempts;
     private List<String> interfaces;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, InterfaceConfigData> interfaceConfigs;
     private URI catalogSchemaId;
     private Map<String, Object> catalogProperties;
 }

--- a/server/src/main/java/com/epam/aidial/core/server/data/InterfaceConfigData.java
+++ b/server/src/main/java/com/epam/aidial/core/server/data/InterfaceConfigData.java
@@ -1,0 +1,56 @@
+package com.epam.aidial.core.server.data;
+
+import com.epam.aidial.core.config.Deployment;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.server.util.DeploymentEndpointUtil;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * One {@code interface_configs} entry of a deployment listing: the features, the defaults and the default
+ * headers in force for a single interface the deployment serves.
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class InterfaceConfigData {
+
+    private FeaturesData features;
+    private Map<String, Object> defaults;
+    /**
+     * The default headers in force for the interface, resolved by {@link Deployment#resolveDefaultHeaders}.
+     * Empty when the deployment defaults no header for this interface, like {@link #defaults}.
+     */
+    private Map<String, String> defaultHeaders;
+
+    /**
+     * The listing's {@code interface_configs} map: one entry per interface the deployment advertises,
+     * keyed by the interface's own name. Features, defaults and default headers are the ones in force for
+     * that interface; the {@code chat_completion} and {@code responses_api} flags name the API the interface
+     * itself is, unlike the deployment-level features where they name the APIs the deployment serves at all.
+     */
+    @JsonIgnore
+    public static Map<String, InterfaceConfigData> createInterfaceConfigs(Deployment deployment) {
+        Map<String, InterfaceConfigData> configsByInterface = new LinkedHashMap<>();
+        for (InterfaceType type : InterfaceType.values()) {
+            if (!DeploymentEndpointUtil.isInterfaceDeclared(deployment, type)) {
+                continue;
+            }
+            InterfaceConfigData config = new InterfaceConfigData();
+            FeaturesData features = FeaturesData.createFeatures(deployment.resolveFeatures(type));
+            features.setChatCompletion(type == InterfaceType.OPENAI_CHAT_COMPLETIONS);
+            features.setResponsesApi(type == InterfaceType.OPENAI_RESPONSES);
+            config.setFeatures(features);
+            config.setDefaults(deployment.resolveDefaults(type));
+            config.setDefaultHeaders(deployment.resolveDefaultHeaders(type));
+            configsByInterface.put(type.getValue(), config);
+        }
+        return configsByInterface;
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/ApplicationDeploymentApiTest.java
@@ -1039,6 +1039,38 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "owner" : "EPM-RTC-GPT",
                     "created_at" : "@ignore",
                     "updated_at" : "@ignore",
@@ -1105,6 +1137,38 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { },
                     "viewer_url" : "http://some-host",
                     "editor_url" : "http://some-host"
@@ -1150,6 +1214,38 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : {
                       "index-search" : {
                         "rewritePath" : true,
@@ -1204,6 +1300,68 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      },
+                      "openaiResponses" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : false,
+                          "responses_api" : true,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { }
                   }, {
                     "id" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my-app",
@@ -1248,6 +1406,38 @@ class ApplicationDeploymentApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "function" : {
                       "id" : "0123",
                       "runtime" : "python3.11",

--- a/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/CustomApplicationApiTest.java
@@ -603,6 +603,38 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { },
                     "viewer_url" : "http://some-host",
                     "editor_url" : "http://some-host"
@@ -648,6 +680,38 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : {
                       "index-search" : {
                         "rewritePath" : true,
@@ -702,6 +766,68 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      },
+                      "openaiResponses" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : false,
+                          "responses_api" : true,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { }
                   } ],
                   "object" : "list"
@@ -767,6 +893,40 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults":{},
                     "description_keywords":[],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "owner" : "EPM-RTC-GPT",
                     "created_at" : "@ignore",
                     "updated_at" : "@ignore",
@@ -820,6 +980,38 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { },
                     "viewer_url" : "http://some-host",
                     "editor_url" : "http://some-host"
@@ -865,6 +1057,38 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : false,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : {
                       "index-search" : {
                         "rewritePath" : true,
@@ -919,6 +1143,68 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      },
+                      "openaiResponses" : {
+                        "features" : {
+                          "rate" : false,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : false,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : false,
+                          "responses_api" : true,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { }
                   }, {
                     "id" : "applications/3CcedGxCx23EwiVbVmscVktScRyf46KypuBQ65miviST/my-custom-application",
@@ -963,6 +1249,38 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                     "responses_defaults" : { },
                     "description_keywords" : [ ],
                     "max_retry_attempts" : 1,
+                    "interface_configs" : {
+                      "openaiChatCompletions" : {
+                        "features" : {
+                          "rate" : true,
+                          "tokenize" : false,
+                          "truncate_prompt" : false,
+                          "configuration" : true,
+                          "system_prompt" : true,
+                          "tools" : false,
+                          "seed" : false,
+                          "url_attachments" : false,
+                          "folder_attachments" : false,
+                          "allow_resume" : true,
+                          "accessible_by_per_request_key" : true,
+                          "content_parts" : false,
+                          "temperature" : true,
+                          "cache" : false,
+                          "auto_caching" : false,
+                          "parallel_tool_calls" : true,
+                          "assistant_attachments_in_request" : false,
+                          "mcp" : false,
+                          "chat_completion" : true,
+                          "responses_api" : false,
+                          "max_tokens_supported" : true,
+                          "max_completion_tokens_supported" : false,
+                          "custom_temperature_supported" : true,
+                          "reasoning_efforts" : [ ]
+                        },
+                        "defaults" : { },
+                        "default_headers" : { }
+                      }
+                    },
                     "routes" : { }
                   } ],
                   "object" : "list"
@@ -1239,6 +1557,38 @@ public class CustomApplicationApiTest extends ResourceBaseTest {
                   "responses_defaults" : { },
                   "description_keywords" : [ ],
                   "max_retry_attempts" : 1,
+                  "interface_configs" : {
+                    "openaiChatCompletions" : {
+                      "features" : {
+                        "rate" : false,
+                        "tokenize" : false,
+                        "truncate_prompt" : false,
+                        "configuration" : false,
+                        "system_prompt" : true,
+                        "tools" : false,
+                        "seed" : false,
+                        "url_attachments" : false,
+                        "folder_attachments" : false,
+                        "allow_resume" : true,
+                        "accessible_by_per_request_key" : true,
+                        "content_parts" : false,
+                        "temperature" : true,
+                        "cache" : false,
+                        "auto_caching" : false,
+                        "parallel_tool_calls" : true,
+                        "assistant_attachments_in_request" : false,
+                        "mcp" : false,
+                        "chat_completion" : true,
+                        "responses_api" : false,
+                        "max_tokens_supported" : true,
+                        "max_completion_tokens_supported" : false,
+                        "custom_temperature_supported" : true,
+                        "reasoning_efforts" : [ ]
+                      },
+                      "defaults" : { },
+                      "default_headers" : { }
+                    }
+                  },
                   "application_properties" : {
                     "property1" : "test property1"
                   },

--- a/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/DeploymentApiTest.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.vertx.core.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeploymentApiTest extends ResourceBaseTest {
+
+    private static final double DELTA = 1e-9;
 
     @DialConfigLocation("dial-config/deployment-interfaces-listing.json")
     @Test
@@ -160,6 +164,76 @@ public class DeploymentApiTest extends ResourceBaseTest {
         assertTrue(applications.get("app-legacy").get("chat_completion").asBoolean());
     }
 
+    @DialConfigLocation("dial-config/deployment-interface-configs.json")
+    @Test
+    public void testInterfaceConfigsListEffectiveFeaturesAndDefaultsPerInterface() throws JsonProcessingException {
+        Map<String, JsonNode> deploymentsById = collectDeployments(send(HttpMethod.GET, "/v1/deployments", null, null));
+
+        JsonNode modelConfigs = deploymentsById.get("gpt-5.4-mini").get("interface_configs");
+        assertEquals(Set.of("openaiChatCompletions", "openaiResponses", "anthropicMessages"), fieldNames(modelConfigs));
+
+        // the API-surface flags name the API each interface itself is, unlike the deployment-level
+        // features where they name the APIs the deployment serves at all
+        JsonNode chat = modelConfigs.get("openaiChatCompletions");
+        assertTrue(chat.get("features").get("chat_completion").asBoolean());
+        assertFalse(chat.get("features").get("responses_api").asBoolean());
+        assertTrue(chat.get("features").get("system_prompt").asBoolean());
+        assertEquals(1, chat.get("defaults").get("temperature").asDouble(), DELTA);
+
+        JsonNode responses = modelConfigs.get("openaiResponses");
+        assertFalse(responses.get("features").get("chat_completion").asBoolean());
+        assertTrue(responses.get("features").get("responses_api").asBoolean());
+        assertEquals(1, responses.get("defaults").get("temperature").asDouble(), DELTA);
+
+        JsonNode anthropic = modelConfigs.get("anthropicMessages");
+        assertFalse(anthropic.get("features").get("chat_completion").asBoolean());
+        assertFalse(anthropic.get("features").get("responses_api").asBoolean());
+        // the interface-level reasoning efforts and defaults replace the deployment-level ones ...
+        assertEquals(List.of("low", "medium", "high", "xhigh", "max"),
+                textValues(anthropic.get("features").get("reasoning_efforts")));
+        assertEquals(0.5, anthropic.get("defaults").get("temperature").asDouble(), DELTA);
+        // ... for that interface only: the deployment-level view keeps its own values
+        JsonNode model = deploymentsById.get("gpt-5.4-mini");
+        assertEquals(List.of("low", "medium"), textValues(model.get("features").get("reasoning_efforts")));
+        assertEquals(1, model.get("defaults").get("temperature").asDouble(), DELTA);
+
+        // the default headers follow the same resolution: the deployment-level set, overlaid per interface
+        assertEquals("cache-priority", chat.get("default_headers").get("x-dial-cache-policy").asText());
+        assertEquals("foo-bar", chat.get("default_headers").get("x-dial-custom-header").asText());
+        assertEquals("foo-bar", responses.get("default_headers").get("x-dial-custom-header").asText());
+        assertEquals("cache-priority", anthropic.get("default_headers").get("x-dial-cache-policy").asText());
+        // the interface entry overrides the header it names and adds the one the deployment level lacks
+        assertEquals("foo-bar-2", anthropic.get("default_headers").get("x-dial-custom-header").asText());
+        assertEquals("some-value", anthropic.get("default_headers").get("x-dial-custom-header-2").asText());
+
+        // a legacy endpoint is advertised as the interface matching what the model says it is
+        assertEquals(Set.of("openaiChatCompletions"),
+                fieldNames(deploymentsById.get("model-legacy").get("interface_configs")));
+        // a deployment with no default headers lists an empty object, like defaults
+        JsonNode legacyChat = deploymentsById.get("model-legacy").get("interface_configs").get("openaiChatCompletions");
+        assertEquals(ProxyUtil.MAPPER.createObjectNode(), legacyChat.get("default_headers"));
+        assertEquals(Set.of("openaiEmbeddings"),
+                fieldNames(deploymentsById.get("embedding-ada").get("interface_configs")));
+
+        // applications carry their interface entry too, and one serving no typed interface omits the field
+        JsonNode appConfigs = deploymentsById.get("app-iface").get("interface_configs");
+        assertEquals(Set.of("openaiChatCompletions"), fieldNames(appConfigs));
+        assertEquals(0.1, appConfigs.get("openaiChatCompletions").get("defaults").get("temperature").asDouble(), DELTA);
+        assertFalse(deploymentsById.get("app-ui-only").has("interface_configs"));
+
+        // the openai listings and the single-deployment endpoints return the same configs
+        assertEquals(modelConfigs, collectDeployments(
+                send(HttpMethod.GET, "/openai/models", null, null)).get("gpt-5.4-mini").get("interface_configs"));
+        assertEquals(modelConfigs, collectDeployments(
+                send(HttpMethod.GET, "/openai/deployments", null, null)).get("gpt-5.4-mini").get("interface_configs"));
+        assertEquals(appConfigs, collectDeployments(
+                send(HttpMethod.GET, "/openai/applications", null, null)).get("app-iface").get("interface_configs"));
+        assertEquals(modelConfigs, readDeployment(
+                send(HttpMethod.GET, "/v1/deployments/gpt-5.4-mini")).get("interface_configs"));
+        assertEquals(modelConfigs, readDeployment(
+                send(HttpMethod.GET, "/openai/deployments/gpt-5.4-mini")).get("interface_configs"));
+    }
+
     /**
      * Maps deployment id to its {@code features} object. Handles both the bare array returned by
      * {@code /v1/deployments} and the {@code {"data": [...]}} envelope of the legacy listings.
@@ -199,5 +273,35 @@ public class DeploymentApiTest extends ResourceBaseTest {
             result.put(deployment.get("id").asText(), interfaces);
         }
         return result;
+    }
+
+    /**
+     * Maps deployment id to its whole listing entry. Handles both the bare array returned by
+     * {@code /v1/deployments} and the {@code {"data": [...]}} envelope of the legacy listings.
+     */
+    private static Map<String, JsonNode> collectDeployments(Response response) throws JsonProcessingException {
+        verify(response, 200);
+        JsonNode body = ProxyUtil.MAPPER.readTree(response.body());
+        JsonNode deployments = body.isArray() ? body : body.get("data");
+
+        Map<String, JsonNode> result = new HashMap<>();
+        for (JsonNode deployment : deployments) {
+            result.put(deployment.get("id").asText(), deployment);
+        }
+        return result;
+    }
+
+    private static Set<String> fieldNames(JsonNode object) {
+        Set<String> names = new HashSet<>();
+        object.fieldNames().forEachRemaining(names::add);
+        return names;
+    }
+
+    private static List<String> textValues(JsonNode array) {
+        List<String> values = new ArrayList<>();
+        for (JsonNode value : array) {
+            values.add(value.asText());
+        }
+        return values;
     }
 }

--- a/server/src/test/java/com/epam/aidial/core/server/data/InterfaceConfigDataTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/data/InterfaceConfigDataTest.java
@@ -1,0 +1,134 @@
+package com.epam.aidial.core.server.data;
+
+import com.epam.aidial.core.config.DeploymentInterface;
+import com.epam.aidial.core.config.Features;
+import com.epam.aidial.core.config.InterfaceType;
+import com.epam.aidial.core.config.Model;
+import com.epam.aidial.core.config.ModelType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InterfaceConfigDataTest {
+
+    @Test
+    void interfaceFlagsNameTheApiTheInterfaceItselfIs() {
+        Model model = new Model();
+        model.setInterfaces(declaredInterfaces(
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, InterfaceType.OPENAI_RESPONSES, InterfaceType.ANTHROPIC_MESSAGES));
+
+        Map<String, InterfaceConfigData> configsByInterface = InterfaceConfigData.createInterfaceConfigs(model);
+
+        assertEquals(Set.of("openaiChatCompletions", "openaiResponses", "anthropicMessages"), configsByInterface.keySet());
+        assertTrue(configsByInterface.get("openaiChatCompletions").getFeatures().isChatCompletion());
+        assertFalse(configsByInterface.get("openaiChatCompletions").getFeatures().isResponsesApi());
+        assertTrue(configsByInterface.get("openaiResponses").getFeatures().isResponsesApi());
+        assertFalse(configsByInterface.get("openaiResponses").getFeatures().isChatCompletion());
+        assertFalse(configsByInterface.get("anthropicMessages").getFeatures().isChatCompletion());
+        assertFalse(configsByInterface.get("anthropicMessages").getFeatures().isResponsesApi());
+    }
+
+    @Test
+    void featuresAreTheOnesInForceForThatInterface() {
+        Model model = new Model();
+        Features features = new Features();
+        features.setToolsSupported(true);
+        features.setReasoningEfforts(List.of("low", "medium"));
+        model.setFeatures(features);
+        Features overrides = new Features();
+        overrides.setReasoningEfforts(List.of("low", "medium", "high", "xhigh", "max"));
+        DeploymentInterface declared = new DeploymentInterface("http://localhost:7001");
+        declared.setFeatures(overrides);
+        model.setInterfaces(Map.of(InterfaceType.ANTHROPIC_MESSAGES.getValue(), declared));
+
+        Map<String, InterfaceConfigData> configsByInterface = InterfaceConfigData.createInterfaceConfigs(model);
+
+        FeaturesData anthropicFeatures = configsByInterface.get("anthropicMessages").getFeatures();
+        assertTrue(anthropicFeatures.isTools());
+        assertEquals(List.of("low", "medium", "high", "xhigh", "max"), anthropicFeatures.getReasoningEfforts());
+    }
+
+    @Test
+    void defaultsAreTheOnesInForceForThatInterface() {
+        Model model = new Model();
+        model.setDefaults(Map.of("temperature", 1));
+        model.setResponsesDefaults(Map.of("temperature", 0.9));
+        Map<String, DeploymentInterface> interfacesByType = declaredInterfaces(
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, InterfaceType.OPENAI_RESPONSES, InterfaceType.ANTHROPIC_MESSAGES);
+        interfacesByType.get(InterfaceType.ANTHROPIC_MESSAGES.getValue()).setDefaults(Map.of("temperature", 0.5));
+        model.setInterfaces(interfacesByType);
+
+        Map<String, InterfaceConfigData> configsByInterface = InterfaceConfigData.createInterfaceConfigs(model);
+
+        assertEquals(Map.of("temperature", 1), configsByInterface.get("openaiChatCompletions").getDefaults());
+        assertEquals(Map.of("temperature", 0.9), configsByInterface.get("openaiResponses").getDefaults());
+        assertEquals(Map.of("temperature", 0.5), configsByInterface.get("anthropicMessages").getDefaults());
+    }
+
+    @Test
+    void defaultHeadersAreTheOnesInForceForThatInterface() {
+        Model model = new Model();
+        model.setDefaultHeaders(Map.of(
+                "x-dial-cache-policy", "cache-priority",
+                "x-dial-custom-header", "foo-bar"));
+        Map<String, DeploymentInterface> interfacesByType = declaredInterfaces(
+                InterfaceType.OPENAI_CHAT_COMPLETIONS, InterfaceType.ANTHROPIC_MESSAGES);
+        interfacesByType.get(InterfaceType.ANTHROPIC_MESSAGES.getValue()).setDefaultHeaders(Map.of(
+                "x-dial-custom-header", "foo-bar-2",
+                "x-dial-custom-header-2", "some-value"));
+        model.setInterfaces(interfacesByType);
+
+        Map<String, InterfaceConfigData> configsByInterface = InterfaceConfigData.createInterfaceConfigs(model);
+
+        // an interface declaring no headers of its own serves the deployment-level set
+        assertEquals(Map.of("x-dial-cache-policy", "cache-priority", "x-dial-custom-header", "foo-bar"),
+                configsByInterface.get("openaiChatCompletions").getDefaultHeaders());
+        // one that does overrides by name and adds new ones, inheriting the rest
+        assertEquals(Map.of(
+                "x-dial-cache-policy", "cache-priority",
+                "x-dial-custom-header", "foo-bar-2",
+                "x-dial-custom-header-2", "some-value"),
+                configsByInterface.get("anthropicMessages").getDefaultHeaders());
+    }
+
+    @Test
+    void legacyFieldsAreAdvertisedAsTheInterfaceMatchingTheModelType() {
+        Model chat = new Model();
+        chat.setType(ModelType.CHAT);
+        chat.setEndpoint("http://localhost:7001/chat/completions");
+        assertEquals(Set.of("openaiChatCompletions"), InterfaceConfigData.createInterfaceConfigs(chat).keySet());
+
+        Model embedding = new Model();
+        embedding.setType(ModelType.EMBEDDING);
+        embedding.setEndpoint("http://localhost:7001/embeddings");
+        assertEquals(Set.of("openaiEmbeddings"), InterfaceConfigData.createInterfaceConfigs(embedding).keySet());
+
+        Model responses = new Model();
+        responses.setType(ModelType.CHAT);
+        responses.setResponsesEndpoint("http://localhost:7001/responses");
+        assertEquals(Set.of("openaiResponses"), InterfaceConfigData.createInterfaceConfigs(responses).keySet());
+    }
+
+    @Test
+    void deploymentServingNoInterfaceHasNoConfigs() {
+        Model model = new Model();
+        model.setBaseUrl("http://localhost:7001");
+
+        assertEquals(Map.of(), InterfaceConfigData.createInterfaceConfigs(model));
+    }
+
+    private static Map<String, DeploymentInterface> declaredInterfaces(InterfaceType... types) {
+        Map<String, DeploymentInterface> interfacesByType = new HashMap<>();
+        for (InterfaceType type : types) {
+            interfacesByType.put(type.getValue(), new DeploymentInterface("http://localhost:7001"));
+        }
+        return interfacesByType;
+    }
+}

--- a/server/src/test/resources/dial-config/deployment-interface-configs.json
+++ b/server/src/test/resources/dial-config/deployment-interface-configs.json
@@ -1,0 +1,56 @@
+{
+  "applications": {
+    "app-iface": {
+      "displayName": "App configured via interfaces",
+      "interfaces": {
+        "openaiChatCompletions": {
+          "base_url": "http://localhost:7001",
+          "defaults": {"temperature": 0.1}
+        }
+      }
+    },
+    "app-ui-only": {
+      "displayName": "App serving no typed interface",
+      "viewerUrl": "http://localhost:7001/app"
+    }
+  },
+  "models": {
+    "gpt-5.4-mini": {
+      "type": "chat",
+      "displayName": "GPT 5.4 mini",
+      "features": {
+        "system_prompt_supported": true,
+        "temperature_supported": true,
+        "tools_supported": true,
+        "reasoning_efforts": ["low", "medium"]
+      },
+      "defaults": {"temperature": 1},
+      "responsesDefaults": {"temperature": 1},
+      "defaultHeaders": {"x-dial-cache-policy": "cache-priority", "x-dial-custom-header": "foo-bar"},
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "http://localhost:7001"},
+        "openaiResponses": {"base_url": "http://localhost:7001"},
+        "anthropicMessages": {
+          "base_url": "http://localhost:7001",
+          "features": {"reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
+          "defaults": {"temperature": 0.5},
+          "defaultHeaders": {"x-dial-custom-header": "foo-bar-2", "x-dial-custom-header-2": "some-value"}
+        }
+      }
+    },
+    "model-legacy": {
+      "type": "chat",
+      "endpoint": "http://localhost:7001/openai/deployments/model-legacy/chat/completions"
+    },
+    "embedding-ada": {
+      "type": "embedding",
+      "endpoint": "http://localhost:7001/openai/deployments/embedding-ada/embeddings"
+    }
+  },
+  "keys": {
+    "proxyKey1": {
+      "project": "EPM-RTC-GPT",
+      "role": "default"
+    }
+  }
+}


### PR DESCRIPTION
### Description of changes

- Add `interface_configs` to model and application listing/detail responses, exposing effective `features`, `defaults`, and `default_headers` per advertised interface.
- Preserve existing deployment-level fields and the `interfaces` array. Set `chat_completion` and `responses_api` for each interface, inherit and override default headers case-insensitively, and include empty `default_headers` as `{}`.
- Update OpenAPI and listing regression tests, including legacy endpoints and custom applications. Keep listing response details out of the deployment configuration guides.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All focused tests pass (InterfaceConfigDataTest 6/6, DeploymentApiTest 6/6, ApplicationDeploymentApiTest 20/20, CustomApplicationApiTest 20/20; server main/test Checkstyle and `git diff --check` clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
