### PR TITLE
fix: NPE in streaming chat-completions function chain #1963

### DIFF
--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFn.java
@@ -26,6 +26,10 @@ public class CollectChatCompletionUsageFn extends BaseResponseFunction {
 
     @Override
     public Future<JsonNode> apply(JsonNode tree) {
+        if (tree == null) {
+            return Future.succeededFuture(tree);
+        }
+
         usage = MergeChunks.merge(usage, tree.get("usage"));
         if (tree.get("service_tier") != null) {
             serviceTier = tree.get("service_tier");

--- a/server/src/main/java/com/epam/aidial/core/server/function/CollectResponseAttachmentsFn.java
+++ b/server/src/main/java/com/epam/aidial/core/server/function/CollectResponseAttachmentsFn.java
@@ -38,7 +38,7 @@ public abstract class CollectResponseAttachmentsFn extends BaseResponseFunction 
                 processAttachedFile(attachment, permittedAttachments);
             }
             if (permittedAttachments.isEmpty()) {
-                return Future.succeededFuture();
+                return Future.succeededFuture(tree);
             }
             return proxy.getTaskExecutor().submit(() -> {
                 proxy.getApiKeyStore().updatePerRequestApiKey(perRequestKey, json -> updateAutoSharedAttachments(json, permittedAttachments, perRequestKey));

--- a/server/src/main/java/com/epam/aidial/core/server/vertx/stream/BufferingReadStream.java
+++ b/server/src/main/java/com/epam/aidial/core/server/vertx/stream/BufferingReadStream.java
@@ -267,10 +267,10 @@ public class BufferingReadStream implements ReadStream<Buffer> {
         @SneakyThrows
         private Future<Void> handle(SseEvent event) {
             Future<JsonNode> result;
-            if (functions.isEmpty() || skipEvent(event)) {
+            String data = event.getData();
+            if (functions.isEmpty() || skipEvent(event) || data == null || data.isBlank()) {
                 result = Future.succeededFuture();
             } else {
-                String data = event.getData();
                 try {
                     JsonNode tree = ProxyUtil.MAPPER.readTree(data);
                     result = Future.succeededFuture(tree);

--- a/server/src/test/java/com/epam/aidial/core/server/function/ChatCompletionFunctionChainTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/ChatCompletionFunctionChainTest.java
@@ -1,0 +1,75 @@
+package com.epam.aidial.core.server.function;
+
+import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
+import com.epam.aidial.core.server.util.ProxyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.vertx.core.Future;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the real function chain wired by DeploymentPostController for streaming
+ * {@code /chat/completions} responses (StripUsagePerModelFn -&gt; CollectResponseChatCompletionAttachmentsFn
+ * -&gt; CollectChatCompletionUsageFn), composed the same way {@code BufferingReadStream.BaseEventListener}
+ * chains it via {@code Future.compose}. Regression test for a null tree silently produced by one
+ * function and blindly dereferenced by the next.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChatCompletionFunctionChainTest {
+
+    @Mock
+    private ProxyContext context;
+
+    @Test
+    public void testChainToleratesChunksWithNoAttachmentsAndCollectsUsage() throws JsonProcessingException {
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setPerRequestKey("per-request-key");
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+        when(context.isStreamingRequest()).thenReturn(true);
+        doCallRealMethod().when(context).setPricingUsageNode(any());
+        doCallRealMethod().when(context).getPricingUsageNode();
+
+        List<BaseResponseFunction> functions = List.of(
+                new StripUsagePerModelFn(null, context),
+                new CollectResponseChatCompletionAttachmentsFn(null, context),
+                new CollectChatCompletionUsageFn(null, context));
+
+        Future<JsonNode> contentChunk = process(functions, """
+                { "choices": [{ "index": 0, "delta": { "content": "hi" } }] }
+                """);
+        assertTrue(contentChunk.succeeded(), () -> "chain failed: " + contentChunk.cause());
+
+        Future<JsonNode> usageChunk = process(functions, """
+                {
+                  "choices": [{ "index": 0, "delta": {} }],
+                  "usage": { "completion_tokens": 33, "prompt_tokens": 19, "total_tokens": 52 }
+                }
+                """);
+        assertTrue(usageChunk.succeeded(), () -> "chain failed: " + usageChunk.cause());
+
+        JsonNode pricingUsageNode = context.getPricingUsageNode();
+        assertNotNull(pricingUsageNode);
+        assertEquals(52, pricingUsageNode.path("usage").path("total_tokens").asLong());
+    }
+
+    private static Future<JsonNode> process(List<BaseResponseFunction> functions, String json) throws JsonProcessingException {
+        Future<JsonNode> result = Future.succeededFuture(ProxyUtil.MAPPER.readTree(json));
+        for (BaseResponseFunction fn : functions) {
+            result = result.compose(fn);
+        }
+        return result;
+    }
+}

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectChatCompletionUsageFnTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 
@@ -65,6 +66,15 @@ class CollectChatCompletionUsageFnTest {
         JsonNode output = fn.apply(input).result();
 
         assertEquals(input, output);
+    }
+
+    @Test
+    public void testTolerantOfNullTree() {
+        CollectChatCompletionUsageFn fn = new CollectChatCompletionUsageFn(null, context);
+
+        JsonNode output = fn.apply(null).result();
+
+        assertNull(output);
     }
 
     private static JsonNode tree(String json) throws JsonProcessingException {

--- a/server/src/test/java/com/epam/aidial/core/server/function/CollectResponseChatCompletionAttachmentsFnTest.java
+++ b/server/src/test/java/com/epam/aidial/core/server/function/CollectResponseChatCompletionAttachmentsFnTest.java
@@ -1,8 +1,10 @@
 package com.epam.aidial.core.server.function;
 
 import com.epam.aidial.core.server.ProxyContext;
+import com.epam.aidial.core.server.data.ApiKeyData;
 import com.epam.aidial.core.server.util.ProxyUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.when;
 
 
@@ -217,5 +220,22 @@ class CollectResponseChatCompletionAttachmentsFnTest {
         assertEquals(Set.of("files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/b1/file1.txt",
                 "files/7G9WZNcoY26Vy9D7bEgbv6zqbJGfyDp9KZyEbJR4XMZt/b1/file2.txt"), files);
 
+    }
+
+    @Test
+    public void testApplyPassesTreeThroughUnchangedWhenNoAttachments() throws JsonProcessingException {
+        ApiKeyData apiKeyData = new ApiKeyData();
+        apiKeyData.setPerRequestKey("per-request-key");
+        when(context.getApiKeyData()).thenReturn(apiKeyData);
+
+        JsonNode tree = ProxyUtil.MAPPER.readTree("""
+                {
+                  "choices": [{ "index": 0, "delta": { "content": "hi" } }]
+                }
+                """);
+
+        JsonNode result = new CollectResponseChatCompletionAttachmentsFn(null, context).apply(tree).result();
+
+        assertSame(tree, result);
     }
 }


### PR DESCRIPTION
Fixes a null-pointer exception in the streaming `/chat/completions` response-function chain that silently fires on nearly every streaming chunk with no attachments, logged as "Function call is failed with error. Try to recover SSE event" and swallowed by generic error recovery.

### Applicable issues

- fixes #1963

### Description of changes

- `CollectResponseAttachmentsFn.apply()` now returns `Future.succeededFuture(tree)` instead of a null-valued future when a chunk has no attachments, so the tree is passed through unchanged instead of dropped.
- `CollectChatCompletionUsageFn.apply()` now guards against a null `tree` input, preventing a similar mistake elsewhere in the chain from causing the same regression.
- `BufferingReadStream.BaseEventListener.handle()` now guards against a null/blank SSE `data` payload before parsing it as JSON.
- Added a regression test (`CollectResponseChatCompletionAttachmentsFnTest#testApplyPassesTreeThroughUnchangedWhenNoAttachments`) and a null-tolerance test (`CollectChatCompletionUsageFnTest#testTolerantOfNullTree`), plus a new `ChatCompletionFunctionChainTest` that exercises the real 3-function chain used by `DeploymentPostController` end-to-end, closing the test gap that let this regression through originally (each function was previously only tested in isolation).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.